### PR TITLE
fix: add repo details to bundle

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -51,6 +51,7 @@ metadata:
         "thanosrulers.monitoring.rhobs"
       ]
     operators.operatorframework.io/project_layout: unknown
+    repository: https://github.com/rhobs/observability-operator
   name: observability-operator.v0.0.22
   namespace: placeholder
 spec:

--- a/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
+++ b/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
@@ -16,6 +16,7 @@ metadata:
         "prometheuses.monitoring.rhobs", "alertmanagers.monitoring.rhobs",
         "thanosrulers.monitoring.rhobs"
       ]
+    repository: 'https://github.com/rhobs/observability-operator'
   name: observability-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This is an optional but recommended detail for the bundle to be published to 
OpenShift Community Catalog. 

See: https://redhat-openshift-ecosystem.github.io/community-operators-prod/packaging-required-fields/
