### PR TITLE
fix: number of Prometheus replicas can be 0

### DIFF
--- a/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
+++ b/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
@@ -831,7 +831,7 @@ spec:
                     description: Number of replicas/pods to deploy for a Prometheus
                       deployment.
                     format: int32
-                    minimum: 1
+                    minimum: 0
                     type: integer
                 type: object
               resourceSelector:

--- a/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
+++ b/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
@@ -832,7 +832,7 @@ spec:
                     description: Number of replicas/pods to deploy for a Prometheus
                       deployment.
                     format: int32
-                    minimum: 1
+                    minimum: 0
                     type: integer
                 type: object
               resourceSelector:

--- a/docs/api.md
+++ b/docs/api.md
@@ -305,7 +305,7 @@ Define prometheus config
           <br/>
             <i>Format</i>: int32<br/>
             <i>Default</i>: 2<br/>
-            <i>Minimum</i>: 1<br/>
+            <i>Minimum</i>: 0<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/pkg/apis/monitoring/v1alpha1/types.go
+++ b/pkg/apis/monitoring/v1alpha1/types.go
@@ -164,7 +164,7 @@ type PrometheusConfig struct {
 	// Number of replicas/pods to deploy for a Prometheus deployment.
 	// +optional
 	// +kubebuilder:default=2
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// Define remote write for prometheus


### PR DESCRIPTION
This updates my original PR cbb95f32509ecde346b70eb30bd558483f162e2f to allow 0 number of replicas for the Prometheus config.