### PR TITLE
feat: add resourceDiscovery status condition

### DIFF
--- a/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
+++ b/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
@@ -835,7 +835,10 @@ spec:
                     type: integer
                 type: object
               resourceSelector:
-                description: Label selector for Monitoring Stack Resources.
+                description: Label selector for Monitoring Stack Resources. Set to
+                  the empty LabelSelector ({}) to monitoring everything. Set to null
+                  to disable service discovery.
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
+++ b/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
@@ -836,7 +836,10 @@ spec:
                     type: integer
                 type: object
               resourceSelector:
-                description: Label selector for Monitoring Stack Resources.
+                description: Label selector for Monitoring Stack Resources. Set to
+                  the empty LabelSelector to monitoring everything. Set to null to
+                  disable service discovery.
+                nullable: true
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
+++ b/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
@@ -837,8 +837,8 @@ spec:
                 type: object
               resourceSelector:
                 description: Label selector for Monitoring Stack Resources. Set to
-                  the empty LabelSelector to monitoring everything. Set to null to
-                  disable service discovery.
+                  the empty LabelSelector ({}) to monitoring everything. Set to null
+                  to disable service discovery.
                 nullable: true
                 properties:
                   matchExpressions:

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,7 +124,7 @@ MonitoringStackSpec is the specification for desired Monitoring Stack
         <td><b><a href="#monitoringstackspecresourceselector">resourceSelector</a></b></td>
         <td>object</td>
         <td>
-          Label selector for Monitoring Stack Resources.<br/>
+          Label selector for Monitoring Stack Resources. Set to the empty LabelSelector to monitoring everything. Set to null to disable service discovery.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1803,7 +1803,7 @@ RelabelConfig allows dynamic rewriting of the label set, being applied to sample
 
 
 
-Label selector for Monitoring Stack Resources.
+Label selector for Monitoring Stack Resources. Set to the empty LabelSelector to monitoring everything. Set to null to disable service discovery.
 
 <table>
     <thead>

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,7 +124,7 @@ MonitoringStackSpec is the specification for desired Monitoring Stack
         <td><b><a href="#monitoringstackspecresourceselector">resourceSelector</a></b></td>
         <td>object</td>
         <td>
-          Label selector for Monitoring Stack Resources. Set to the empty LabelSelector to monitoring everything. Set to null to disable service discovery.<br/>
+          Label selector for Monitoring Stack Resources. Set to the empty LabelSelector ({}) to monitoring everything. Set to null to disable service discovery.<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -1803,7 +1803,7 @@ RelabelConfig allows dynamic rewriting of the label set, being applied to sample
 
 
 
-Label selector for Monitoring Stack Resources. Set to the empty LabelSelector to monitoring everything. Set to null to disable service discovery.
+Label selector for Monitoring Stack Resources. Set to the empty LabelSelector ({}) to monitoring everything. Set to null to disable service discovery.
 
 <table>
     <thead>

--- a/pkg/apis/monitoring/v1alpha1/types.go
+++ b/pkg/apis/monitoring/v1alpha1/types.go
@@ -58,8 +58,11 @@ type MonitoringStackSpec struct {
 	LogLevel LogLevel `json:"logLevel,omitempty"`
 
 	// Label selector for Monitoring Stack Resources.
+	// Set to the empty LabelSelector ({}) to monitoring everything.
+	// Set to null to disable service discovery.
 	// +optional
-	ResourceSelector *metav1.LabelSelector `json:"resourceSelector,omitempty"`
+	// +nullable
+	ResourceSelector *metav1.LabelSelector `json:"resourceSelector"`
 
 	// Namespace selector for Monitoring Stack Resources.
 	// If left empty the Monitoring Stack will only match resources in the namespace it was created in.
@@ -108,8 +111,9 @@ const (
 	ConditionFalse   ConditionStatus = "False"
 	ConditionUnknown ConditionStatus = "Unknown"
 
-	ReconciledCondition ConditionType = "Reconciled"
-	AvailableCondition  ConditionType = "Available"
+	ReconciledCondition        ConditionType = "Reconciled"
+	AvailableCondition         ConditionType = "Available"
+	ResourceDiscoveryCondition ConditionType = "ResourceDiscovery"
 )
 
 type Condition struct {

--- a/pkg/controllers/monitoring/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components.go
@@ -108,9 +108,6 @@ func newPrometheus(
 	instanceSelectorValue string,
 ) *monv1.Prometheus {
 	prometheusSelector := ms.Spec.ResourceSelector
-	if prometheusSelector == nil {
-		prometheusSelector = &metav1.LabelSelector{}
-	}
 
 	config := ms.Spec.PrometheusConfig
 

--- a/pkg/controllers/monitoring/monitoring-stack/conditions.go
+++ b/pkg/controllers/monitoring/monitoring-stack/conditions.go
@@ -25,51 +25,20 @@ const (
 )
 
 func updateConditions(ms *v1alpha1.MonitoringStack, prom monv1.Prometheus, recError error) []v1alpha1.Condition {
-	msConditions := ms.Status.Conditions
-	if len(msConditions) == 0 {
-		return []v1alpha1.Condition{
-			{
-				Type:               v1alpha1.AvailableCondition,
-				Status:             v1alpha1.ConditionUnknown,
-				Reason:             NoReason,
-				LastTransitionTime: metav1.Now(),
-			},
-			{
-				Type:               v1alpha1.ReconciledCondition,
-				Status:             v1alpha1.ConditionUnknown,
-				Reason:             NoReason,
-				LastTransitionTime: metav1.Now(),
-			},
-			updateResourceDiscovery(ms),
+	return []v1alpha1.Condition{
+		updateResourceDiscovery(ms),
+		updateAvailable(ms.Status.Conditions, prom, ms.Generation),
+		updateReconciled(ms.Status.Conditions, prom, ms.Generation, recError),
+	}
+}
+
+func getMSCondition(conditions []v1alpha1.Condition, t v1alpha1.ConditionType) (v1alpha1.Condition, error) {
+	for _, c := range conditions {
+		if c.Type == t {
+			return c, nil
 		}
 	}
-	generation := ms.Generation
-	var updatedConditions []v1alpha1.Condition
-
-	for _, mc := range msConditions {
-		switch mc.Type {
-		case v1alpha1.AvailableCondition:
-			available := updateAvailable(mc, prom, generation)
-			if !available.Equal(mc) {
-				available.LastTransitionTime = metav1.Now()
-			}
-			updatedConditions = append(updatedConditions, available)
-		case v1alpha1.ReconciledCondition:
-			reconciled := updateReconciled(mc, prom, generation, recError)
-			if !reconciled.Equal(mc) {
-				reconciled.LastTransitionTime = metav1.Now()
-			}
-			updatedConditions = append(updatedConditions, reconciled)
-		case v1alpha1.ResourceDiscoveryCondition:
-			resourceDiscovery := updateResourceDiscovery(ms)
-			if !resourceDiscovery.Equal(mc) {
-				resourceDiscovery.LastTransitionTime = metav1.Now()
-			}
-			updatedConditions = append(updatedConditions, resourceDiscovery)
-		}
-	}
-
-	return updatedConditions
+	return v1alpha1.Condition{}, fmt.Errorf("condition type %v not found", t)
 }
 
 // updateResourceDiscovery updates the ResourceDiscoveryCondition based on the
@@ -100,13 +69,24 @@ func updateResourceDiscovery(ms *v1alpha1.MonitoringStack) v1alpha1.Condition {
 
 // updateAvailable gets existing "Available" condition and updates its parameters
 // based on the Prometheus "Available" condition
-func updateAvailable(ac v1alpha1.Condition, prom monv1.Prometheus, generation int64) v1alpha1.Condition {
+func updateAvailable(conditions []v1alpha1.Condition, prom monv1.Prometheus, generation int64) v1alpha1.Condition {
+	ac, err := getMSCondition(conditions, v1alpha1.AvailableCondition)
+	if err != nil {
+		ac = v1alpha1.Condition{
+			Type:               v1alpha1.AvailableCondition,
+			Status:             v1alpha1.ConditionUnknown,
+			Reason:             NoReason,
+			LastTransitionTime: metav1.Now(),
+		}
+	}
+
 	prometheusAvailable, err := getPrometheusCondition(prom.Status.Conditions, monv1.PrometheusAvailable)
 
 	if err != nil {
 		ac.Status = v1alpha1.ConditionUnknown
 		ac.Reason = PrometheusNotAvailable
 		ac.Message = CannotReadPrometheusConditions
+		ac.LastTransitionTime = metav1.Now()
 		return ac
 	}
 	// MonitoringStack status will not be updated if there is a difference between the Prometheus generation
@@ -123,31 +103,43 @@ func updateAvailable(ac v1alpha1.Condition, prom monv1.Prometheus, generation in
 			ac.Reason = PrometheusNotAvailable
 		}
 		ac.Message = prometheusAvailable.Message
+		ac.LastTransitionTime = metav1.Now()
 		return ac
 	}
 	ac.Status = v1alpha1.ConditionTrue
 	ac.Reason = AvailableReason
 	ac.Message = AvailableMessage
 	ac.ObservedGeneration = generation
+	ac.LastTransitionTime = metav1.Now()
 	return ac
 }
 
 // updateReconciled updates "Reconciled" conditions based on the provided error value and
 // Prometheus "Reconciled" condition
-func updateReconciled(rc v1alpha1.Condition, prom monv1.Prometheus, generation int64, err error) v1alpha1.Condition {
-
-	if err != nil {
+func updateReconciled(conditions []v1alpha1.Condition, prom monv1.Prometheus, generation int64, reconcileErr error) v1alpha1.Condition {
+	rc, cErr := getMSCondition(conditions, v1alpha1.ReconciledCondition)
+	if cErr != nil {
+		rc = v1alpha1.Condition{
+			Type:               v1alpha1.ReconciledCondition,
+			Status:             v1alpha1.ConditionUnknown,
+			Reason:             NoReason,
+			LastTransitionTime: metav1.Now(),
+		}
+	}
+	if reconcileErr != nil {
 		rc.Status = v1alpha1.ConditionFalse
-		rc.Message = err.Error()
+		rc.Message = reconcileErr.Error()
 		rc.Reason = FailedToReconcileReason
+		rc.LastTransitionTime = metav1.Now()
 		return rc
 	}
-	prometheusReconciled, err := getPrometheusCondition(prom.Status.Conditions, monv1.PrometheusReconciled)
+	prometheusReconciled, reconcileErr := getPrometheusCondition(prom.Status.Conditions, monv1.PrometheusReconciled)
 
-	if err != nil {
+	if reconcileErr != nil {
 		rc.Status = v1alpha1.ConditionUnknown
 		rc.Reason = PrometheusNotReconciled
 		rc.Message = CannotReadPrometheusConditions
+		rc.LastTransitionTime = metav1.Now()
 		return rc
 	}
 
@@ -159,12 +151,14 @@ func updateReconciled(rc v1alpha1.Condition, prom monv1.Prometheus, generation i
 		rc.Status = prometheusStatusToMSStatus(prometheusReconciled.Status)
 		rc.Reason = PrometheusNotReconciled
 		rc.Message = prometheusReconciled.Message
+		rc.LastTransitionTime = metav1.Now()
 		return rc
 	}
 	rc.Status = v1alpha1.ConditionTrue
 	rc.Reason = ReconciledReason
 	rc.Message = SuccessfullyReconciledMessage
 	rc.ObservedGeneration = generation
+	rc.LastTransitionTime = metav1.Now()
 	return rc
 }
 

--- a/pkg/controllers/monitoring/monitoring-stack/conditions_test.go
+++ b/pkg/controllers/monitoring/monitoring-stack/conditions_test.go
@@ -13,219 +13,97 @@ func TestUpdateConditions(t *testing.T) {
 	transitionTime := metav1.Now()
 
 	tt := []struct {
-		name                 string
-		originalMSConditions []v1alpha1.Condition
-		prometheus           monv1.Prometheus
-		generation           int64
-		recError             error
-		expectedResults      []v1alpha1.Condition
+		name             string
+		msWithConditions v1alpha1.MonitoringStack
+		prometheus       monv1.Prometheus
+		recError         error
+		expectedResults  []v1alpha1.Condition
 		// flag to compare LastTransitionTime of each condition
 		sameTransitionTimes bool
 	}{
 		{
-			name:                 "empty conditions",
-			originalMSConditions: []v1alpha1.Condition{},
-			generation:           1,
-			recError:             nil,
-			prometheus:           monv1.Prometheus{},
-			expectedResults: []v1alpha1.Condition{
-				{
-					Type:   v1alpha1.AvailableCondition,
-					Status: v1alpha1.ConditionUnknown,
-					Reason: "None",
+			name: "empty conditions",
+			msWithConditions: v1alpha1.MonitoringStack{
+				Status: v1alpha1.MonitoringStackStatus{
+					Conditions: []v1alpha1.Condition{},
 				},
-				{
-					Type:   v1alpha1.ReconciledCondition,
-					Status: v1alpha1.ConditionUnknown,
-					Reason: "None",
-				}},
-		},
-		{
-			name: "conditions not changed when Prometheus Available",
-			originalMSConditions: []v1alpha1.Condition{
-				{
-					Type:               v1alpha1.AvailableCondition,
-					Status:             v1alpha1.ConditionTrue,
-					ObservedGeneration: 1,
-					Reason:             AvailableReason,
-					Message:            AvailableMessage,
-					LastTransitionTime: transitionTime,
-				},
-				{
-					Type:               v1alpha1.ReconciledCondition,
-					Status:             v1alpha1.ConditionTrue,
-					ObservedGeneration: 1,
-					Reason:             ReconciledReason,
-					Message:            SuccessfullyReconciledMessage,
-					LastTransitionTime: transitionTime,
-				},
-			},
-			generation: 1,
-			recError:   nil,
-			prometheus: monv1.Prometheus{
 				ObjectMeta: metav1.ObjectMeta{
 					Generation: 1,
 				},
-				Status: monv1.PrometheusStatus{
-					Conditions: []monv1.PrometheusCondition{
-						{
-							Type:               monv1.PrometheusAvailable,
-							Status:             monv1.PrometheusConditionTrue,
-							ObservedGeneration: 1,
-						},
-						{
-							Type:               monv1.PrometheusReconciled,
-							Status:             monv1.PrometheusConditionTrue,
-							ObservedGeneration: 1,
-						},
-					}}},
-			expectedResults: []v1alpha1.Condition{
-				{
-					Type:               v1alpha1.AvailableCondition,
-					Status:             v1alpha1.ConditionTrue,
-					ObservedGeneration: 1,
-					Reason:             AvailableReason,
-					Message:            AvailableMessage,
-					LastTransitionTime: transitionTime,
-				},
-				{
-					Type:               v1alpha1.ReconciledCondition,
-					Status:             v1alpha1.ConditionTrue,
-					ObservedGeneration: 1,
-					Reason:             ReconciledReason,
-					Message:            SuccessfullyReconciledMessage,
-					LastTransitionTime: transitionTime,
-				}},
-			sameTransitionTimes: true,
-		},
-		{
-			name: "cannot read Prometheus conditions",
-			originalMSConditions: []v1alpha1.Condition{
-				{
-					Type:               v1alpha1.AvailableCondition,
-					Status:             v1alpha1.ConditionTrue,
-					ObservedGeneration: 1,
-					Reason:             AvailableReason,
-					Message:            AvailableMessage,
-					LastTransitionTime: transitionTime,
-				},
-				{
-					Type:               v1alpha1.ReconciledCondition,
-					Status:             v1alpha1.ConditionTrue,
-					ObservedGeneration: 1,
-					Reason:             ReconciledReason,
-					Message:            SuccessfullyReconciledMessage,
-					LastTransitionTime: transitionTime,
-				},
 			},
-			generation: 1,
 			recError:   nil,
 			prometheus: monv1.Prometheus{},
 			expectedResults: []v1alpha1.Condition{
 				{
-					Type:               v1alpha1.AvailableCondition,
-					Status:             v1alpha1.ConditionUnknown,
-					ObservedGeneration: 1,
-					Reason:             PrometheusNotAvailable,
-					Message:            CannotReadPrometheusConditions,
+					Type:   v1alpha1.AvailableCondition,
+					Status: v1alpha1.ConditionUnknown,
+					Reason: NoReason,
 				},
 				{
-					Type:               v1alpha1.ReconciledCondition,
-					Status:             v1alpha1.ConditionUnknown,
-					ObservedGeneration: 1,
-					Reason:             PrometheusNotReconciled,
-					Message:            CannotReadPrometheusConditions,
-				}},
-		},
-		{
-			name: "degraded Prometheus conditions",
-			originalMSConditions: []v1alpha1.Condition{
-				{
-					Type:               v1alpha1.AvailableCondition,
-					Status:             v1alpha1.ConditionTrue,
-					ObservedGeneration: 1,
-					Reason:             AvailableReason,
-					Message:            AvailableMessage,
-					LastTransitionTime: transitionTime,
+					Type:   v1alpha1.ReconciledCondition,
+					Status: v1alpha1.ConditionUnknown,
+					Reason: NoReason,
 				},
 				{
-					Type:               v1alpha1.ReconciledCondition,
-					Status:             v1alpha1.ConditionTrue,
+					Type:               v1alpha1.ResourceDiscoveryCondition,
+					Status:             v1alpha1.ConditionFalse,
+					Reason:             ResourceSelectorIsNil,
+					Message:            ResourceSelectorIsNilMessage,
 					ObservedGeneration: 1,
-					Reason:             ReconciledReason,
-					Message:            SuccessfullyReconciledMessage,
 					LastTransitionTime: transitionTime,
 				},
 			},
-			generation: 1,
-			recError:   nil,
+		},
+		{
+			name: "lastTransitionTime is updated",
+			msWithConditions: v1alpha1.MonitoringStack{
+				Status: v1alpha1.MonitoringStackStatus{
+					Conditions: []v1alpha1.Condition{
+						{
+							Type:               v1alpha1.AvailableCondition,
+							Status:             v1alpha1.ConditionTrue,
+							ObservedGeneration: 1,
+							Reason:             AvailableReason,
+							Message:            AvailableMessage,
+							LastTransitionTime: transitionTime,
+						},
+						{
+							Type:               v1alpha1.ReconciledCondition,
+							Status:             v1alpha1.ConditionTrue,
+							ObservedGeneration: 1,
+							Reason:             ReconciledReason,
+							Message:            SuccessfullyReconciledMessage,
+							LastTransitionTime: transitionTime,
+						},
+						{
+							Type:               v1alpha1.ResourceDiscoveryCondition,
+							Status:             v1alpha1.ConditionFalse,
+							Reason:             ResourceSelectorIsNil,
+							Message:            ResourceSelectorIsNilMessage,
+							ObservedGeneration: 1,
+							LastTransitionTime: transitionTime,
+						},
+					},
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 2,
+				},
+			},
+			recError: nil,
 			prometheus: monv1.Prometheus{
 				ObjectMeta: metav1.ObjectMeta{
-					Generation: 1,
+					Generation: 2,
 				},
 				Status: monv1.PrometheusStatus{
 					Conditions: []monv1.PrometheusCondition{
 						{
 							Type:               monv1.PrometheusAvailable,
-							Status:             monv1.PrometheusConditionDegraded,
-							ObservedGeneration: 1,
-						},
-						{
-							Type:               monv1.PrometheusReconciled,
-							Status:             monv1.PrometheusConditionDegraded,
-							ObservedGeneration: 1,
-						},
-					}}},
-			expectedResults: []v1alpha1.Condition{
-				{
-					Type:               v1alpha1.AvailableCondition,
-					Status:             v1alpha1.ConditionFalse,
-					ObservedGeneration: 1,
-					Reason:             PrometheusDegraded,
-				},
-				{
-					Type:               v1alpha1.ReconciledCondition,
-					Status:             v1alpha1.ConditionFalse,
-					ObservedGeneration: 1,
-					Reason:             PrometheusNotReconciled,
-				}},
-		},
-		{
-			name: "Prometheus observed generation is different from the Prometheus generation",
-			originalMSConditions: []v1alpha1.Condition{
-				{
-					Type:               v1alpha1.AvailableCondition,
-					Status:             v1alpha1.ConditionTrue,
-					ObservedGeneration: 2,
-					Reason:             AvailableReason,
-					Message:            AvailableMessage,
-					LastTransitionTime: transitionTime,
-				},
-				{
-					Type:               v1alpha1.ReconciledCondition,
-					Status:             v1alpha1.ConditionTrue,
-					ObservedGeneration: 2,
-					Reason:             ReconciledReason,
-					Message:            SuccessfullyReconciledMessage,
-					LastTransitionTime: transitionTime,
-				},
-			},
-			generation: 2,
-			recError:   nil,
-			prometheus: monv1.Prometheus{
-				ObjectMeta: metav1.ObjectMeta{
-					Generation: 3,
-				},
-				Status: monv1.PrometheusStatus{
-					Conditions: []monv1.PrometheusCondition{
-						{
-							Type:               monv1.PrometheusAvailable,
-							Status:             monv1.PrometheusConditionFalse,
+							Status:             monv1.PrometheusConditionTrue,
 							ObservedGeneration: 2,
 						},
 						{
 							Type:               monv1.PrometheusReconciled,
-							Status:             monv1.PrometheusConditionFalse,
+							Status:             monv1.PrometheusConditionTrue,
 							ObservedGeneration: 2,
 						},
 					}}},
@@ -245,13 +123,22 @@ func TestUpdateConditions(t *testing.T) {
 					Reason:             ReconciledReason,
 					Message:            SuccessfullyReconciledMessage,
 					LastTransitionTime: transitionTime,
-				}},
-			sameTransitionTimes: true,
+				},
+				{
+					Type:               v1alpha1.ResourceDiscoveryCondition,
+					Status:             v1alpha1.ConditionFalse,
+					Reason:             ResourceSelectorIsNil,
+					Message:            ResourceSelectorIsNilMessage,
+					ObservedGeneration: 2,
+					LastTransitionTime: transitionTime,
+				},
+			},
+			sameTransitionTimes: false,
 		},
 	}
 
 	for _, test := range tt {
-		res := updateConditions(test.originalMSConditions, test.prometheus, test.generation, test.recError)
+		res := updateConditions(&test.msWithConditions, test.prometheus, test.recError)
 		for _, c := range res {
 			expectedC := getConditionByType(test.expectedResults, c.Type)
 			assert.Check(t, expectedC.Equal(c), "%s - expected:\n %v\n and got:\n %v\n", test.name, expectedC, c)
@@ -271,4 +158,302 @@ func getConditionByType(conditions []v1alpha1.Condition, ctype v1alpha1.Conditio
 		}
 	}
 	return nil
+}
+
+func TestUpdateAvailable(t *testing.T) {
+	tt := []struct {
+		name              string
+		prometheus        monv1.Prometheus
+		previousCondition v1alpha1.Condition
+		generation        int64
+		expectedResult    v1alpha1.Condition
+	}{
+		{
+			name: "conditions not changed when Prometheus Available",
+			previousCondition: v1alpha1.Condition{
+				Type:               v1alpha1.AvailableCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             AvailableReason,
+				Message:            AvailableMessage,
+			},
+			prometheus: monv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+				},
+				Status: monv1.PrometheusStatus{
+					Conditions: []monv1.PrometheusCondition{
+						{
+							Type:               monv1.PrometheusAvailable,
+							Status:             monv1.PrometheusConditionTrue,
+							ObservedGeneration: 1,
+						},
+					}}},
+			generation: 1,
+			expectedResult: v1alpha1.Condition{
+				Type:               v1alpha1.AvailableCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             AvailableReason,
+				Message:            AvailableMessage,
+			},
+		},
+		{
+			name: "cannot read Prometheus conditions",
+			previousCondition: v1alpha1.Condition{
+				Type:               v1alpha1.AvailableCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             AvailableReason,
+				Message:            AvailableMessage,
+			},
+			generation: 1,
+			prometheus: monv1.Prometheus{},
+			expectedResult: v1alpha1.Condition{
+				Type:               v1alpha1.AvailableCondition,
+				Status:             v1alpha1.ConditionUnknown,
+				ObservedGeneration: 1,
+				Reason:             PrometheusNotAvailable,
+				Message:            CannotReadPrometheusConditions,
+			},
+		},
+		{
+			name: "degraded Prometheus conditions",
+			previousCondition: v1alpha1.Condition{
+				Type:               v1alpha1.AvailableCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             AvailableReason,
+				Message:            AvailableMessage,
+			},
+			generation: 1,
+			prometheus: monv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+				},
+				Status: monv1.PrometheusStatus{
+					Conditions: []monv1.PrometheusCondition{
+						{
+							Type:               monv1.PrometheusAvailable,
+							Status:             monv1.PrometheusConditionDegraded,
+							ObservedGeneration: 1,
+						},
+					}}},
+			expectedResult: v1alpha1.Condition{
+				Type:               v1alpha1.AvailableCondition,
+				Status:             v1alpha1.ConditionFalse,
+				ObservedGeneration: 1,
+				Reason:             PrometheusDegraded,
+			},
+		},
+		{
+			name: "Prometheus observed generation is different from the Prometheus generation",
+			previousCondition: v1alpha1.Condition{
+				Type:               v1alpha1.AvailableCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 2,
+				Reason:             AvailableReason,
+				Message:            AvailableMessage,
+			},
+			generation: 1,
+			prometheus: monv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 3,
+				},
+				Status: monv1.PrometheusStatus{
+					Conditions: []monv1.PrometheusCondition{
+						{
+							Type:               monv1.PrometheusAvailable,
+							Status:             monv1.PrometheusConditionFalse,
+							ObservedGeneration: 2,
+						},
+					}}},
+			expectedResult: v1alpha1.Condition{
+				Type:               v1alpha1.AvailableCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 2,
+				Reason:             AvailableReason,
+				Message:            AvailableMessage,
+			},
+		},
+	}
+
+	for _, test := range tt {
+		res := updateAvailable(test.previousCondition, test.prometheus, test.generation)
+		assert.Check(t, test.expectedResult.Equal(res), "%s - expected:\n %v\n and got:\n %v\n", test.name, test.expectedResult, res)
+	}
+}
+
+func TestUpdateReconciled(t *testing.T) {
+	tt := []struct {
+		name              string
+		prometheus        monv1.Prometheus
+		previousCondition v1alpha1.Condition
+		generation        int64
+		recError          error
+		expectedResult    v1alpha1.Condition
+	}{
+		{
+			name: "conditions not changed when Prometheus Available",
+			previousCondition: v1alpha1.Condition{
+				Type:               v1alpha1.ReconciledCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             ReconciledReason,
+				Message:            SuccessfullyReconciledMessage,
+			},
+			recError:   nil,
+			generation: 1,
+			prometheus: monv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+				},
+				Status: monv1.PrometheusStatus{
+					Conditions: []monv1.PrometheusCondition{
+						{
+							Type:               monv1.PrometheusReconciled,
+							Status:             monv1.PrometheusConditionTrue,
+							ObservedGeneration: 1,
+						},
+					}}},
+			expectedResult: v1alpha1.Condition{
+				Type:               v1alpha1.ReconciledCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             ReconciledReason,
+				Message:            SuccessfullyReconciledMessage,
+			},
+		},
+		{
+			name: "cannot read Prometheus conditions",
+			previousCondition: v1alpha1.Condition{
+				Type:               v1alpha1.ReconciledCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             ReconciledReason,
+				Message:            SuccessfullyReconciledMessage,
+			},
+			recError:   nil,
+			generation: 1,
+			prometheus: monv1.Prometheus{},
+			expectedResult: v1alpha1.Condition{
+				Type:               v1alpha1.ReconciledCondition,
+				Status:             v1alpha1.ConditionUnknown,
+				ObservedGeneration: 1,
+				Reason:             PrometheusNotReconciled,
+				Message:            CannotReadPrometheusConditions,
+			},
+		},
+		{
+			name: "degraded Prometheus conditions",
+			previousCondition: v1alpha1.Condition{
+				Type:               v1alpha1.ReconciledCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 1,
+				Reason:             ReconciledReason,
+				Message:            SuccessfullyReconciledMessage,
+			},
+			recError:   nil,
+			generation: 1,
+			prometheus: monv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 1,
+				},
+				Status: monv1.PrometheusStatus{
+					Conditions: []monv1.PrometheusCondition{
+						{
+							Type:               monv1.PrometheusReconciled,
+							Status:             monv1.PrometheusConditionDegraded,
+							ObservedGeneration: 1,
+						},
+					}}},
+			expectedResult: v1alpha1.Condition{
+				Type:               v1alpha1.ReconciledCondition,
+				Status:             v1alpha1.ConditionFalse,
+				ObservedGeneration: 1,
+				Reason:             PrometheusNotReconciled,
+			},
+		},
+		{
+			name: "Prometheus observed generation is different from the Prometheus generation",
+			previousCondition: v1alpha1.Condition{
+				Type:               v1alpha1.ReconciledCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 2,
+				Reason:             ReconciledReason,
+				Message:            SuccessfullyReconciledMessage,
+			},
+			recError:   nil,
+			generation: 1,
+			prometheus: monv1.Prometheus{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 3,
+				},
+				Status: monv1.PrometheusStatus{
+					Conditions: []monv1.PrometheusCondition{
+						{
+							Type:               monv1.PrometheusReconciled,
+							Status:             monv1.PrometheusConditionFalse,
+							ObservedGeneration: 2,
+						},
+					}}},
+			expectedResult: v1alpha1.Condition{
+				Type:               v1alpha1.ReconciledCondition,
+				Status:             v1alpha1.ConditionTrue,
+				ObservedGeneration: 2,
+				Reason:             ReconciledReason,
+				Message:            SuccessfullyReconciledMessage,
+			},
+		},
+	}
+
+	for _, test := range tt {
+		res := updateReconciled(test.previousCondition, test.prometheus, test.generation, test.recError)
+		assert.Check(t, test.expectedResult.Equal(res), "%s - expected:\n %v\n and got:\n %v\n", test.name, test.expectedResult, res)
+	}
+}
+
+func TestUpdateResourceDiscovery(t *testing.T) {
+	transitionTime := metav1.Now()
+	tt := []struct {
+		name             string
+		msWithConditions v1alpha1.MonitoringStack
+		expectedResults  v1alpha1.Condition
+	}{
+		{
+			name: "set resource discovery true when ResourceSelector not nil",
+			msWithConditions: v1alpha1.MonitoringStack{
+				Spec: v1alpha1.MonitoringStackSpec{
+					ResourceSelector: &metav1.LabelSelector{},
+				},
+			},
+			expectedResults: v1alpha1.Condition{
+				Type:    v1alpha1.ResourceDiscoveryCondition,
+				Status:  v1alpha1.ConditionTrue,
+				Reason:  NoReason,
+				Message: ResourceDiscoveryOnMessage,
+			},
+		},
+		{
+			name: "set resource discovery false when ResourceSelector is nil",
+			msWithConditions: v1alpha1.MonitoringStack{
+				Spec: v1alpha1.MonitoringStackSpec{
+					ResourceSelector: nil,
+				},
+			},
+			expectedResults: v1alpha1.Condition{
+				Type:               v1alpha1.ResourceDiscoveryCondition,
+				Status:             v1alpha1.ConditionFalse,
+				Reason:             ResourceSelectorIsNil,
+				Message:            ResourceSelectorIsNilMessage,
+				LastTransitionTime: transitionTime,
+			},
+		},
+	}
+
+	for _, test := range tt {
+		res := updateResourceDiscovery(&test.msWithConditions)
+		assert.Check(t, test.expectedResults.Equal(res), "%s - expected:\n %v\n and got:\n %v\n", test.name, test.expectedResults, res)
+	}
+
 }

--- a/pkg/controllers/monitoring/monitoring-stack/controller.go
+++ b/pkg/controllers/monitoring/monitoring-stack/controller.go
@@ -163,7 +163,7 @@ func (rm resourceManager) updateStatus(ctx context.Context, req ctrl.Request, ms
 		logger.Info("Failed to get prometheus object", "err", err)
 		return ctrl.Result{RequeueAfter: 2 * time.Second}
 	}
-	ms.Status.Conditions = updateConditions(ms.Status.Conditions, prom, ms.Generation, recError)
+	ms.Status.Conditions = updateConditions(ms, prom, recError)
 	err = rm.k8sClient.Status().Update(ctx, ms)
 	if err != nil {
 		logger.Info("Failed to update status", "err", err)


### PR DESCRIPTION
    feat: add resourceDiscovery status condition

    The ResourceSelector field in a MonitoringStack CR can be set to nil.
    This is passed on to the Prometheus CR and can be used to disable all
    service discovery and thus most scraping (we add prometheus and
    alertmanager scrape jobs via additionalScrapeConfigs).
    When this is configured we now set a new status condition to alert users
    to the fact that no service discovery is configured.


Fixes: https://issues.redhat.com/browse/MON-2864

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>