### PR TITLE
fix: change slack details in README according to rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,6 @@ ___
 
 ## Contact
 ___
-- CoreOS Slack #mso-users and ping @mso-support.
+- CoreOS Slack #observability-users and ping @obo-support.
 - [Mailing list](mso-users@redhat.com)
 - Github Team: @rhobs/observability-operator-maintainers


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajersk@redhat.com>