### PR TITLE
fix: field manager name for generated resources

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -34,8 +34,7 @@ func (r Updater) Reconcile(ctx context.Context, c client.Client, scheme *runtime
 		}
 	}
 
-	owner := fmt.Sprintf("%s/%s", r.resourceOwner.GetNamespace(), r.resourceOwner.GetName())
-	if err := c.Patch(ctx, r.resource, client.Apply, client.ForceOwnership, client.FieldOwner(owner)); err != nil {
+	if err := c.Patch(ctx, r.resource, client.Apply, client.ForceOwnership, client.FieldOwner("observability-operator")); err != nil {
 		return fmt.Errorf("%s/%s (%s): updater failed to patch: %w",
 			r.resource.GetNamespace(), r.resource.GetName(),
 			r.resource.GetObjectKind().GroupVersionKind().String(), err)


### PR DESCRIPTION
Fixes the  field `manager` name of the generated resources

fixes: #266 