### PR TITLE
fix: use mebibytes instead of megabytes for resource defaults

### DIFF
--- a/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
+++ b/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
@@ -886,10 +886,10 @@ spec:
                 default:
                   limits:
                     cpu: 500m
-                    memory: 512M
+                    memory: 512Mi
                   requests:
                     cpu: 100m
-                    memory: 256M
+                    memory: 256Mi
                 description: Define resources requests and limits for Monitoring Stack
                   Pods.
                 properties:

--- a/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
+++ b/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
@@ -887,10 +887,10 @@ spec:
                 default:
                   limits:
                     cpu: 500m
-                    memory: 512M
+                    memory: 512Mi
                   requests:
                     cpu: 100m
-                    memory: 256M
+                    memory: 256Mi
                 description: Define resources requests and limits for Monitoring Stack
                   Pods.
                 properties:

--- a/docs/api.md
+++ b/docs/api.md
@@ -133,7 +133,7 @@ MonitoringStackSpec is the specification for desired Monitoring Stack
         <td>
           Define resources requests and limits for Monitoring Stack Pods.<br/>
           <br/>
-            <i>Default</i>: map[limits:map[cpu:500m memory:512M] requests:map[cpu:100m memory:256M]]<br/>
+            <i>Default</i>: map[limits:map[cpu:500m memory:512Mi] requests:map[cpu:100m memory:256Mi]]<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/apis/monitoring/v1alpha1/types.go
+++ b/pkg/apis/monitoring/v1alpha1/types.go
@@ -76,7 +76,7 @@ type MonitoringStackSpec struct {
 
 	// Define resources requests and limits for Monitoring Stack Pods.
 	// +optional
-	// +kubebuilder:default={requests:{cpu: "100m", memory: "256M"}, limits:{memory: "512M", cpu: "500m"}}
+	// +kubebuilder:default={requests:{cpu: "100m", memory: "256Mi"}, limits:{memory: "512Mi", cpu: "500m"}}
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Define prometheus config


### PR DESCRIPTION
The MonitoringStack CRD uses megabytes for default resource limits and requests. Everywhere else we use mebibytes.
This commit changes the default to mebibytes as well. Fixes: https://issues.redhat.com/browse/MON-2865

Signed-off-by: Jan Fajerski <jfajersk@redhat.com>