### PR TITLE
build: create branch for olm-publish action

### DIFF
--- a/.github/olm-publish/action.yaml
+++ b/.github/olm-publish/action.yaml
@@ -13,10 +13,6 @@ inputs:
 runs:
   using: composite
   steps:
-  - uses: actions/checkout@v3
-    with:
-      fetch-depth: 0
-
   - name: Setup Go environment
     uses: actions/setup-go@v3
     with:
@@ -33,6 +29,18 @@ runs:
       registry: quay.io
       username: ${{ inputs.quay_login }}
       password: ${{ inputs.quay_token }}
+
+  - uses: actions/checkout@v3
+    with:
+      fetch-depth: 0
+
+  - name: Create new integration branch
+    shell: bash
+    # Creating a branch here in order to avoid commiting to our local main
+    # branch further down in this action. In some make targets we use main's sha
+    # and by creating a branch here we can just assume local main is the same as
+    # remote main.
+    run: git checkout -b olm-publish-action-scratch
 
   - name: Git merge olm-catalog branch
     shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,8 +115,7 @@ jobs:
         id: publish_tag
         run: |
           # NOTE tag is created by standard-version and points to the
-          # chore(release): commit as opposed to pointing to the commit added
-          # to olm-catalog branch after images are built and pushed
+          # chore(release): commit
           git push --follow-tags
           echo "tag_name=$(git describe HEAD --abbrev=0)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Problem: In the make target `catalog-tag-sha` we want to use main's sha sum to tag the catalog image. The olm-publish action however adds commits to the local main branch before that happens, resulting in a sha tag that doesn't correspond to main.

Solution: The olm-publish action creates a branch to add commits in.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>