### PR TITLE
fix: grants SA of components access to nonroot SCC

### DIFF
--- a/deploy/dependencies/kustomization.yaml
+++ b/deploy/dependencies/kustomization.yaml
@@ -60,6 +60,7 @@ patches:
             - security.openshift.io
           resourceNames:
             - nonroot-v2
+            - nonroot
           resources:
             - securitycontextconstraints
           verbs:

--- a/deploy/operator/observability-operator-cluster-role.yaml
+++ b/deploy/operator/observability-operator-cluster-role.yaml
@@ -161,6 +161,7 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
+  - nonroot
   - nonroot-v2
   resources:
   - securitycontextconstraints

--- a/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
+++ b/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
@@ -144,7 +144,7 @@ func newAlertManagerRole(ms *stack.MonitoringStack, rbacResourceName string, rba
 			{
 				APIGroups:     []string{"security.openshift.io"},
 				Resources:     []string{"securitycontextconstraints"},
-				ResourceNames: []string{"nonroot-v2"},
+				ResourceNames: []string{"nonroot", "nonroot-v2"},
 				Verbs:         []string{"use"},
 			},
 		},

--- a/pkg/controllers/monitoring/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components.go
@@ -88,7 +88,7 @@ func newPrometheusRole(ms *stack.MonitoringStack, rbacResourceName string, rbacV
 			{
 				APIGroups:     []string{"security.openshift.io"},
 				Resources:     []string{"securitycontextconstraints"},
-				ResourceNames: []string{"nonroot-v2"},
+				ResourceNames: []string{"nonroot", "nonroot-v2"},
 				Verbs:         []string{"use"},
 			},
 		},

--- a/pkg/controllers/monitoring/monitoring-stack/controller.go
+++ b/pkg/controllers/monitoring/monitoring-stack/controller.go
@@ -70,8 +70,8 @@ type Options struct {
 //+kubebuilder:rbac:groups="",resources=pods;services;endpoints,verbs=get;list;watch
 //+kubebuilder:rbac:groups=extensions;networking.k8s.io,resources=ingresses,verbs=get;list;watch
 
-// RBAC for delegating the use of SCC nonroot-v2 needed for OpenShift
-//+kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,resourceNames=nonroot-v2,verbs=use
+// RBAC for delegating the use of SCC nonroot-v2 (for OpenShift >= 4.11) and nonroot (for OpenShift < 4.11)
+//+kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,resourceNames=nonroot;nonroot-v2,verbs=use
 
 // RegisterWithManager registers the controller with Manager
 func RegisterWithManager(mgr ctrl.Manager, opts Options) error {


### PR DESCRIPTION
Necessary for cases where nonroot-v2 still does not exist e.g OpenShift 4.10. Otherwise prometheus-operator pods would not be able to start