### PR TITLE
fix: do not update MonitoringStack status in case of Prometheus

### DIFF
--- a/pkg/controllers/monitoring/monitoring-stack/controller.go
+++ b/pkg/controllers/monitoring/monitoring-stack/controller.go
@@ -163,7 +163,7 @@ func (rm resourceManager) updateStatus(ctx context.Context, req ctrl.Request, ms
 		logger.Info("Failed to get prometheus object", "err", err)
 		return ctrl.Result{RequeueAfter: 2 * time.Second}
 	}
-	ms.Status.Conditions = updateConditions(ms.Status.Conditions, prom.Status.Conditions, ms.Generation, recError)
+	ms.Status.Conditions = updateConditions(ms.Status.Conditions, prom, ms.Generation, recError)
 	err = rm.k8sClient.Status().Update(ctx, ms)
 	if err != nil {
 		logger.Info("Failed to update status", "err", err)


### PR DESCRIPTION
generation difference

This adds check comparing the Prometheus observedGeneration to the current MonitoringStack generation. If there is a difference then the MonitoringStack status is not updated.