### PR TITLE
refactor: use https to fetch tags in release targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,12 +220,12 @@ $(STANDARD_VERSION):
 
 .PHONY: initiate-release
 initiate-release: $(STANDARD_VERSION)
-	git fetch git@github.com:rhobs/observability-operator.git --tags
+	git fetch https://github.com/rhobs/observability-operator.git --tags
 	$(STANDARD_VERSION) -a --skip.tag # The tag will be created in the pipeline
 
 .PHONY: initiate-release-as
 initiate-release-as: $(STANDARD_VERSION)
-	git fetch git@github.com:rhobs/observability-operator.git --tags
+	git fetch https://github.com/rhobs/observability-operator.git --tags
 	$(STANDARD_VERSION) -a --skip.tag --release-as $(RELEASE_VERSION)
 
 .PHONY: kind-cluster


### PR DESCRIPTION
Using git as the fetch protocol requires ghub auth to be setup. If I want to run the release process in a container, I need to add my auth key to the containers. For fetching tags that is really not needed.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>