### PR TITLE
fix: remove SeccompProfile

### DIFF
--- a/deploy/dependencies/kustomization.yaml
+++ b/deploy/dependencies/kustomization.yaml
@@ -42,8 +42,6 @@ patches:
                 terminationMessagePolicy: FallbackToLogsOnError
             securityContext:
               runAsNonRoot: true
-              seccompProfile:
-                type: RuntimeDefault
   - patch: |-
       - op: remove
         path: /spec/template/spec/nodeSelector

--- a/deploy/operator/observability-operator-deployment.yaml
+++ b/deploy/operator/observability-operator-deployment.yaml
@@ -22,8 +22,6 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       containers:
         - name: operator
           image: observability-operator:0.0.1

--- a/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
+++ b/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
@@ -71,9 +71,6 @@ func newAlertmanager(
 				FSGroup:      pointer.Int64(AlertmanagerUserFSGroupID),
 				RunAsNonRoot: pointer.Bool(true),
 				RunAsUser:    pointer.Int64(AlertmanagerUserFSGroupID),
-				SeccompProfile: &corev1.SeccompProfile{
-					Type: corev1.SeccompProfileTypeRuntimeDefault,
-				},
 			},
 		},
 	}

--- a/pkg/controllers/monitoring/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components.go
@@ -179,9 +179,6 @@ func newPrometheus(
 					FSGroup:      pointer.Int64(PrometheusUserFSGroupID),
 					RunAsNonRoot: pointer.Bool(true),
 					RunAsUser:    pointer.Int64(PrometheusUserFSGroupID),
-					SeccompProfile: &corev1.SeccompProfile{
-						Type: corev1.SeccompProfileTypeRuntimeDefault,
-					},
 				},
 				RemoteWrite:    config.RemoteWrite,
 				ExternalLabels: config.ExternalLabels,


### PR DESCRIPTION
It seems that built-in SCCs (except `privileged`) don't allow to set the
seccomp profile [1]. Until this is fixed in OpenShift, we should leave
it to the default (which is already `RuntimeDefault`).

[1] https://github.com/openshift/cluster-kube-apiserver-operator/issues/1325

Fixes #163