### PR TITLE
fix: ensure OLM bundle installs fine all supported OpenShift Versions

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -424,8 +424,6 @@ spec:
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 65534
-                seccompProfile:
-                  type: RuntimeDefault
               serviceAccountName: obo-prometheus-operator
       - label:
           app.kubernetes.io/name: prometheus-operator-admission-webhook
@@ -495,8 +493,6 @@ spec:
               securityContext:
                 runAsNonRoot: true
                 runAsUser: 65534
-                seccompProfile:
-                  type: RuntimeDefault
               serviceAccountName: obo-prometheus-operator-admission-webhook
       - label:
           app.kubernetes.io/component: operator

--- a/deploy/dependencies/kustomization.yaml
+++ b/deploy/dependencies/kustomization.yaml
@@ -165,3 +165,16 @@ patches:
               volumeMounts:
               - name: tls-certificates
                 $patch: delete
+
+    # HACK: remove the RuntimeDefault from ALL deploymens until we figure out
+    # how to run the operator on all openshift version from 4.9-13. Currently the
+    # webhook fails to deploy on 4.10
+    # SEE: https://issues.redhat.com/browse/MON-3225 which should provide an actual fix
+  - patch: |-
+      - op: remove
+        path: /spec/template/spec/securityContext/seccompProfile
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: '.*'


### PR DESCRIPTION
NOTE: this HACK removes the RuntimeDefault seccomProfile from prometheus-operator deployments (opearator and webhook) so that the bundle installs fine on all OpenShift versions >= 4.9.

Without this HACK pods fail to be created with the following status error ...

```
status:
  conditions:
    message: '
      pods "obo-prometheus-operator-5864dd8b49-xjs55" is forbidden:
      unable to validate against any security context constraint: [pod.metadata.annotations.seccomp.security.alpha.kubernetes.io/pod:
      Forbidden: seccomp may not be set pod.metadata.annotations.container.seccomp.security.alpha.kubernetes.io/prometheus-operator:
      Forbidden: seccomp may not be set provider "anyuid":
      Forbidden: not usable by user or serviceaccount pod.metadata.annotations.seccomp.security.alpha.kubernetes.io/pod:
      Forbidden: seccomp may not be set spec.containers[0].securityContext.runAsUser:
	Invalid value: 65534: must be in the ranges: [1000410000, 1000419999] pod.metadata.annotations.container.seccomp.security.alpha.kubernetes.io/prometheus-operator:
      Forbidden: seccomp may not be set provider "hostmount-anyuid":
      Forbidden: not usable by user or serviceaccount provider "machine-api-termination-handler":
      Forbidden: not usable by user or serviceaccount provider "hostnetwork":
      Forbidden: not usable by user or serviceaccount provider "hostaccess":
      Forbidden: not usable by user or serviceaccount provider "node-exporter":
      Forbidden: not usable by user or serviceaccount provider "privileged":
      Forbidden: not usable by user or serviceaccount]'
    reason: FailedCreate
    status: "True"
    type: ReplicaFailure
```

Ref: https://issues.redhat.com/browse/MON-3225