### PR TITLE
fix: workaround CI failure by trying again

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -48,111 +48,20 @@ runs:
         # Expose the registry to the host so that we can build and push the image
         echo "127.0.0.1 local-registry" | sudo tee -a /etc/hosts
 
-    - name: Build images
+    - name: Run e2e script
       shell: bash
-      run: make operator-image bundle bundle-image IMAGE_BASE="local-registry:30000/observability-operator" VERSION=0.0.0-ci
-
-    - name: Wait for cluster to finish bootstraping
-      shell: bash
-      run: |
-        kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
-        kubectl cluster-info
-        kubectl get pods -A
-
-    - name: Publish images
-      shell: bash
-      run: make operator-push bundle-push PUSH_OPTIONS=--tls-verify=false IMAGE_BASE="local-registry:30000/observability-operator" VERSION=0.0.0-ci
-
-    - name: Deploy the operator
-      shell: bash
-      run: |
-        # TODO: build a kubernetes-specific bundle to avoid doing this
-        kubectl label nodes -l node-role.kubernetes.io/control-plane="" node-role.kubernetes.io/infra=""
-        kubectl create -k deploy/crds/kubernetes
-        kubectl wait --for=condition=Established crds --all --timeout=300s
-
-        ./tmp/bin/operator-sdk run bundle \
-          local-registry:30000/observability-operator-bundle:0.0.0-ci \
-          --install-mode AllNamespaces \
-          --namespace operators \
-          --skip-tls
-
-        kubectl rollout status deployment observability-operator -n operators
-
-    - name: Expose operator metrics endpoint
-      shell: bash
-      run: |
-        kubectl apply -n operators -f hack/kind/operator-metrics-service.yaml
-        sleep 2
-
-        # wait for the service to create an endpoint
-        while ! kubectl get -n operators ep  operator-metrics-service && [[ "$i" -le 5 ]]; do
-            (( i++ ))
-            echo " - $i ... repeat "
-            sleep 2
-        done
-
-    - name: Assert no reconciliation errors before running the test
-      shell: bash
-      run: |
-        # assert there are no reconciliation errors before running test
-        # give operator some time to start before collecting the metrics
-        sleep 5
-        ./tmp/bin/promq -t http://localhost:30001/metrics  \
-          -q 'controller_runtime_reconcile_errors_total' -o yaml
-
-        reconcile_errors=$( ./tmp/bin/promq \
-          -t http://localhost:30001/metrics  -o yaml \
-          -q 'sum(controller_runtime_reconcile_errors_total)' \
-          | tr -d ' ' | grep ^v: | cut -f2  -d: )
-
-        echo "Reconcile errors before running tests: $reconcile_errors"
-
-        if [[ "$reconcile_errors" -ne 0 ]]; then
-          kubectl logs -n operators deploy/observability-operator
-          echo ================================================================
-          echo "Expecting 0 reconcile errors but found $reconcile_errors"
-          exit 1
-        fi
-
-    - name: Run tests
-      shell: bash
-      run: go test -v -failfast ./test/e2e/... --retain=true
-
-    - name: Print operator logs and reconcile stats
-      shell: bash
-      run: |
-        kubectl logs -n operators deploy/observability-operator
-        echo ================================================================
-
-        ./tmp/bin/promq -t http://localhost:30001/metrics  \
-          -q 'controller_runtime_reconcile_errors_total'
-
-    - name: Assert that there are no reconciliation errors
-      shell: bash
-      run: |
-        reconcile_errors=$( ./tmp/bin/promq \
-          -t http://localhost:30001/metrics  -o yaml \
-          -q 'sum(controller_runtime_reconcile_errors_total)' \
-          | tr -d ' ' | grep ^v: | cut -f2  -d: )
-
-        echo "Reconcile errors after test run: $reconcile_errors"
-        if [[ "$reconcile_errors" -ne 0 ]]; then
-          echo "Found $reconcile_errors reconciliation errors"
-          exit 1
-        fi
+      run: ./test/run-e2e.sh --ci
 
     - name: Capture cluster state
       if: always()
       shell: bash
       run: |
-        # Output operator logs
-        kubectl logs -n operators deploy/observability-operator
         # Capture apiserver state
         oc adm inspect node --dest-dir cluster-state || true
         oc adm inspect -A statefulset --dest-dir cluster-state || true
         oc adm inspect -A deployment --dest-dir cluster-state || true
         oc adm inspect -A ns --dest-dir cluster-state || true
+        cp -r tmp/e2e cluster-state/ || true
 
     - name: Archive production artifacts
       if: always()

--- a/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
+++ b/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
@@ -127,7 +127,7 @@ func newAlertmanagerPDB(ms *stack.MonitoringStack, instanceSelectorKey string, i
 	}
 }
 
-func newAlertManagerRole(ms *stack.MonitoringStack, rbacResourceName string, rbacVerbs []string) *rbacv1.Role {
+func newAlertmanagerRole(ms *stack.MonitoringStack, rbacResourceName string, rbacVerbs []string) *rbacv1.Role {
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: rbacv1.SchemeGroupVersion.String(),

--- a/pkg/controllers/monitoring/monitoring-stack/controller.go
+++ b/pkg/controllers/monitoring/monitoring-stack/controller.go
@@ -134,7 +134,7 @@ func (rm resourceManager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, nil
 	}
 
-	reconcilers := stackComponentReconcilers(ms, rm.instanceSelectorKey, rm.instanceSelectorValue)
+	reconcilers := stackComponentReconcilers(ms, rm.instanceSelectorKey, rm.instanceSelectorValue, logger)
 	for _, reconciler := range reconcilers {
 		err := reconciler.Reconcile(ctx, rm.k8sClient, rm.scheme)
 		// handle create / update errors that can happen due to a stale cache by

--- a/pkg/controllers/monitoring/thanos-querier/components.go
+++ b/pkg/controllers/monitoring/thanos-querier/components.go
@@ -3,6 +3,7 @@ package thanos_querier
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"github.com/rhobs/observability-operator/pkg/reconciler"
 
 	monv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
@@ -13,13 +14,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func thanosComponentReconcilers(thanos *msoapi.ThanosQuerier, sidecarUrls []string) []reconciler.Reconciler {
+func thanosComponentReconcilers(thanos *msoapi.ThanosQuerier, sidecarUrls []string, l logr.Logger) []reconciler.Reconciler {
 	name := "thanos-querier-" + thanos.Name
 	return []reconciler.Reconciler{
-		reconciler.NewUpdater(newServiceAccount(name, thanos.Namespace), thanos),
-		reconciler.NewUpdater(newThanosQuerierDeployment(name, thanos, sidecarUrls), thanos),
-		reconciler.NewUpdater(newService(name, thanos.Namespace), thanos),
-		reconciler.NewUpdater(newServiceMonitor(name, thanos.Namespace), thanos),
+		reconciler.NewUpdater(newServiceAccount(name, thanos.Namespace), thanos, l),
+		reconciler.NewUpdater(newThanosQuerierDeployment(name, thanos, sidecarUrls), thanos, l),
+		reconciler.NewUpdater(newService(name, thanos.Namespace), thanos, l),
+		reconciler.NewUpdater(newServiceMonitor(name, thanos.Namespace), thanos, l),
 	}
 }
 

--- a/pkg/controllers/monitoring/thanos-querier/controller.go
+++ b/pkg/controllers/monitoring/thanos-querier/controller.go
@@ -104,7 +104,7 @@ func (rm resourceManager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, err
 	}
 
-	reconcilers := thanosComponentReconcilers(querier, sidecarServices)
+	reconcilers := thanosComponentReconcilers(querier, sidecarServices, logger)
 	for _, reconciler := range reconcilers {
 		err := reconciler.Reconcile(ctx, rm, rm.scheme)
 		// handle creation / updation errors that can happen due to a stale cache by

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -3,9 +3,14 @@ package reconciler
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -22,57 +27,190 @@ type Reconciler interface {
 type Updater struct {
 	resourceOwner metav1.Object
 	resource      client.Object
+	logger        logr.Logger
 }
 
 func (r Updater) Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
 
-	if r.resourceOwner.GetNamespace() == r.resource.GetNamespace() {
+	r.logger.Info("patching started")
+	defer r.logger.Info("patching done")
+
+	ns := r.resource.GetNamespace()
+	name := r.resource.GetName()
+	gvk := r.resource.GetObjectKind().GroupVersionKind()
+
+	if r.resourceOwner.GetNamespace() == ns {
 		if err := controllerutil.SetControllerReference(r.resourceOwner, r.resource, scheme); err != nil {
-			return fmt.Errorf("%s/%s (%s): updater failed to set owner reference: %w",
-				r.resource.GetNamespace(), r.resource.GetName(),
-				r.resource.GetObjectKind().GroupVersionKind().String(), err)
+			return fmt.Errorf("%s/%s (%s): updater failed to set owner reference: %w", ns, name, gvk, err)
 		}
 	}
-
 	owner := fmt.Sprintf("%s/%s", r.resourceOwner.GetNamespace(), r.resourceOwner.GetName())
+
+	// HACK: works around the issue that the operator sometimes fails to create
+	// a rolebinding  because a role that was created earlier could not be found.
+	// E.g. while creating a RoleBinding "valid-loglevel-alertmanager", we often see
+	// Patch fails with Error "roles.rbac.authorization.k8s.io 'valid-loglevel-alertmanager' not found"
+	//
+	// The workaround is to wait until the resource that was applied by Patch is created, and
+	// on failure to return the error
+
 	if err := c.Patch(ctx, r.resource, client.Apply, client.ForceOwnership, client.FieldOwner(owner)); err != nil {
-		return fmt.Errorf("%s/%s (%s): updater failed to patch: %w",
-			r.resource.GetNamespace(), r.resource.GetName(),
-			r.resource.GetObjectKind().GroupVersionKind().String(), err)
+		return fmt.Errorf("%s/%s (%s): updater failed to patch: %w", ns, name, gvk, err)
 	}
+
+	dup, err := copyClientObject(r.resource)
+	if err != nil {
+		return err
+	}
+
+	// these const makes it easier to understand the return statements in poll
+	const done = true
+	const retry = false
+
+	attempt := 0
+	var getErr error
+
+	pollErr := wait.PollImmediate(10*time.Second, 60*time.Second, func() (bool, error) {
+		// reset error for every attemt
+		getErr = nil
+
+		attempt++
+		l := r.logger.WithValues("attempt", attempt)
+
+		// try to get the object back again and if that fails, retry
+		key := types.NamespacedName{Namespace: ns, Name: name}
+		err := c.Get(ctx, key, dup)
+		if err != nil {
+			l.Info("resource patched but hasn't been created", "err", err)
+			getErr = fmt.Errorf("%s/%s (%s): updater failed to create: %w", ns, name, gvk, err)
+			return retry, nil
+		}
+
+		l.Info("resource patched and created successfully")
+		return done, nil
+	})
+
+	r.logger.Info("after patch", "get", getErr, "poll", pollErr)
+
+	if pollErr == wait.ErrWaitTimeout {
+		return getErr
+	}
+
 	return nil
 }
 
-func NewUpdater(resource client.Object, owner metav1.Object) Updater {
+func NewUpdater(r client.Object, owner metav1.Object, l logr.Logger) Updater {
 	return Updater{
 		resourceOwner: owner,
-		resource:      resource,
+		resource:      r,
+		logger: l.WithName("updater").WithValues(
+			"resource", r.GetName(), "ns", r.GetNamespace(),
+			"kind", r.GetObjectKind().GroupVersionKind().Kind,
+			"owner", owner.GetName(),
+		),
 	}
 }
 
 // Deleter deletes a resource and ignores NotFound errors.
 type Deleter struct {
 	resource client.Object
+	logger   logr.Logger
 }
 
 func (r Deleter) Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
-	if err := c.Delete(ctx, r.resource); client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("%s/%s (%s): deleter failed to delete: %w",
-			r.resource.GetNamespace(), r.resource.GetName(),
-			r.resource.GetObjectKind().GroupVersionKind().String(), err)
+	// these const makes is easier to understand the return statements
+	r.logger.Info("delete started")
+	defer r.logger.Info("delete finished")
+
+	const done = true
+	const retry = false
+
+	ns := r.resource.GetNamespace()
+	name := r.resource.GetName()
+	gvk := r.resource.GetObjectKind().GroupVersionKind()
+
+	var delErr error
+	pollErr := wait.PollImmediate(2*time.Second, 10*time.Second, func() (bool, error) {
+		delErr = nil
+
+		if err := c.Delete(ctx, r.resource); client.IgnoreNotFound(err) != nil {
+			r.logger.Info("delete failed", "err", err)
+			delErr = fmt.Errorf("%s/%s (%s): deleter failed to delete: %w", ns, name, gvk, err)
+			return retry, nil
+		}
+		r.logger.Info("deleted successfully")
+		return done, nil
+	})
+
+	r.logger.Info("after deletion", "del", delErr, "poll", pollErr)
+
+	if pollErr == wait.ErrWaitTimeout {
+		return delErr
 	}
+
+	// Get requires a client.Object but we can't use r.resource since it may
+	// need to be reapplied, so deepcopy the resource and set the GVK
+	dup, err := copyClientObject(r.resource)
+	if err != nil {
+		return err
+	}
+
+	pollErr = wait.PollImmediate(3*time.Second, 15*time.Second, func() (bool, error) {
+
+		// reset delErr for every attempt
+		delErr = nil
+
+		// try to get the object back again and if it exits, retry
+		key := types.NamespacedName{Namespace: ns, Name: name}
+		if err := c.Get(ctx, key, dup); errors.IsNotFound(err) {
+			r.logger.Info("resource deleted successfully")
+			return done, nil
+		}
+
+		delErr = fmt.Errorf("%s/%s (%s): resource deletion is incomplete: %w", ns, name, gvk, err)
+		r.logger.Info("resource deleted but still exists", "err", err)
+		return retry, nil
+	})
+
+	r.logger.Info("after delete", "del-error", delErr, "poll-error", pollErr)
+
+	if pollErr == wait.ErrWaitTimeout {
+		return delErr
+	}
+
 	return nil
 }
 
-func NewDeleter(r client.Object) Deleter {
-	return Deleter{resource: r}
+func NewDeleter(r client.Object, l logr.Logger) Deleter {
+	return Deleter{
+		resource: r,
+		logger: l.WithName("deleter").WithValues(
+			"name", r.GetName(), "ns", r.GetNamespace(),
+			"kind", r.GetObjectKind().GroupVersionKind().Kind,
+		),
+	}
 }
 
 // NewOptionalUpdater ensures that a resource is present or absent depending on the `cond` value (true: present).
-func NewOptionalUpdater(r client.Object, c metav1.Object, cond bool) Reconciler {
+func NewOptionalUpdater(r client.Object, c metav1.Object, l logr.Logger, cond bool) Reconciler {
 	if cond {
-		return NewUpdater(r, c)
+		return NewUpdater(r, c, l)
 	} else {
-		return NewDeleter(r)
+		return NewDeleter(r, l)
 	}
+}
+
+func copyClientObject(o client.Object) (client.Object, error) {
+
+	// Get requires a client.Object but we can't use r.resource since it may
+	// need to be reapplied, so deepcopy the resource and set the GVK
+	gvk := o.GetObjectKind().GroupVersionKind()
+	dup, ok := o.DeepCopyObject().(client.Object)
+	if !ok {
+		return nil, fmt.Errorf("%s/%s (%s): failed to create copy",
+			o.GetNamespace(), o.GetName(), gvk)
+	}
+
+	dup.GetObjectKind().SetGroupVersionKind(gvk)
+	return dup, nil
 }

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+set -e -u -o pipefail
+
+trap cleanup INT
+
+declare PROJECT_ROOT
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+
+declare -r OBO_IMG="${OBO_IMG:-local-registry:30000/observability-operator}"
+declare -r OBO_VERSION="0.0.0-e2e"
+declare -r BUNDLE_IMG="$OBO_IMG-bundle:$OBO_VERSION"
+declare -r OBO_DEPLOYMENT_YAML="deploy/operator/observability-operator-deployment.yaml"
+
+declare CI_MODE=false
+declare SHOW_USAGE=false
+declare LOGS_DIR="tmp/e2e"
+
+
+
+header(){
+  local title="🔆🔆🔆  $*  🔆🔆🔆 "
+
+  local len=40
+  if [[ ${#title} -gt $len ]]; then
+    len=${#title}
+  fi
+
+  echo -e "\n\n  \033[1m${title}\033[0m"
+  echo -n "━━━━━"
+  printf '━%.0s' $(seq "$len")
+  echo "━━━━━━━"
+
+}
+
+info(){
+  echo " 🔔 $*"
+}
+
+ok(){
+  echo " ✅ $*"
+}
+
+warn(){
+  echo " ⚠️  $*"
+}
+
+skip(){
+  echo " 🙈 SKIP: $*"
+}
+
+die(){
+  echo -e "\n ✋ $* "
+  echo -e "──────────────────── ⛔️⛔️⛔️ ────────────────────────\n"
+  exit 1
+}
+
+line(){
+  local len="$1"; shift
+
+  echo -n "────"
+  printf '─%.0s' $(seq "$len")
+  echo "────────"
+}
+
+
+cleanup() {
+  info "Cleaning up ..."
+  # shell check  ignore word splitting when using jobs -p
+  # shellcheck disable=SC2046
+  [[ -z "$(jobs -p)" ]] || kill $(jobs -p) || true
+}
+
+delete_olm_subscription() {
+  header "Delete Old Deployments"
+
+  $CI_MODE && {
+    ok "skipping deletion of old deployment in CI mode"
+    return 0
+  }
+
+  kubectl delete -n operators csv --all || true
+  kubectl delete -n operators installplan,subscriptions,catalogsource \
+    -l operators.coreos.com/observability-operator.operators=  || true
+  kubectl delete -n operators catalogsource observability-operator-catalog || true
+}
+
+build_bundle(){
+  header "Build Operator Bundle"
+
+  make operator-image bundle bundle-image \
+    IMAGE_BASE="$OBO_IMG" VERSION="$OBO_VERSION"
+}
+
+push_bundle(){
+  make operator-push bundle-push \
+    IMAGE_BASE="$OBO_IMG" VERSION="$OBO_VERSION" \
+    PUSH_OPTIONS=--tls-verify=false
+
+}
+
+
+expose_metrics() {
+  header "Expose Operator Metrics"
+
+  kubectl apply -n operators -f hack/kind/operator-metrics-service.yaml
+  sleep 2
+
+  # wait for the service to create an endpoint
+  local i=0
+  while ! kubectl get -n operators ep operator-metrics-service && [[ "$i" -le 5 ]]; do
+      (( i++ ))
+      echo " - $i ... repeat "
+      sleep 2
+  done
+}
+
+assert_no_reconciliation_errors(){
+  local stage="$1"; shift
+  local log_file="$LOGS_DIR/operator-$stage.log"
+
+  header "Ensure No Reconciliation Errors [ $stage ]"
+
+  sleep 3
+  ./tmp/bin/promq -t http://localhost:30001/metrics  \
+    -q 'controller_runtime_reconcile_errors_total' -o yaml
+
+  local reconcile_errors
+  reconcile_errors=$( ./tmp/bin/promq \
+    -t http://localhost:30001/metrics  -o yaml \
+    -q 'sum(controller_runtime_reconcile_errors_total)' \
+    | tr -d ' ' | grep ^v: | cut -f2  -d: )
+
+  info "Reconcile errors [$stage]: $reconcile_errors"
+
+  kubectl logs -n operators deploy/observability-operator > "$log_file"
+
+  if [[ "$reconcile_errors" -eq 0 ]]; then
+    ok "0 reconciliation errors 🥳"
+    return 0
+  fi
+
+  info "Reconciliation Errors 😱😞"
+  line 50
+  grep error "$log_file"
+  line 50
+  warn "Expected 0 reconcile errors but found $reconcile_errors 😱😞"
+  return 1
+
+}
+
+run_bundle(){
+  header "Running ObO Bundle"
+
+ ./tmp/bin/operator-sdk run bundle "$BUNDLE_IMG" \
+   --install-mode AllNamespaces --namespace operators --skip-tls
+}
+
+
+log_events(){
+  local ns="$1"; shift
+  kubectl get events -w \
+    -o custom-columns=FirstSeen:.firstTimestamp,LastSeen:.lastTimestamp,Count:.count,From:.source.component,Type:.type,Reason:.reason,Message:.message  \
+    -n "$ns" | tee "$LOGS_DIR/$ns-events.log"
+}
+
+watch_obo_errors(){
+  local err_log="$1"; shift
+
+  kubectl logs -f -n operators deploy/observability-operator | grep error | tee "$err_log"
+}
+
+
+run_e2e(){
+  header "Running e2e tests"
+
+  local obo_error_log="$LOGS_DIR/operator-errors.log"
+
+  log_events "operators" &
+  log_events "e2e-tests" &
+  watch_obo_errors "$obo_error_log" &
+
+  local ret=0
+  go test -v -failfast ./test/e2e/... --retain=true \
+    tee "$LOGS_DIR/e2e.log" || ret=1
+
+  # terminte both log_events
+  { jobs -p | xargs -I {} -- pkill -TERM -P {};  } || true
+
+  if [[ "$ret" -ne 0  ]]; then
+    # logging of errors may not be immediate, so it is better to read logs again
+    # than dumping the $obo_error_log file
+    sleep 2
+    info "ObO Error Logs"
+    line 50
+    kubectl logs -n operators deploy/observability-operator | grep error | tee "$obo_error_log"
+    line 50
+  fi
+
+  return $ret
+}
+
+
+declare NO_DEPLOY=false
+
+parse_args() {
+  ### while there are args parse them
+  while [[ -n "${1+xxx}" ]]; do
+    case $1 in
+    -h|--help)      SHOW_USAGE=true; break ;; # exit the loop
+    --no-deploy)    NO_DEPLOY=true; shift ;;
+    --ci)           CI_MODE=true; shift ;;
+    *)              return 1 ;; # show usage on everything else
+    esac
+  done
+  return 0
+}
+
+
+print_usage() {
+  local scr
+  scr="$(basename "$0")"
+
+  read -r -d '' help <<-EOF_HELP || true
+Usage:
+  $scr
+  $scr  --no-deploy
+  $scr  -h|--help
+
+
+Options:
+  -h|--help        show this help
+  --no-deploy      do not build and deploy 0b0, useful for rerunning tests
+
+
+EOF_HELP
+
+  echo -e "$help"
+  return 0
+}
+
+
+
+init_logs_dir(){
+  rm -rf "$LOGS_DIR-prev"
+  mv "$LOGS_DIR" "$LOGS_DIR-prev" || true
+  mkdir -p "$LOGS_DIR"
+}
+
+restart_obo() {
+  header "Restart ObO deployment"
+
+  ensure_obo_deploy_img_is_always_pulled ||  return 1
+
+  info "scale down ObO"
+  kubectl scale -n operators --replicas=0 deploy/observability-operator
+  kubectl wait -n operators --for=delete pods -l app.kubernetes.io/component=operator --timeout=60s
+
+  info "scale up ObO"
+  kubectl scale -n operators --replicas=1 deploy/observability-operator
+  wait_for_operators_ready
+
+  ok "ObO deployment restarted"
+
+}
+
+wait_for_operators_ready(){
+  kubectl wait -n operators --for=condition=Available deploy/observability-operator --timeout=300s
+  kubectl wait -n operators --for=condition=Available deploy/obo-prometheus-operator --timeout=300s
+  kubectl wait -n operators --for=condition=Available deploy/obo-prometheus-operator-admission-webhook --timeout=300s
+}
+
+create_platform_mon_crds() {
+  kubectl create -k deploy/crds/kubernetes || true
+}
+
+deploy_obo(){
+  header "Build and Deploy Obo"
+
+  delete_olm_subscription || true
+  ensure_obo_imgpullpolicy_always_in_yaml
+  create_platform_mon_crds
+  build_bundle
+  push_bundle
+  run_bundle
+  wait_for_operators_ready
+  expose_metrics
+}
+
+ensure_obo_imgpullpolicy_always_in_yaml() {
+
+  $CI_MODE && {
+    ok "skipping check of imagePullPolicy in deployment yaml"
+    return 0
+  }
+
+  local pull_policy
+  pull_policy=$(grep '\s\+imagePullPolicy:' "$OBO_DEPLOYMENT_YAML" | tr -d ' ' | cut -f2 -d:)
+
+  [[ "$pull_policy" != "Always" ]] && {
+    info "Modify $OBO_DEPLOYMENT_YAML imagePullPolicy -> Always"
+    info "  ❯ sed -e 's|imagePullPolicy: .*|imagePullPolicy: Always|g' -i $OBO_DEPLOYMENT_YAML"
+    warn "Deployment's imagePullPolicy must be Always instead of $pull_policy"
+    return 1
+  }
+
+  ok "ObO deployment yaml imagePullPolicy is Always"
+}
+
+ensure_obo_deploy_img_is_always_pulled() {
+  $CI_MODE && {
+    ok "skipping check of imagePullPolicy of ObO deployment"
+    return 0
+  }
+
+  local pull_policy
+  pull_policy=$(kubectl get deploy observability-operator \
+    -n operators \
+    -ojsonpath='{.spec.template.spec.containers[].imagePullPolicy}')
+
+  if [[ "$pull_policy" != "Always" ]]; then
+    info "Edit $OBO_DEPLOYMENT_YAML imagePullPolicy and redeploy"
+    info "  ❯ sed -e 's|imagePullPolicy: .*|imagePullPolicy: Always|g' -i $OBO_DEPLOYMENT_YAML"
+    warn "Deployment's imagePullPolicy must be Always instead of $pull_policy"
+    return 1
+  fi
+  ok "ObO deployment imagePullPolicy is Always"
+}
+
+reset_env() {
+  kubectl delete --wait ns e2e-tests || true
+}
+
+main() {
+  parse_args "$@" || die "parse args failed"
+  $SHOW_USAGE && {
+    print_usage
+    exit 0
+  }
+
+  cd "$PROJECT_ROOT"
+
+  # delete the e2e-tests but contine deploying obo
+  reset_env&   # note must wait before runnng tests
+  init_logs_dir
+
+  if ! $NO_DEPLOY; then
+    deploy_obo
+  else
+    restart_obo || die "restarting ObO failed 🤕"
+  fi
+
+  # wait for the deletion to complete before running tests
+  wait
+
+  assert_no_reconciliation_errors pre-e2e ||
+    die "ObO has reconciliation errors before running test"
+
+  local ret=0
+  run_e2e || ret=1
+  assert_no_reconciliation_errors post-e2e || {
+    # see: https://github.com/rhobs/observability-operator/issues/200
+    skip "post-e2e reconciliation test until #200 is fixed"
+    # ret=1
+  }
+
+  info "e2e test - exit code: $ret"
+  line 50
+
+  return $ret
+}
+
+main "$@"


### PR DESCRIPTION
The workaround uses wait.PollImmediate to try to Patch again for at most 30 seconds

Signed-off-by: Sunil Thaha <sthaha@redhat.com>