### PR TITLE
fix: Set seccomp profiles and grant SAs necessary premissions to run

### DIFF
--- a/deploy/dependencies/kustomization.yaml
+++ b/deploy/dependencies/kustomization.yaml
@@ -40,6 +40,10 @@ patches:
                     cpu: 5m
                     memory: 150Mi
                 terminationMessagePolicy: FallbackToLogsOnError
+            securityContext:
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
   - patch: |-
       - op: remove
         path: /spec/template/spec/nodeSelector
@@ -48,3 +52,20 @@ patches:
       version: v1
       kind: Deployment
 
+  - patch: |-
+      - op: add
+        path: /rules/-
+        value:
+          apiGroups:
+            - security.openshift.io
+          resourceNames:
+            - nonroot-v2
+          resources:
+            - securitycontextconstraints
+          verbs:
+            - use
+    target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: prometheus-operator

--- a/deploy/operator/observability-operator-cluster-role.yaml
+++ b/deploy/operator/observability-operator-cluster-role.yaml
@@ -158,3 +158,11 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot-v2
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/deploy/operator/observability-operator-deployment.yaml
+++ b/deploy/operator/observability-operator-deployment.yaml
@@ -22,6 +22,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: operator
           image: observability-operator:0.0.1
@@ -35,6 +37,9 @@ spec:
                 fieldPath: metadata.namespace
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           resources:
             limits:
               cpu: 200m

--- a/pkg/controllers/monitoring/monitoring-stack/controller.go
+++ b/pkg/controllers/monitoring/monitoring-stack/controller.go
@@ -70,6 +70,9 @@ type Options struct {
 //+kubebuilder:rbac:groups="",resources=pods;services;endpoints,verbs=get;list;watch
 //+kubebuilder:rbac:groups=extensions;networking.k8s.io,resources=ingresses,verbs=get;list;watch
 
+// RBAC for delegating the use of SCC nonroot-v2 needed for OpenShift
+//+kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,resourceNames=nonroot-v2,verbs=use
+
 // RegisterWithManager registers the controller with Manager
 func RegisterWithManager(mgr ctrl.Manager, opts Options) error {
 	split := strings.Split(opts.InstanceSelector, "=")


### PR DESCRIPTION
When running in namespace with Pod Security Standard profile "restricted"
we need to set RunAsNonRoot and SeccompProfile to all workloads running
on that namespace. Futhermore on OpenShift to run with a SeccompProfile
set we need to grant service accounts premisisons to use the SCC
nonroot-v2 
Fixes https://github.com/rhobs/observability-operator/issues/149