### PR TITLE
build: add make lint-shell and add to PR checks

### DIFF
--- a/.github/tools
+++ b/.github/tools
@@ -13,3 +13,4 @@ jsonnetfmt v0.17.0
 jsonnet-lint v0.17.0
 jb v0.4.0
 gojsontoyaml 0.0.1
+shellcheck 0.9.0

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -45,6 +45,9 @@ jobs:
       - name: jsonnet-lint
         run: make lint-jsonnet
 
+      - name: shellcheck
+        run: make lint-shell
+
   generate:
     runs-on: ubuntu-latest
     name: Generate and format

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: operator
 ## Development
 
 .PHONY: lint
-lint: lint-golang lint-jsonnet
+lint: lint-golang lint-jsonnet lint-shell
 
 .PHONY: lint-golang
 lint-golang: $(GOLANGCI_LINT)
@@ -29,6 +29,10 @@ lint-jsonnet: $(JSONNET_LINT) jsonnet-vendor
 		-o -name '*.libsonnet' -print \
 		-o -name '*.jsonnet' -print \
 	| xargs -n 1 -- $(JSONNET_LINT) -J $(JSONNET_VENDOR)
+
+.PHONY: lint-shell
+lint-shell:
+	find -name "*.sh" -print0 | xargs --null $(SHELLCHECK)
 
 .PHONY: fmt-jsonnet
 fmt-jsonnet: $(JSONNETFMT) jsonnet-vendor

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -50,10 +50,13 @@ JB_VERSION = v0.4.0
 ## NOTE: gojsontoyaml does not have any releases, so we use a fake version starting with v0.0.1
 # thus to upgrade/invalidate the github cache, increment the value
 GOJSONTOYAML = $(TOOLS_DIR)/gojsontoyaml
-GOJSONTOYAML_VERSRION = 0.0.1
+GOJSONTOYAML_VERSION = 0.0.1
 
 JSONNET_VENDOR = jsonnet/vendor
 JSONNETFMT_ARGS = -n 2 --max-blank-lines 2 --string-style s --comment-style s
+
+SHELLCHECK = $(TOOLS_DIR)/shellcheck
+SHELLCHECK_VERSION = 0.9.0
 
 $(TOOLS_DIR):
 	@mkdir -p $(TOOLS_DIR)
@@ -185,6 +188,19 @@ $(GOJSONTOYAML) gojsontoyaml: $(TOOLS_DIR)
 		GOBIN=$(TOOLS_DIR) go install github.com/brancz/gojsontoyaml@latest ;\
 	}
 
+.PHONY: shellcheck
+$(SHELLCHECK) shellcheck: $(TOOLS_DIR)
+	@{ \
+		set -ex ;\
+		[[ -f $(SHELLCHECK) ]] && exit 0 ;\
+		cd $$(mktemp -d) ;\
+		curl -sSLo shellcheck-stable.tar.xz "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz";\
+		tar -xJf shellcheck-stable.tar.xz ;\
+		cp shellcheck-stable/shellcheck $(SHELLCHECK) ;\
+		version=$(SHELLCHECK_VERSION) ;\
+		$(SHELLCHECK) -V | grep -q $${version##v} ;\
+	}
+
 .PHONY: jsonnet-tools
 jsonnet-tools: jsonnet jsonnetfmt jsonnet-lint jb gojsontoyaml
 
@@ -198,6 +214,7 @@ tools: $(CONTROLLER_GEN) \
 		$(PROMQ) \
 		$(CRDOC) \
 		$(GOLANGCI_LINT) \
+		$(SHELLCHECK) \
 		jsonnet-tools
 	@{ \
 		set -ex ;\
@@ -216,7 +233,8 @@ tools: $(CONTROLLER_GEN) \
 		echo  $$(basename $(JSONNETFMT)) $(JSONNETFMT_VERSION) >> $$tools_file ;\
 		echo  $$(basename $(JSONNET_LINT)) $(JSONNET_LINT_VERSION) >> $$tools_file ;\
 		echo  $$(basename $(JB)) $(JB_VERSION) >> $$tools_file ;\
-		echo  $$(basename $(GOJSONTOYAML)) $(GOJSONTOYAML_VERSRION) >> $$tools_file ;\
+		echo  $$(basename $(GOJSONTOYAML)) $(GOJSONTOYAML_VERSION) >> $$tools_file ;\
+		echo  $$(basename $(SHELLCHECK)) $(SHELLCHECK_VERSION) >> $$tools_file ;\
 	}
 
 .PHONY: clean-tools
@@ -236,3 +254,4 @@ validate-tools:
 	@$(JSONNETFMT) --version
 	@$(JSONNET_LINT) --version
 	@$(JB) --version
+	@$(SHELLCHECK) -V | head -n 2

--- a/hack/kind/setup.sh
+++ b/hack/kind/setup.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -e -u -o pipefail
 
-declare -r SCRIPT_PATH=$(readlink -f "$0")
-declare -r SCRIPT_DIR=$(cd $(dirname "$SCRIPT_PATH") && pwd)
+SCRIPT_PATH=$(readlink -f "$0")
+declare -r SCRIPT_PATH
+SCRIPT_DIR=$(cd "$(dirname "$SCRIPT_PATH")" && pwd)
+declare -r SCRIPT_DIR
 declare -r PROJECT_ROOT_DIR="$SCRIPT_DIR/../../"
 declare -r OP_NAME="obs-operator"
 
@@ -91,7 +93,7 @@ label_infra_node() {
 
 setup_olm() {
   header "Install OLM"
-  $PROJECT_ROOT_DIR/tmp/bin/operator-sdk olm install
+  "$PROJECT_ROOT_DIR"/tmp/bin/operator-sdk olm install
   line 50
 }
 


### PR DESCRIPTION
This add a `shellcheck` make target and PR test. Additionall this fixes existing shellcheck issues.

Fixes: https://github.com/rhobs/observability-operator/issues/212

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>