### PR TITLE
fix: do not report Available=degraded condition

### DIFF
--- a/pkg/apis/monitoring/v1alpha1/types.go
+++ b/pkg/apis/monitoring/v1alpha1/types.go
@@ -96,10 +96,9 @@ type ConditionStatus string
 type ConditionType string
 
 const (
-	ConditionTrue     ConditionStatus = "True"
-	ConditionDegraded ConditionStatus = "Degraded"
-	ConditionFalse    ConditionStatus = "False"
-	ConditionUnknown  ConditionStatus = "Unknown"
+	ConditionTrue    ConditionStatus = "True"
+	ConditionFalse   ConditionStatus = "False"
+	ConditionUnknown ConditionStatus = "Unknown"
 
 	ReconciledCondition ConditionType = "Reconciled"
 	AvailableCondition  ConditionType = "Available"

--- a/pkg/controllers/monitoring/monitoring-stack/conditions_test.go
+++ b/pkg/controllers/monitoring/monitoring-stack/conditions_test.go
@@ -165,13 +165,13 @@ func TestUpdateConditions(t *testing.T) {
 			expectedResults: []v1alpha1.Condition{
 				{
 					Type:               v1alpha1.AvailableCondition,
-					Status:             v1alpha1.ConditionDegraded,
+					Status:             v1alpha1.ConditionFalse,
 					ObservedGeneration: 1,
-					Reason:             PrometheusNotAvailable,
+					Reason:             PrometheusDegraded,
 				},
 				{
 					Type:               v1alpha1.ReconciledCondition,
-					Status:             v1alpha1.ConditionDegraded,
+					Status:             v1alpha1.ConditionFalse,
 					ObservedGeneration: 1,
 					Reason:             PrometheusNotReconciled,
 				}},


### PR DESCRIPTION
The convention is to report only true,false or unknown as the condition status value.