### PR TITLE
fix: e2e test cleanup and exit code

### DIFF
--- a/test/run-e2e-ocp.sh
+++ b/test/run-e2e-ocp.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e -u -o pipefail
 
-trap cleanup INT
+trap cleanup EXIT
 
 # NOTE: install ObO and run e2e against the installation
 
@@ -21,12 +21,11 @@ declare NO_UNINSTALL=false
 declare SHOW_USAGE=false
 
 cleanup() {
-	# NOTE: clears trap INT
-	trap - INT
-
 	# skip cleanup if user requested help
 	$SHOW_USAGE && return 0
-	delete_obo
+
+	delete_obo || true
+	return 0
 }
 
 install_obo() {
@@ -123,9 +122,9 @@ main() {
 	wait_for_operators_ready "$OPERATORS_NS"
 
 	local -i ret=0
-	./test/run-e2e.sh --no-deploy --ns "$OPERATORS_NS" || ret=1
-	delete_obo
+	./test/run-e2e.sh --no-deploy --ns "$OPERATORS_NS" || ret=$?
 
+	# NOTE: delete_obo will be automatically called when script exits
 	return $ret
 }
 

--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -28,6 +28,7 @@ cleanup() {
 	# shell check  ignore word splitting when using jobs -p
 	# shellcheck disable=SC2046
 	[[ -z "$(jobs -p)" ]] || kill $(jobs -p) || true
+	return 0
 }
 
 delete_olm_subscription() {
@@ -367,8 +368,8 @@ main() {
 	assert_no_reconciliation_errors pre-e2e ||
 		die "ObO has reconciliation errors before running test"
 
-	local ret=0
-	run_e2e || ret=1
+	local -i ret=0
+	run_e2e || ret=$?
 	assert_no_reconciliation_errors post-e2e || {
 		# see: https://github.com/rhobs/observability-operator/issues/200
 		skip "post-e2e reconciliation test until #200 is fixed"


### PR DESCRIPTION
Previously, the cleanup of ocp test will be run twice; i.e.
  1. One after the tests are run
  2. When the script exits

Additionally both test scripts failed to return the actual test run return code and only returned 1 on failure. This patch fixes both issues.