### PR TITLE
fix: apply base CSV during bundle generation

### DIFF
--- a/deploy/olm/bases/monitoring-stack-operator.clusterserviceversion.yaml
+++ b/deploy/olm/bases/monitoring-stack-operator.clusterserviceversion.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-  name: monitoring-operator-stack.v0.0.0
+  name: monitoring-stack-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
The base CSV needs to have the package prefix in order to be taken
into account during bundle generation.