### PR TITLE
chore: improve kind setup UX

### DIFF
--- a/hack/kind/setup.sh
+++ b/hack/kind/setup.sh
@@ -6,25 +6,78 @@ declare -r SCRIPT_DIR=$(cd $(dirname "$SCRIPT_PATH") && pwd)
 declare -r PROJECT_ROOT_DIR="$SCRIPT_DIR/../../"
 declare -r OP_NAME="obs-operator"
 
+# use tools installed to tmp/bin
+export PATH="$PROJECT_ROOT_DIR/tmp/bin/:$PATH"
+
 ### create a separate config file for kind clusters
 export KUBECONFIG=~/.kube/kind/obs-operator
 
-err() {
-  echo -e "ERROR: $@" >&2
+header(){
+  local title="🔆🔆🔆  $*  🔆🔆🔆 "
+
+  local len=40
+  if [[ ${#title} -gt $len ]]; then
+    len=${#title}
+  fi
+
+  echo -e "\n\n  \033[1m${title}\033[0m"
+  echo -n "━━━━━"
+  printf '━%.0s' $(seq "$len")
+  echo "━━━━━"
 }
 
-info() {
-  echo -e "INFO: $@"
+info(){
+  echo " 🔔 $*"
 }
 
-die() {
-  echo -e "FATAL: $@" >&2
+ok(){
+  echo " ✅ $*"
+}
+
+err(){
+  echo " 🛑 $*"
+}
+
+die(){
+  echo -e "\n ✋ $* "
+  echo -e "──────────────────── ⛔️⛔️⛔️ ────────────────────────\n"
   exit 1
+}
+
+line(){
+  local len="$1"; shift
+
+  echo -n "────"
+  printf '─%.0s' $(seq "$len")
+  echo "────────"
+}
+
+validate_prerequisites(){
+  header "Validating Prerequisites"
+
+  local fail=0
+
+  [[ -x $PROJECT_ROOT_DIR/tmp/bin/operator-sdk  ]] || {
+    err "operator-sdk not found - did you run 'make tools'?"
+    fail=1
+  }
+
+  grep -q local-registry /etc/hosts || {
+    err "/etc/hosts does not contain local-registry entry"
+
+    info "No local-registry entry in hosts; run:"
+    echo -e "    ❯ echo \"127.0.0.1\tlocal-registry\" | sudo tee -a /etc/hosts"
+    fail=1
+  }
+
+  return $fail
 }
 
 # turn the control-plane into to infra to validate if the operator pods
 # get deployed on infra nodes
 label_infra_node() {
+  header "Labeling Infra Nodes"
+
   kubectl label nodes  \
     -l kubernetes.io/hostname=="${OP_NAME}-control-plane"\
     node-role.kubernetes.io/infra="" \
@@ -32,24 +85,18 @@ label_infra_node() {
   [[ $( kubectl get nodes -l node-role.kubernetes.io/infra=="" -o name | wc -l ) -ne 0 ]] || {
     die "No infra nodes were found"
   }
+  line 50
 }
 
+
 setup_olm() {
-  [[ -x $PROJECT_ROOT_DIR/tmp/bin/operator-sdk  ]] || {
-    die "operator-sdk not found - did you run 'make tools'?"
-  }
+  header "Install OLM"
   $PROJECT_ROOT_DIR/tmp/bin/operator-sdk olm install
-  echo -e "      ---------------------------------- \n"
+  line 50
 }
 
 run_registry() {
-  info "Deploying Registry ..."
-
-  grep -q local-registry /etc/hosts || {
-    err "No local-registry entry in hosts; try:"
-    info "echo \"127.0.0.1\tlocal-registry\" | sudo tee -a /etc/hosts"
-    die "/etc/hosts does not contain local-registry entry"
-  }
+  header "Deploying Registry"
 
   kubectl apply -f ./hack/kind/registry.yaml -n operators
   kubectl rollout status deployment local-registry -n operators
@@ -61,11 +108,15 @@ run_registry() {
     http://local-registry:30000 || {
     die "Failed to reach local-registry running"
   }
-  echo -e "      ---------------------------------- \n"
+  line 50
 
 }
 
 setup_cluster() {
+  header "Setting up Cluster"
+
+  mkdir -p "$(dirname $KUBECONFIG)"
+
   kind create cluster \
     -v 10 \
     --name $OP_NAME \
@@ -78,17 +129,20 @@ setup_cluster() {
 }
 
 install_kubectl() {
-    if ! command -v kubectl &> /dev/null; then
+  header "Installing kubectl"
+
+  if ! command -v kubectl &> /dev/null; then
     info "kubectl not found, attempting to install"
     mkdir -p tmp/bin
     curl -o tmp/bin/kubectl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
     chmod +x tmp/bin/kubectl
-    export PATH="$(pwd)/tmp/bin/:$PATH"
-fi
+  fi
 
 }
 
 create_platform_mon_crds() {
+  header "Installing Monitoring CRDs"
+
   kubectl create -k deploy/crds/kubernetes
   kubectl wait --for=condition=Established crds --all --timeout=120s
 }
@@ -97,7 +151,9 @@ create_platform_mon_crds() {
 main() {
   ## NOTE: all paths are relative to the root of the project
   cd "$PROJECT_ROOT_DIR"
-  mkdir -p tmp/logs "$(dirname $KUBECONFIG)"
+  validate_prerequisites || die "fix errors above and rerun the script"
+
+  mkdir -p tmp/logs
 
   install_kubectl
   setup_cluster
@@ -106,19 +162,20 @@ main() {
   run_registry
   create_platform_mon_crds
 
-  info "Waiting for cluster boot to complete ..."
-  echo -e "      ---------------------------------- \n"
+  header "Waiting for cluster boot to complete ..."
   kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
-  echo -e "      ---------------------------------- \n"
+  line 50
 
+  header "Setup Complete"
   info "NOTE: To delete the cluster, run:
     kind delete cluster --name obs-operator \n"
 
   info "NOTE: export KUBECONFIG=$KUBECONFIG \n"
 
   info "NEXT: deploy Prometheus Operator and required CRDs by:
-    kubectl --kubeconfig=$KUBECONFIG create -k deploy/crds/kubernetes
-    kubectl --kubeconfig=$KUBECONFIG create -k deploy/dependencies"
+    ❯ kubectl --kubeconfig=$KUBECONFIG create -k deploy/crds/kubernetes
+    ❯ kubectl --kubeconfig=$KUBECONFIG create -k deploy/dependencies"
+  line 50
 
   return $?
 }


### PR DESCRIPTION
Previously, when running hack/kind/setup.sh, the script ran its validations such as if the tools are installed, local-registry is entry is added to /etc/hosts etc in the middle of the run instead of the start. This required the cluster to be deleted again and again until all validations pass.

This commit improve the experience
  * running validations in the starting of the script
  * ensuring binaries in <project-root>/tmp/bin takes precedence all the time (as opposed to only when kubeclt was missing)
  * Better emojis 🔔 ✅ 🛑

Signed-off-by: Sunil Thaha <sthaha@redhat.com>

```
❯ ./hack/kind/setup.sh

  🔆🔆🔆  Validating Prerequisites  🔆🔆🔆
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 🛑 operator-sdk not found - did you run 'make tools'?

 🛑 /etc/hosts does not contain local-registry entry
 🔔 No local-registry entry in hosts; run:
    ❯ echo "127.0.0.1	local-registry" | sudo tee -a /etc/hosts

 ✋ fix errors above and rerun the script
──────────────────── ⛔️⛔️⛔️ ────────────────────────
```

