### PR TITLE
feat: extend OBO conditions to read & propagate Alertmanager conditions

### DIFF
--- a/pkg/controllers/monitoring/monitoring-stack/conditions.go
+++ b/pkg/controllers/monitoring/monitoring-stack/conditions.go
@@ -9,36 +9,45 @@ import (
 )
 
 const (
-	AvailableReason                = "MonitoringStackAvailable"
-	ReconciledReason               = "MonitoringStackReconciled"
-	FailedToReconcileReason        = "FailedToReconcile"
-	PrometheusNotAvailable         = "PrometheusNotAvailable"
-	PrometheusNotReconciled        = "PrometheusNotReconciled"
-	PrometheusDegraded             = "PrometheusDegraded"
-	ResourceSelectorIsNil          = "ResourceSelectorNil"
-	CannotReadPrometheusConditions = "Cannot read Prometheus status conditions"
-	AvailableMessage               = "Monitoring Stack is available"
-	SuccessfullyReconciledMessage  = "Monitoring Stack is successfully reconciled"
-	ResourceSelectorIsNilMessage   = "No resources will be discovered, ResourceSelector is nil"
-	ResourceDiscoveryOnMessage     = "Resource discovery is operational"
-	NoReason                       = "None"
+	AlertmanagerNotAvailable         = "AlertmanagerNotAvailable"
+	AlertmanagerDegraded             = "AlertmanagerDegraded"
+	AlertmanagerNotReconciled        = "AlertmanagerNotReconciled"
+	AvailableReason                  = "MonitoringStackAvailable"
+	ReconciledReason                 = "MonitoringStackReconciled"
+	FailedToReconcileReason          = "FailedToReconcile"
+	PrometheusNotAvailable           = "PrometheusNotAvailable"
+	PrometheusNotReconciled          = "PrometheusNotReconciled"
+	PrometheusDegraded               = "PrometheusDegraded"
+	ResourceSelectorIsNil            = "ResourceSelectorNil"
+	CannotReadPrometheusConditions   = "Cannot read Prometheus status conditions"
+	CannotReadAlertmanagerConditions = "Cannot read Alertmanager status conditions"
+	AvailableMessage                 = "Monitoring Stack is available"
+	SuccessfullyReconciledMessage    = "Monitoring Stack is successfully reconciled"
+	ResourceSelectorIsNilMessage     = "No resources will be discovered, ResourceSelector is nil"
+	ResourceDiscoveryOnMessage       = "Resource discovery is operational"
+	NoReason                         = "None"
 )
 
-func updateConditions(ms *v1alpha1.MonitoringStack, prom monv1.Prometheus, recError error) []v1alpha1.Condition {
+func updateConditions(ms *v1alpha1.MonitoringStack, prom monv1.Prometheus, alertManager *monv1.Alertmanager, recError error) []v1alpha1.Condition {
 	return []v1alpha1.Condition{
 		updateResourceDiscovery(ms),
-		updateAvailable(ms.Status.Conditions, prom, ms.Generation),
-		updateReconciled(ms.Status.Conditions, prom, ms.Generation, recError),
+		updateAvailable(ms.Status.Conditions, prom, alertManager, ms.Generation),
+		updateReconciled(ms.Status.Conditions, prom, alertManager, ms.Generation, recError),
 	}
 }
 
-func getMSCondition(conditions []v1alpha1.Condition, t v1alpha1.ConditionType) (v1alpha1.Condition, error) {
+func getMSCondition(conditions []v1alpha1.Condition, t v1alpha1.ConditionType) v1alpha1.Condition {
 	for _, c := range conditions {
 		if c.Type == t {
-			return c, nil
+			return c
 		}
 	}
-	return v1alpha1.Condition{}, fmt.Errorf("condition type %v not found", t)
+	return v1alpha1.Condition{
+		Type:               t,
+		Status:             v1alpha1.ConditionUnknown,
+		Reason:             NoReason,
+		LastTransitionTime: metav1.Now(),
+	}
 }
 
 // updateResourceDiscovery updates the ResourceDiscoveryCondition based on the
@@ -69,18 +78,38 @@ func updateResourceDiscovery(ms *v1alpha1.MonitoringStack) v1alpha1.Condition {
 
 // updateAvailable gets existing "Available" condition and updates its parameters
 // based on the Prometheus "Available" condition
-func updateAvailable(conditions []v1alpha1.Condition, prom monv1.Prometheus, generation int64) v1alpha1.Condition {
-	ac, err := getMSCondition(conditions, v1alpha1.AvailableCondition)
-	if err != nil {
-		ac = v1alpha1.Condition{
-			Type:               v1alpha1.AvailableCondition,
-			Status:             v1alpha1.ConditionUnknown,
-			Reason:             NoReason,
-			LastTransitionTime: metav1.Now(),
+func updateAvailable(conditions []v1alpha1.Condition, prom monv1.Prometheus, alertManager *monv1.Alertmanager,
+	generation int64) v1alpha1.Condition {
+	ac := getMSCondition(conditions, v1alpha1.AvailableCondition)
+	// alertmanager can be disabled
+	if alertManager != nil {
+		amAvailable, err := getConditionByType(alertManager.Status.Conditions, monv1.Available)
+		if err != nil {
+			ac.Status = v1alpha1.ConditionUnknown
+			ac.Reason = AlertmanagerNotAvailable
+			ac.Message = CannotReadAlertmanagerConditions
+			ac.LastTransitionTime = metav1.Now()
+			return ac
+		}
+
+		if amAvailable.ObservedGeneration != alertManager.Generation {
+			return ac
+		}
+
+		if amAvailable.Status != monv1.ConditionTrue {
+			ac.Status = monitoringStatusToRhobsMSStatus(amAvailable.Status)
+			if amAvailable.Status == monv1.ConditionDegraded {
+				ac.Reason = AlertmanagerDegraded
+			} else {
+				ac.Reason = AlertmanagerNotAvailable
+			}
+			ac.Message = amAvailable.Message
+			ac.LastTransitionTime = metav1.Now()
+			return ac
 		}
 	}
 
-	prometheusAvailable, err := getPrometheusCondition(prom.Status.Conditions, monv1.Available)
+	prometheusAvailable, err := getConditionByType(prom.Status.Conditions, monv1.Available)
 
 	if err != nil {
 		ac.Status = v1alpha1.ConditionUnknown
@@ -96,7 +125,7 @@ func updateAvailable(conditions []v1alpha1.Condition, prom monv1.Prometheus, gen
 	}
 
 	if prometheusAvailable.Status != monv1.ConditionTrue {
-		ac.Status = prometheusStatusToMSStatus(prometheusAvailable.Status)
+		ac.Status = monitoringStatusToRhobsMSStatus(prometheusAvailable.Status)
 		if prometheusAvailable.Status == monv1.ConditionDegraded {
 			ac.Reason = PrometheusDegraded
 		} else {
@@ -116,16 +145,9 @@ func updateAvailable(conditions []v1alpha1.Condition, prom monv1.Prometheus, gen
 
 // updateReconciled updates "Reconciled" conditions based on the provided error value and
 // Prometheus "Reconciled" condition
-func updateReconciled(conditions []v1alpha1.Condition, prom monv1.Prometheus, generation int64, reconcileErr error) v1alpha1.Condition {
-	rc, cErr := getMSCondition(conditions, v1alpha1.ReconciledCondition)
-	if cErr != nil {
-		rc = v1alpha1.Condition{
-			Type:               v1alpha1.ReconciledCondition,
-			Status:             v1alpha1.ConditionUnknown,
-			Reason:             NoReason,
-			LastTransitionTime: metav1.Now(),
-		}
-	}
+func updateReconciled(conditions []v1alpha1.Condition, prom monv1.Prometheus, alertManager *monv1.Alertmanager,
+	generation int64, reconcileErr error) v1alpha1.Condition {
+	rc := getMSCondition(conditions, v1alpha1.ReconciledCondition)
 	if reconcileErr != nil {
 		rc.Status = v1alpha1.ConditionFalse
 		rc.Message = reconcileErr.Error()
@@ -133,7 +155,29 @@ func updateReconciled(conditions []v1alpha1.Condition, prom monv1.Prometheus, ge
 		rc.LastTransitionTime = metav1.Now()
 		return rc
 	}
-	prometheusReconciled, reconcileErr := getPrometheusCondition(prom.Status.Conditions, monv1.Reconciled)
+	if alertManager != nil {
+		amReconciled, err := getConditionByType(alertManager.Status.Conditions, monv1.Reconciled)
+		if err != nil {
+			rc.Status = v1alpha1.ConditionUnknown
+			rc.Reason = AlertmanagerNotReconciled
+			rc.Message = CannotReadAlertmanagerConditions
+			rc.LastTransitionTime = metav1.Now()
+			return rc
+		}
+
+		if amReconciled.ObservedGeneration != alertManager.Generation {
+			return rc
+		}
+
+		if amReconciled.Status != monv1.ConditionTrue {
+			rc.Status = monitoringStatusToRhobsMSStatus(amReconciled.Status)
+			rc.Reason = AlertmanagerNotReconciled
+			rc.Message = amReconciled.Message
+			rc.LastTransitionTime = metav1.Now()
+			return rc
+		}
+	}
+	prometheusReconciled, reconcileErr := getConditionByType(prom.Status.Conditions, monv1.Reconciled)
 
 	if reconcileErr != nil {
 		rc.Status = v1alpha1.ConditionUnknown
@@ -148,7 +192,7 @@ func updateReconciled(conditions []v1alpha1.Condition, prom monv1.Prometheus, ge
 	}
 
 	if prometheusReconciled.Status != monv1.ConditionTrue {
-		rc.Status = prometheusStatusToMSStatus(prometheusReconciled.Status)
+		rc.Status = monitoringStatusToRhobsMSStatus(prometheusReconciled.Status)
 		rc.Reason = PrometheusNotReconciled
 		rc.Message = prometheusReconciled.Message
 		rc.LastTransitionTime = metav1.Now()
@@ -162,7 +206,7 @@ func updateReconciled(conditions []v1alpha1.Condition, prom monv1.Prometheus, ge
 	return rc
 }
 
-func getPrometheusCondition(prometheusConditions []monv1.Condition, t monv1.ConditionType) (*monv1.Condition, error) {
+func getConditionByType(prometheusConditions []monv1.Condition, t monv1.ConditionType) (*monv1.Condition, error) {
 	for _, c := range prometheusConditions {
 		if c.Type == t {
 			return &c, nil
@@ -171,7 +215,7 @@ func getPrometheusCondition(prometheusConditions []monv1.Condition, t monv1.Cond
 	return nil, fmt.Errorf("cannot find condition %v", t)
 }
 
-func prometheusStatusToMSStatus(ps monv1.ConditionStatus) v1alpha1.ConditionStatus {
+func monitoringStatusToRhobsMSStatus(ps monv1.ConditionStatus) v1alpha1.ConditionStatus {
 	switch ps {
 	// Prometheus "Available" condition with status "Degraded" is reported as "Available" condition
 	// with status false


### PR DESCRIPTION
This extends existing `conditions.go` to read and cover Alertmanager status if the Alertmanager is deployed in the monitoring stack.