### PR TITLE
ci: run tests against olm bundle

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -1,0 +1,75 @@
+name: e2e-tests-olm
+description: Runs E2E tests against the OLM bundle
+inputs:
+  go-version:
+    description: "go version"
+    required: false
+    default: 1.16
+  kind-version:
+    description: "kind version"
+    required: false
+    default: 'v0.11.1'
+  kind-image:
+    description: "kind version"
+    required: false
+    default: 'kindest/node:v1.22.0'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@v2.1.4
+      with:
+        go-version: 1.16
+
+    - uses: azure/setup-kubectl@v1
+
+    - name: Start KinD
+      uses: engineerd/setup-kind@v0.5.0
+      with:
+        version: ${{ inputs.kind-version }}
+        image: ${{ inputs.kind-image }}
+        wait: 300s
+        config: ./hack/kind/config.yaml
+
+    - name: Install OLM
+      shell: bash
+      run: |
+        make operator-sdk
+        ./tmp/bin/operator-sdk olm install
+
+    - name: Create a local docker registry in the Kind cluster
+      shell: bash
+      run: |
+        kubectl apply -f hack/kind/registry.yaml
+        kubectl rollout status deployment local-registry
+        # Expose the registry to the host so that we can build and push the image
+        kubectl port-forward svc/local-registry 5000:5000 &
+        echo "127.0.0.1 local-registry" | sudo tee -a /etc/hosts
+
+    - name: Build images
+      run: make operator-image bundle bundle-image IMAGE_BASE="local-registry:5000/monitoring-stack-operator" VERSION=0.0.0-ci
+      shell: bash
+
+    - name: Wait for cluster to finish bootstraping
+      shell: bash
+      run: |
+        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
+        kubectl cluster-info
+        kubectl get pods -A
+
+    - name: Publish images
+      run: make operator-push bundle-push IMAGE_BASE="local-registry:5000/monitoring-stack-operator" VERSION=0.0.0-ci
+      shell: bash
+
+    - name: Deploy the operator
+      shell: bash
+      run: |
+        # TODO: build a kubernetes-specific bundle to avoid doing this
+        kubectl apply -k deploy/crds/kubernetes
+        kubectl wait --for=condition=Established crds --all --timeout=300s
+
+        ./tmp/bin/operator-sdk run bundle local-registry:5000/monitoring-stack-operator-bundle:0.0.0-ci --install-mode AllNamespaces --skip-tls
+
+    - name: Run tests
+      shell: bash
+      run: go test ./test/e2e/... --with-operator=false

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -61,3 +61,12 @@ jobs:
         uses: ./.github/e2e-tests
         with:
           go-version: ${{ env.go-version }}
+
+  e2e-tests-olm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: e2e tests through OLM
+        uses: ./.github/e2e-tests-olm
+        with:
+          go-version: ${{ env.go-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,15 @@ jobs:
         with:
           go-version: ${{ env.go-version }}
 
+  e2e-tests-olm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: e2e tests through OLM
+        uses: ./.github/e2e-tests-olm
+        with:
+          go-version: ${{ env.go-version }}
+
   publish-olm-development:
     if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
     runs-on: ubuntu-latest

--- a/hack/kind/config.yaml
+++ b/hack/kind/config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+containerdConfigPatches:
+  # 10.96.223.192 is the fixed ip of the registry service - see: hack/kind/registry.yaml
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."local-registry:5000"]
+      endpoint = ["http://10.96.223.192:5000"]

--- a/hack/kind/registry.yaml
+++ b/hack/kind/registry.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app: local-registry
+  name: local-registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-registry
+  template:
+    metadata:
+      labels:
+        app: local-registry
+    spec:
+      containers:
+        - image: registry:2
+          name: registry
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: local-registry
+  name: local-registry
+spec:
+  # Use a fixed IP address so that we can use it in config.yaml to
+  # patch the registry address and force an http protocol
+  clusterIP: 10.96.223.192
+  ports:
+    - port: 5000
+      protocol: TCP
+      targetPort: 5000
+  selector:
+    app: local-registry


### PR DESCRIPTION
We currently have to wait for the OLM bundle to be deployed in order to
validate whether it properly works. This lenghtens the development
feedback loop and could lead to subtle bugs with the released bundles.

This commit adds a job in the pipeline that runs the e2e tests against
an actual OLM bundle. Since the bundle image needs to be pullable, the
e2e job deploys a local registry in a kind cluster and pushes the image
to that registry. OLM can then pull the bundle and deploy it before the
e2e tests are executed.
