### PR TITLE
fix: update log levels to reflect alertmanager levels

### DIFF
--- a/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
+++ b/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
@@ -51,7 +51,8 @@ spec:
                 enum:
                 - debug
                 - info
-                - warning
+                - warn
+                - error
                 type: string
               namespaceSelector:
                 description: Namespace selector for Monitoring Stack Resources. If

--- a/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
+++ b/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
@@ -52,7 +52,8 @@ spec:
                 enum:
                 - debug
                 - info
-                - warning
+                - warn
+                - error
                 type: string
               namespaceSelector:
                 description: Namespace selector for Monitoring Stack Resources. If

--- a/docs/api.md
+++ b/docs/api.md
@@ -100,7 +100,7 @@ MonitoringStackSpec is the specification for desired Monitoring Stack
         <td>
           Loglevel set log levels of configured components<br/>
           <br/>
-            <i>Enum</i>: debug, info, warning<br/>
+            <i>Enum</i>: debug, info, warn, error<br/>
             <i>Default</i>: info<br/>
         </td>
         <td>false</td>

--- a/pkg/apis/monitoring/v1alpha1/types.go
+++ b/pkg/apis/monitoring/v1alpha1/types.go
@@ -34,7 +34,7 @@ type MonitoringStackList struct {
 }
 
 // Loglevel set log levels of configured components
-// +kubebuilder:validation:Enum=debug;info;warning
+// +kubebuilder:validation:Enum=debug;info;warn;error
 type LogLevel string
 
 const (
@@ -44,8 +44,11 @@ const (
 	// Info Log level
 	Info LogLevel = "info"
 
-	// Warning Log level
-	Warning LogLevel = "warning"
+	// Warn Log level
+	Warn LogLevel = "warn"
+
+	// Error Log level
+	Error LogLevel = "error"
 )
 
 // MonitoringStackSpec is the specification for desired Monitoring Stack

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -276,6 +276,7 @@ func validateStackLogLevel(t *testing.T) {
 		"xyz",
 		"Info",
 		"Debug",
+		"Warning",
 	}
 	ms := newMonitoringStack(t, "invalid-loglevel-stack")
 	for _, v := range invalidLogLevels {


### PR DESCRIPTION
This updates the valid log level values in the API. This adds new "error" log level and changes the "warning" log level to "warn".