### PR TITLE
build: generate and publish package in ghub actions

### DIFF
--- a/.github/package-operator-publish/action.yaml
+++ b/.github/package-operator-publish/action.yaml
@@ -1,0 +1,44 @@
+name: 'Publish package-operator package'
+description: 'Publishes the operator as a package-operator package'
+inputs:
+  quay_login:
+    description: "Quay login"
+    required: true
+  quay_token:
+    description: "Quay token"
+    required: true
+  go-version:
+    description: "go version"
+    required: true
+runs:
+  using: composite
+  steps:
+  - uses: actions/checkout@v3
+    with:
+      fetch-depth: 0
+
+  - name: Setup Go environment
+    uses: actions/setup-go@v3
+    with:
+      go-version: ${{ inputs.go-version }}
+
+  - name: Use go cache
+    uses: ./.github/go-cache
+
+  - name: Install tools
+    uses: ./.github/tools-cache
+
+  - name: Registry Login
+    uses: docker/login-action@v2
+    with:
+      registry: quay.io
+      username: ${{ inputs.quay_login }}
+      password: ${{ inputs.quay_token }}
+
+  - name: Generate Package image
+    shell: bash
+    run: make package
+
+  - name: Publish Package
+    shell: bash
+    run: make package-push

--- a/.github/package-operator-publish/action.yaml
+++ b/.github/package-operator-publish/action.yaml
@@ -42,3 +42,11 @@ runs:
   - name: Publish Package
     shell: bash
     run: make package-push
+
+  - name: Generate Package image with kubeconfig option
+    shell: bash
+    run: make package-kubeconfig
+
+  - name: Publish Package with kubeconfig option
+    shell: bash
+    run: make package-push-kubeconfig

--- a/.github/workflows/package-operator-stable.yaml
+++ b/.github/workflows/package-operator-stable.yaml
@@ -1,0 +1,28 @@
+---
+name: Publish package-operator release
+
+on:
+  release:
+    types:
+      - released
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: quay
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Import common environment variables
+        run: cat ".github/env" >> "$GITHUB_ENV"
+
+      - name: publish
+        uses: ./.github/package-operator-publish
+        env:
+          IMAGE_BASE: ${{ secrets.IMAGE_BASE }}
+        with:
+          quay_login: ${{ secrets.QUAY_LOGIN }}
+          quay_token: ${{ secrets.QUAY_TOKEN }}
+          go-version: ${{ env.go-version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
           version="$(cat VERSION)-$(date +%y%m%d%H%M%S)"
           echo "version=$version" >> $GITHUB_OUTPUT
 
-      - name: Publish
+      - name: Publish OLM
         uses: ./.github/olm-publish
         env:
           IMAGE_BASE: ${{ secrets.IMAGE_BASE }}
@@ -63,6 +63,16 @@ jobs:
         with:
           github_token: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
           branch: olm-catalog
+
+      - name: Publish Package
+        uses: ./.github/package-operator-publish
+        env:
+          IMAGE_BASE: ${{ secrets.IMAGE_BASE }}
+          VERSION: ${{ steps.version.outputs.version }}
+        with:
+          quay_login: ${{ secrets.QUAY_LOGIN }}
+          quay_token: ${{ secrets.QUAY_TOKEN }}
+          go-version: ${{ env.go-version }}
 
   create-github-prerelease:
     needs:

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ PACKAGE_IMG_BASE ?= $(IMAGE_BASE)-package
 PACKAGE_IMG ?= $(PACKAGE_IMG_BASE):$(VERSION)
 
 .PHONY: package
-package: generate-package-resources
+package: generate
 	cd deploy/package-operator && \
 		$(CONTAINER_RUNTIME) build \
 			-f package.Containerfile \

--- a/deploy/package-operator/dependencies-kubeconfig/kustomization.yaml
+++ b/deploy/package-operator/dependencies-kubeconfig/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../dependencies/
+patches:
+- path: patches/kubeconfig-volume.yml
+  target:
+    kind: Deployment

--- a/deploy/package-operator/dependencies-kubeconfig/patches/kubeconfig-volume.yml
+++ b/deploy/package-operator/dependencies-kubeconfig/patches/kubeconfig-volume.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    app.kubernetes.io/part-of: observability-operator
+    name: prometheus-operator
+spec:
+  template:
+    spec:
+      volumes:
+        - name: kubeconfig
+          secret:
+            defaultMode: 400
+            secretName: admin-kubeconfig
+      containers:
+        - name: prometheus-operator
+          volumeMounts:
+            - mountPath: /etc/openshift/kubeconfig
+              name: kubeconfig
+              readOnly: true
+          env:
+            - name: KUBECONFIG
+              value: /etc/openshift/kubeconfig/kubeconfig

--- a/deploy/package-operator/operator-kubeconfig/kustomization.yaml
+++ b/deploy/package-operator/operator-kubeconfig/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../operator/
+patches:
+- path: patches/kubeconfig-volume.yml
+  target:
+    kind: Deployment

--- a/deploy/package-operator/operator-kubeconfig/patches/kubeconfig-volume.yml
+++ b/deploy/package-operator/operator-kubeconfig/patches/kubeconfig-volume.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    app.kubernetes.io/part-of: observability-operator
+    name: observability-operator
+spec:
+  template:
+    spec:
+      volumes:
+        - name: kubeconfig
+          secret:
+            defaultMode: 400
+            secretName: admin-kubeconfig
+      containers:
+        - name: operator
+          volumeMounts:
+            - mountPath: /etc/openshift/kubeconfig
+              name: kubeconfig
+              readOnly: true
+          env:
+            - name: KUBECONFIG
+              value: /etc/openshift/kubeconfig/kubeconfig


### PR DESCRIPTION
This adds github actions to generate and publish the package image to quay.

Versioning and publishing policy follows what we do for the OLM artifacts with one difference:

Since package-operator does not have a notion of channels, this currently only pushes packages for development versions (with the `$tag-$date` tagging scheme and for releases (i.e. not for prereleases).

If we want packages for pre-releases, we need to discuss an addition to the tagging policy.

https://issues.redhat.com/browse/MON-2892