### PR TITLE
Add a CI and a release workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,64 @@
+---
+name: operator-build
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  local:
+    runs-on: ubuntu-latest
+    environment: quay
+
+    steps:
+      # setup
+      - uses: actions/checkout@v2
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v2.1.4
+        with:
+          go-version: 1.16
+
+      - name: Build Operator
+        run: make operator
+
+      - name: Build Bundle
+        run: make bundle
+
+  images:
+    runs-on: ubuntu-latest
+    environment: quay
+
+    steps:
+      # setup
+      - uses: actions/checkout@v2
+      - name: Setup Go environment
+        uses: actions/setup-go@v2.1.4
+        with:
+          go-version: 1.16
+
+      - name: Initialize ENV vars
+        run: |
+          cat $GITHUB_ENV
+
+          echo "GITHUB_REF: $GITHUB_REF"
+
+          VERSION="$(cat VERSION)-$(date +%y%m%d%H%M%S)"
+          CHANNELS=test
+
+          IMG_BASE=$(grep '^IMAGE_TAG_BASE' -- Makefile | cut -f3 -d ' ')
+
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "CHANNELS=$CHANNELS" >> $GITHUB_ENV
+          echo "IMG=${IMG_BASE}:$VERSION" >> $GITHUB_ENV
+          echo "BUNDLE_IMG=${IMG_BASE}-bundle:$VERSION" >> $GITHUB_ENV
+          echo "CATALOG_IMG=${IMG_BASE}-catalog:latest" >> $GITHUB_ENV
+          echo ---------------------------
+          cat $GITHUB_ENV
+          echo ---------------------------
+
+      - name: Build Operator Image
+        run: make operator-image
+
+      - name: Build Bundle Image
+        run: make bundle-image

--- a/.github/workflows/olm.yaml
+++ b/.github/workflows/olm.yaml
@@ -1,15 +1,13 @@
 ---
-name: OLM
+name: OLM Release
 
 on:
   push:
-    branches: [auto-release, main]
+    branches: [main]
     tags: ["v*"]
-  pull_request:
-    branches: [auto-release]
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     environment: quay
 
@@ -27,12 +25,12 @@ jobs:
           SOURCE_BRANCH=${GITHUB_REF#refs/heads/}
           SOURCE_TAG=${GITHUB_REF#refs/tags/}
 
-          if [[ $SOURCE_NAME == auto-release ]]; then
-            VERSION="0.0.1-$(date +%y%m%d%H%M%S)"
-            CHANNELS=candidate
+          if [[ $SOURCE_NAME == main ]]; then
+            VERSION="$(cat VERSION)-$(date +%y%m%d%H%M%S)"
+            CHANNELS=development
           else
             VERSION=${SOURCE_NAME##v}
-            CHANNELS=candidate,stable
+            CHANNELS=development,stable
           fi
 
           IMG_BASE=$(grep '^IMAGE_TAG_BASE' -- Makefile | cut -f3 -d ' ')
@@ -52,7 +50,6 @@ jobs:
           go-version: 1.16
 
       - name: Registry Login
-        # You may pin to the exact commit or the version. uses: docker/login-action@v1.10.0
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: quay.io

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:$(VERSION)
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
 # - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
 # - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
-CHANNELS ?= candidate
+CHANNELS ?= development
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif
@@ -115,7 +115,7 @@ endif
 # To re-generate a bundle for any other default channel without changing the default setup, use:
 # - DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
 # - environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
-DEFAULT_CHANNEL ?= candidate
+DEFAULT_CHANNEL ?= development
 
 ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)


### PR DESCRIPTION
This patch adds a CI workflow and Release workflow

CI workflow is triggered on all pull-requests to main branch. It builds
the operator locally (`make operator bundle`)and also tests if the
images (operator, bundle) can be built properly.

Release workflow gets triggered when a PR is merged to main branch or if
a tag (starting with v) is pushed. The workflow builds all images -
operator, bundle and catalog and pushes those to registry.

The candidate operator can be installed by subscribing to the catalog
See: hack/olm/catalog-src.yaml

Signed-off-by: Sunil Thaha <sthaha@redhat.com>