### PR TITLE
Make catalogsource compatible with restricted SCC enforcement

### DIFF
--- a/deploy/olm/syncselector-template.yaml
+++ b/deploy/olm/syncselector-template.yaml
@@ -53,6 +53,8 @@ objects:
             image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
             publisher: OSD Red Hat Addons
             sourceType: grpc
+            grpcPodConfig:
+              securityContextConfig: restricted
         - apiVersion: operators.coreos.com/v1alpha2
           kind: OperatorGroup
           metadata:

--- a/hack/olm/catalog-src.yaml
+++ b/hack/olm/catalog-src.yaml
@@ -14,6 +14,8 @@ spec:
   image: quay.io/rhobs/observability-operator-catalog:latest
   publisher: Sunil Thaha
   sourceType: grpc
+  grpcPodConfig:
+    securityContextConfig: restricted
   updateStrategy:
     registryPoll:
       interval: 1m0s

--- a/hack/olm/k8s/catalog-src.yaml
+++ b/hack/olm/k8s/catalog-src.yaml
@@ -14,6 +14,8 @@ spec:
   image: quay.io/rhobs/observability-operator-catalog:latest
   publisher: Sunil Thaha
   sourceType: grpc
+  grpcPodConfig:
+    securityContextConfig: restricted
   updateStrategy:
     registryPoll:
       interval: 1m0s


### PR DESCRIPTION
* Restricted SCC enforcement will be added with OCP 4.14
* Updating the catalogsource to allow the operator to get deployed
* Clusters that don't support the setting (<4.12) will ignore it

Jira: OSD-15621