### PR TITLE
feat: set soft affinity on operator deployment

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -67,6 +67,7 @@ runs:
       shell: bash
       run: |
         # TODO: build a kubernetes-specific bundle to avoid doing this
+        kubectl label nodes -l node-role.kubernetes.io/control-plane="" node-role.kubernetes.io/infra=""
         kubectl create -k deploy/crds/kubernetes
         kubectl wait --for=condition=Established crds --all --timeout=300s
 

--- a/deploy/olm/kustomization.yaml
+++ b/deploy/olm/kustomization.yaml
@@ -11,3 +11,26 @@ images:
 - name: observability-operator
   newName: local-registry:30000/observability-operator
   newTag: 0.0.0-ci
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: NOT-USED-BECAUSE-TARGET-IS-SPECIFIED
+      spec:
+        template:
+          spec:
+            affinity:
+              nodeAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                - preference:
+                    matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+                  weight: 1
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: .*-operator


### PR DESCRIPTION
Additionally set the node-role.kubernetes.io/infra label on the master
node in our e2e test kind cluster.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>