### PR TITLE
ci: lint commits according to the Angular convention

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -3,14 +3,18 @@ on:
   pull_request:
   push:
     branches:
-      - 'release-*'
-      - 'master'
-      - 'main'
-    tags:
-      - 'v*'
+    - 'main'
+
 env:
   golang-version: '1.16'
 jobs:
+  commit-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4
   golang-lint:
     runs-on: ubuntu-latest
     name: Golang linter

--- a/README.md
+++ b/README.md
@@ -5,6 +5,24 @@ The project is based on the [controller-runtime](https://github.com/kubernetes-s
 
 ## Development
 
+### Commit message convention
+Commit messages need to comply to the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and should be structured as follows:
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+The type and description are used to generate a changelog and determine the next release version.
+Most commonly used types are:
+* `fix:` a commit of the type fix patches a bug in your codebase (this correlates with PATCH in Semantic Versioning).
+* `feat:` a commit of the type feat introduces a new feature to the codebase (this correlates with MINOR in Semantic Versioning).
+* `BREAKING CHANGE:` a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
+
+Other than `fix:` and `feat:`, the following type can also be used: `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:` and `test:`.
+
 ### Manifest generation
 The Kubernetes CRDs and the ClusterRole needed for their management are generated from go types in `pkg/apis`.   
 Run `make generate` to regenerate the Kubernetes manifests when changing these files.


### PR DESCRIPTION
This commit adds a commit message linter in the CI and documents the
convention that should be used when writing commit messages.
