### PR TITLE
fix: hide internal CRDs from OLM UI

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -40,6 +40,11 @@ metadata:
       ]
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.24.0
+    operators.operatorframework.io/internal-objects: |-
+      [
+        "prometheuses.monitoring.rhobs", "alertmanagers.monitoring.rhobs",
+        "thanosrulers.monitoring.rhobs"
+      ]
     operators.operatorframework.io/project_layout: unknown
   name: observability-operator.v0.0.15
   namespace: placeholder

--- a/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
+++ b/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
@@ -4,7 +4,11 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
-    operators.operatorframework.io/internal-objects: '["prometheuses.monitoring.rhobs","alertmanager.monitoring.rhobs"]'
+    operators.operatorframework.io/internal-objects: |-
+      [
+        "prometheuses.monitoring.rhobs", "alertmanagers.monitoring.rhobs",
+        "thanosrulers.monitoring.rhobs"
+      ]
   name: observability-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
+++ b/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    operators.operatorframework.io/internal-objects: '["prometheuses.monitoring.rhobs","alertmanager.monitoring.rhobs"]'
   name: observability-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION

This commit hides prometheus, alertmanager, thanosruler from
OLM UI.

Jira: https://issues.redhat.com/browse/MON-2835

Signed-off-by: Sunil Thaha <sthaha@redhat.com>
