### PR TITLE
fix: rename alert names to follow convention

### DIFF
--- a/bundle/manifests/observability-operator-rules_monitoring.coreos.com_v1_prometheusrule.yaml
+++ b/bundle/manifests/observability-operator-rules_monitoring.coreos.com_v1_prometheusrule.yaml
@@ -12,7 +12,7 @@ spec:
   groups:
   - name: observability-operator.rules
     rules:
-    - alert: Observability Operator controller reconcile errors
+    - alert: ObservabilityOperatorReconcileErrors
       annotations:
         description: |
           Observability Operator controller - {{ $labels.controller }} fails to reconcile.
@@ -24,8 +24,7 @@ spec:
       for: 15m
       labels:
         severity: warning
-    - alert: Observability Operator controller reconcilation takes longer than 10
-        minutes
+    - alert: ObservabilityOperatorReconcileLongerThan10Min
       annotations:
         description: |
           Observability Operator controller reconcilation takes longer than 10 minutes for the controller - {{ $labels.controller }}.
@@ -39,7 +38,7 @@ spec:
       for: 10m
       labels:
         severity: warning
-    - alert: Observability Operator controller backlog is not being drained
+    - alert: ObservabilityOperatorBacklogNotDrained
       annotations:
         description: |
           The backlog of Observability Operator controller - {{ $labels.name }} is not getting drained; an indication that reconcile loop may be stuck

--- a/deploy/monitoring/observability-operator-rules.yaml
+++ b/deploy/monitoring/observability-operator-rules.yaml
@@ -17,7 +17,7 @@ spec:
   groups:
   - name: observability-operator.rules
     rules:
-    - alert: Observability Operator controller reconcile errors
+    - alert: ObservabilityOperatorReconcileErrors
       annotations:
         description: |
           Observability Operator controller - {{ $labels.controller }} fails to reconcile.
@@ -28,7 +28,7 @@ spec:
       for: 15m
       labels:
         severity: warning
-    - alert: Observability Operator controller reconcilation takes longer than 10 minutes
+    - alert: ObservabilityOperatorReconcileLongerThan10Min
       annotations:
         description: |
           Observability Operator controller reconcilation takes longer than 10 minutes for the controller - {{ $labels.controller }}.
@@ -41,7 +41,7 @@ spec:
       for: 10m
       labels:
         severity: warning
-    - alert: Observability Operator controller backlog is not being drained
+    - alert: ObservabilityOperatorBacklogNotDrained
       annotations:
         description: |
           The backlog of Observability Operator controller - {{ $labels.name }} is not getting drained; an indication that reconcile loop may be stuck

--- a/pkg/apis/monitoring/v1alpha1/register.go
+++ b/pkg/apis/monitoring/v1alpha1/register.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the rhobs v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=monitoring.rhobs
+// +kubebuilder:object:generate=true
+// +groupName=monitoring.rhobs
 package v1alpha1
 
 import (


### PR DESCRIPTION
This updates alert names to follow the camel format convention for alert rules.