### PR TITLE
feat: add probe and scrapeConfig selectors

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,6 +1,6 @@
 # Developer Docs
 
-In order to contribute to this project, make sure you have go 1.18 installed
+In order to contribute to this project, make sure you have go 1.20 installed
 on your local machine.
 
 ## Dependencies

--- a/pkg/controllers/monitoring/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components.go
@@ -141,6 +141,10 @@ func newPrometheus(
 				ServiceMonitorNamespaceSelector: ms.Spec.NamespaceSelector,
 				PodMonitorSelector:              prometheusSelector,
 				PodMonitorNamespaceSelector:     ms.Spec.NamespaceSelector,
+				ProbeSelector:                   prometheusSelector,
+				ProbeNamespaceSelector:          ms.Spec.NamespaceSelector,
+				ScrapeConfigSelector:            prometheusSelector,
+				ScrapeConfigNamespaceSelector:   ms.Spec.NamespaceSelector,
 				Affinity: &corev1.Affinity{
 					PodAntiAffinity: &corev1.PodAntiAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -681,6 +681,8 @@ const oboManagedFieldsJson = `
   },
   "f:podMonitorNamespaceSelector": {},
   "f:podMonitorSelector": {},
+  "f:probeNamespaceSelector": {},
+  "f:probeSelector": {},
   "f:remoteWrite": {},
   "f:replicas": {},
   "f:resources": {},
@@ -690,6 +692,8 @@ const oboManagedFieldsJson = `
   "f:rules": {
     "f:alert": {}
   },
+  "f:scrapeConfigNamespaceSelector": {},
+  "f:scrapeConfigSelector": {},
   "f:scrapeInterval": {},
   "f:securityContext": {
     "f:fsGroup": {},


### PR DESCRIPTION
feat: ObO sets the `probeSelector` and `probeNamespaceSelector` fields in the Prometheus `.spec`
feat: ObO sets the `scrapeConfigSelector` and `scrapeConfigNamespaceSelector` fields in the Prometheus `.spec`

fixes: #283 