### PR TITLE
build: add option to pass SHA to tag catalog

### DIFF
--- a/.github/workflows/olm-candidate.yaml
+++ b/.github/workflows/olm-candidate.yaml
@@ -33,6 +33,7 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           CHANNELS: candidate,development
           DEFAULT_CHANNEL: candidate
+          RELEASE_SHA: ${GITHUB_SHA}
         with:
           quay_login: ${{ secrets.QUAY_LOGIN }}
           quay_token: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/olm-stable.yaml
+++ b/.github/workflows/olm-stable.yaml
@@ -24,6 +24,7 @@ jobs:
           IMAGE_BASE: ${{ secrets.IMAGE_BASE }}
           CHANNELS: stable,candidate,development
           DEFAULT_CHANNEL: stable
+          RELEASE_SHA: ${GITHUB_SHA}
         with:
           quay_login: ${{ secrets.QUAY_LOGIN }}
           quay_token: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,7 @@ jobs:
           IMAGE_BASE: ${{ secrets.IMAGE_BASE }}
           VERSION: ${{ steps.version.outputs.version }}
           CHANNELS: development
+          RELEASE_SHA: ${GITHUB_SHA}
         with:
           quay_login: ${{ secrets.QUAY_LOGIN }}
           quay_token: ${{ secrets.QUAY_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ include Makefile.tools
 IMAGE_BASE ?= observability-operator
 
 VERSION ?= $(shell cat VERSION)
+RELEASE_SHA ?= $(shell git rev-parse origin/main)
 OPERATOR_IMG = $(IMAGE_BASE):$(VERSION)
 OPERATOR_BUNDLE=observability-operator.v$(VERSION)
 CONTAINER_RUNTIME := $(shell command -v podman 2> /dev/null || echo docker)
@@ -195,15 +196,6 @@ CATALOG_IMG ?= $(CATALOG_IMG_BASE):$(VERSION)
 # a single image which keeps updating there by allowing auto upgrades
 CATALOG_IMG_LATEST ?= $(IMAGE_BASE)-catalog:latest
 
-
-# NOTE: This is required to enable continuous deployment to
-# staging/integration environments via app-interface (OSD-13603)
-#
-# The git short-hash of the most recent commit in the main branch.
-# This will be used to associate the catalog image with the operator code that
-# was used to build the imate.
-CATALOG_IMG_SHA = $(CATALOG_IMG_BASE):$(shell git rev-parse --short=8 main)
-
 # Build a catalog image by adding bundle images to an empty catalog using the
 # operator package manager tool, 'opm'.
 .PHONY: catalog-image
@@ -220,6 +212,14 @@ catalog-image: $(OPM)
 	# tag the catalog img:version as latest so that continious release
 	# is possible by refering to latest tag instead of a version
 	$(CONTAINER_RUNTIME) tag $(CATALOG_IMG) $(CATALOG_IMG_LATEST)
+
+# NOTE: This is required to enable continuous deployment to
+# staging/integration environments via app-interface (OSD-13603)
+#
+# The git short-hash of the most recent commit in the main branch.
+# This will be used to associate the catalog image with the operator code that
+# was used to build the imate.
+CATALOG_IMG_SHA = $(CATALOG_IMG_BASE):$(shell git rev-parse --short=8 $(RELEASE_SHA))
 
 # NOTE: This target ensures that the catalog image points to the
 # commit in the main branch that was used to build the catalog image


### PR DESCRIPTION
Problem: In bc3b0d202f0ea36c04a20fbcd44a51d2504d2aed the git rev-parse command was changed to tag catalog images with the `main` commit on which this catalog image is build. The argument to rev-parse was changed from `HEAD` to `main`. In some workflows however `main` might not be a valid local revision.
To reporduce:
```
cd $(mktemp -d)
git init observability-operator
git remote add origin https://github.com/rhobs/observability-operator
cd observability-operator
git remote add origin https://github.com/rhobs/observability-operator
git fetch --prune origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
git checkout --force refs/tags/v0.0.18
git rev-parse main
```

Solution: Add a new Makefile variable `RELEASH_SHA`. If its not defined we use `origin/main`, which should provide backwards compatibility. In the github action workflows we now set this explicitly to `GITHUB_SHA`, which corresponds to the commit that triggered a workflow.

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>