### PR TITLE
feat: add health probe

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -341,7 +341,15 @@ spec:
                       fieldPath: metadata.namespace
                 image: observability-operator:0.0.13
                 imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
                 name: operator
+                readinessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
                 resources:
                   limits:
                     cpu: 50m

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -29,14 +29,16 @@ import (
 
 func main() {
 	var (
-		namespace   string
-		metricsAddr string
+		namespace       string
+		metricsAddr     string
+		healthProbeAddr string
 
 		setupLog = ctrl.Log.WithName("setup")
 	)
 
 	flag.StringVar(&namespace, "namespace", "default", "The namespace in which the operator runs")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&healthProbeAddr, "health-probe-bind-address", ":8081", "The address the health probe endpoint binds to.")
 	opts := zap.Options{
 		Development: true,
 		TimeEncoder: zapcore.RFC3339TimeEncoder,
@@ -50,7 +52,7 @@ func main() {
 		"namespace", namespace,
 		"metrics-bind-address", metricsAddr)
 
-	op, err := operator.New(metricsAddr)
+	op, err := operator.New(metricsAddr, healthProbeAddr)
 	if err != nil {
 		setupLog.Error(err, "cannot create a new operator")
 		os.Exit(1)

--- a/deploy/operator/observability-operator-deployment.yaml
+++ b/deploy/operator/observability-operator-deployment.yaml
@@ -45,5 +45,13 @@ spec:
             requests:
               cpu: 100m
               memory: 150Mi
+          readinessProbe:
+             httpGet:
+               path: /healthz
+               port: 8081
+          livenessProbe:
+             httpGet:
+               path: /healthz
+               port: 8081
       serviceAccountName: observability-operator-sa
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
This adds basic health probe endpoint (using the controller-runtime
options) and exposes the port via the existing OBO service