### PR TITLE
fix: broken release workflow

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -23,7 +23,7 @@ runs:
     - name: Use go cache
       uses: ./.github/go-cache
 
-    - uses: azure/setup-kubectl@v1
+    - uses: azure/setup-kubectl@v3
 
     - name: Start Kind
       uses: engineerd/setup-kind@v0.5.0
@@ -65,7 +65,7 @@ runs:
 
     - name: Archive production artifacts
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: cluster-state
         path: cluster-state

--- a/.github/go-cache/action.yaml
+++ b/.github/go-cache/action.yaml
@@ -5,9 +5,9 @@ runs:
   steps:
     - name: Get branch name
       id: branch-name
-      uses: tj-actions/branch-names@v5
+      uses: tj-actions/branch-names@v6
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.cache/go-build

--- a/.github/olm-publish/action.yaml
+++ b/.github/olm-publish/action.yaml
@@ -13,7 +13,7 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
     with:
       fetch-depth: 0
 
@@ -29,7 +29,7 @@ runs:
     uses: ./.github/tools-cache
 
   - name: Registry Login
-    uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+    uses: docker/login-action@v2
     with:
       registry: quay.io
       username: ${{ inputs.quay_login }}

--- a/.github/tools-cache/action.yaml
+++ b/.github/tools-cache/action.yaml
@@ -3,7 +3,7 @@ description: Caches develoment tools
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: tools-cache
       with:
         path: ./tmp/bin

--- a/.github/workflows/olm-candidate.yaml
+++ b/.github/workflows/olm-candidate.yaml
@@ -12,7 +12,7 @@ jobs:
     environment: quay
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
         id: version
         run: |
           version="$(cat VERSION)-rc"
-          echo "{version}={$version}" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: publish catalog
         uses: ./.github/olm-publish

--- a/.github/workflows/olm-stable.yaml
+++ b/.github/workflows/olm-stable.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: quay
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -6,23 +6,23 @@ jobs:
   commit-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v4
+      - uses: wagoid/commitlint-github-action@v5
 
   github-actions-yaml-lint:
     runs-on: ubuntu-latest
     name: Github Actions yaml linter
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: reviewdog/action-actionlint@v1
 
   lint:
     runs-on: ubuntu-latest
     name: Run all lints
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Import common environment variables
         run: cat ".github/env" >> $GITHUB_ENV
@@ -50,12 +50,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate and format
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Import common environment variables
         run: cat ".github/env" >> $GITHUB_ENV
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go-version }}
 
@@ -70,12 +70,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Validate tools cache
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Import common environment variables
         run: cat ".github/env" >> $GITHUB_ENV
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go-version }}
 
@@ -90,13 +90,13 @@ jobs:
   build-bundle-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Import common environment variables
         run: cat ".github/env" >> $GITHUB_ENV
 
       - name: Setup Go environment
-        uses: actions/setup-go@v2.1.4
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go-version }}
 
@@ -112,7 +112,7 @@ jobs:
   e2e-tests-olm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Import common environment variables
         run: cat ".github/env" >> $GITHUB_ENV

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
   e2e-tests-olm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Import common environment variables
         run: cat ".github/env" >> $GITHUB_ENV
@@ -25,7 +25,7 @@ jobs:
     needs:
       - e2e-tests-olm
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
         run: |
           npx standard-version --skip.commit --skip.tag --skip.changelog
           version="$(cat VERSION)-$(date +%y%m%d%H%M%S)"
-          echo "{version}={$version}" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Publish
         uses: ./.github/olm-publish
@@ -71,7 +71,7 @@ jobs:
     if: "startsWith(github.event.head_commit.message, 'chore(release):')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           token: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
@@ -84,7 +84,7 @@ jobs:
       # Therefore, we first need to setup Go so that we can install the
       # controller-gen binary.
       - name: Setup Go environment
-        uses: actions/setup-go@v2.1.4
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.go-version }}
 
@@ -104,7 +104,7 @@ jobs:
           # chore(release): commit as opposed to pointing to the commit added
           # to olm-catalog branch after images are built and pushed
           git push --follow-tags
-          echo ::set-output name=tag_name::$(git describe HEAD --abbrev=0)
+          echo "tag_name=$(git describe HEAD --abbrev=0)" >> $GITHUB_OUTPUT
 
       - name: Create Github release
         uses: actions/create-release@v1


### PR DESCRIPTION
GitHub release workflow was broken by changes made in commit 4625e3e which was intended to fix deprecation message but the usage was wrong and didn't correctly fix all warnings. This commit aims to fix all warnings and deprecation messages.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>