### PR TITLE
ci: move from actions/create-release to ncipollo/release-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,12 +120,9 @@ jobs:
           echo "tag_name=$(git describe HEAD --abbrev=0)" >> $GITHUB_OUTPUT
 
       - name: Create Github release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPOSITORY_PUSH_TOKEN }}
+        uses: ncipollo/release-action@v1
         with:
-          release_name: ${{ steps.publish_tag.outputs.tag_name }}
-          tag_name: ${{ steps.publish_tag.outputs.tag_name }}
-          body_path: RELEASE_BODY.md
+          tag: ${{ steps.publish_tag.outputs.tag_name }}
+          bodyFile: RELEASE_BODY.md
           # NOTE: We always generate pre-releases and mark them as releases manually
           prerelease: true


### PR DESCRIPTION
Fixes: https://github.com/rhobs/observability-operator/issues/214

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>