### PR TITLE
build: publish catalog image with SHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ IMAGE_BASE ?= observability-operator
 
 VERSION ?= $(shell cat VERSION)
 OPERATOR_IMG = $(IMAGE_BASE):$(VERSION)
+OPERATOR_BUNDLE=observability-operator.v$(VERSION)
 CONTAINER_RUNTIME := $(shell command -v podman 2> /dev/null || echo docker)
 
 # running `make` builds the operator (default target)
@@ -163,52 +164,52 @@ bundle-image: bundle ## Build the bundle image.
 bundle-push: ## Build the bundle image.
 	$(CONTAINER_RUNTIME) push $(PUSH_OPTIONS) $(BUNDLE_IMG)
 
-# A comma-separated list of bundle images e.g.
-# make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
-#
-# NOTE: These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS ?= $(BUNDLE_IMG)
-
 # The image tag given to the resulting catalog image
-CATALOG_IMG ?= $(IMAGE_BASE)-catalog:$(VERSION)
+CATALOG_IMG_BASE ?= $(IMAGE_BASE)-catalog
+CATALOG_IMG ?= $(CATALOG_IMG_BASE):$(VERSION)
 
 # The tag is used as latest since it allows a CatalogSubscription to point to
 # a single image which keeps updating there by allowing auto upgrades
 CATALOG_IMG_LATEST ?= $(IMAGE_BASE)-catalog:latest
 
 
-# mark release as first by setting FIRST_OLM_RELEASE to true. This results in a
-# root catalog image  (i.e. no previous catalog images/ --from-index)
-FIRST_OLM_RELEASE ?= false
-
-# Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to
-# that image except for FIRST_OLM_RELEASE
-ifeq ($(FIRST_OLM_RELEASE), false)
-FROM_INDEX_OPT := --from-index $(CATALOG_IMG_LATEST)
-endif
+# NOTE: This is required to enable continuous deployment to
+# staging/integration environments via app-interface (OSD-13603)
+#
+# The git short-hash of the most recent commit in the repository, which will
+# be used for image tag association against the built catalog image
+CATALOG_IMG_SHA = $(CATALOG_IMG_BASE):$(shell git rev-parse --short=8 HEAD)
 
 # Build a catalog image by adding bundle images to an empty catalog using the
 # operator package manager tool, 'opm'.
-#
-# NOTE: This recipe invokes 'opm' in 'semver' bundle add mode. For more information
-# on add modes, see:
-# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-image
 catalog-image: $(OPM)
-	$(OPM) index add \
-	 	--container-tool $(CONTAINER_RUNTIME) \
-		--mode semver \
-		--tag $(CATALOG_IMG) \
-		--bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) render $(BUNDLE_IMG) \
+		--output=yaml  >> olm/observability-operator-index/index.yaml
+	./olm/update-channels.sh $(CHANNELS) $(OPERATOR_BUNDLE)
+	$(OPM) validate ./olm/observability-operator-index
+
+	$(CONTAINER_RUNTIME) build \
+		-f olm/observability-operator-index.Dockerfile \
+		-t $(CATALOG_IMG)
+
 	# tag the catalog img:version as latest so that continious release
 	# is possible by refering to latest tag instead of a version
 	$(CONTAINER_RUNTIME) tag $(CATALOG_IMG) $(CATALOG_IMG_LATEST)
 
+# NOTE: This target is created to ensure that the catalog image points to the
+# SHA/commit in olm-catalog branch (instead of the commmit in main) which adds
+# the bundle and the olm catalog instead of the SHA of the checkout (code change)
+.PHONY: catalog-tag-sha
+catalog-tag-sha: ## Push a catalog image.
+	$(CONTAINER_RUNTIME) tag $(CATALOG_IMG) $(CATALOG_IMG_SHA)
+
 # Push the catalog image.
 .PHONY: catalog-push
-catalog-push: ## Push a catalog image.
+catalog-push: catalog-tag-sha ## Push a catalog image.
 	$(CONTAINER_RUNTIME) push $(PUSH_OPTIONS) $(CATALOG_IMG)
 	$(CONTAINER_RUNTIME) push $(PUSH_OPTIONS) $(CATALOG_IMG_LATEST)
+	$(CONTAINER_RUNTIME) push $(PUSH_OPTIONS) $(CATALOG_IMG_SHA)
 
 .PHONY: release
 release: operator-image operator-push bundle-image bundle-push catalog-image catalog-push


### PR DESCRIPTION
To enable continuous delivery of OBO to OSD/ROSA clusters via app-interface, the OLM catalog image must be tagged with a git short hash that represents the commit that was used for the creation of the catalog.

This patch adds a make target `catalog-tag-sha` that tags the catalog image with the SHA of the commit that CI bot makes when it updates the catalog.

In addition to that the PR also update the Makefile to reflect the FBC change that was pushed to olm-catalog branch but was missing in main.

JIRA: https://issues.redhat.com/browse/MON-2859

Signed-off-by: Sunil Thaha <sthaha@redhat.com>