### PR TITLE
fix: enforce scheduling registry pod onto infra nodes

### DIFF
--- a/deploy/olm/syncselector-template.yaml
+++ b/deploy/olm/syncselector-template.yaml
@@ -55,6 +55,12 @@ objects:
             sourceType: grpc
             grpcPodConfig:
               securityContextConfig: restricted
+              nodeSelector:
+                node-role.kubernetes.io: infra
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+                operator: Exists
         - apiVersion: operators.coreos.com/v1alpha2
           kind: OperatorGroup
           metadata:


### PR DESCRIPTION
This commit specifies .spec.grpcPodConfig.nodeSelector and .spec.grpdPodConfig.tolerations to schedule this operator's registry pod to infra nodes when possible.

[OSD-6629](https://issues.redhat.com//browse/OSD-6629)