### PR TITLE
fix: add node tolerations to deployments

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -448,6 +448,10 @@ spec:
                 runAsNonRoot: true
                 runAsUser: 65534
               serviceAccountName: obo-prometheus-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+                operator: Exists
       - label:
           app.kubernetes.io/name: prometheus-operator-admission-webhook
           app.kubernetes.io/part-of: observability-operator
@@ -517,6 +521,10 @@ spec:
                 runAsNonRoot: true
                 runAsUser: 65534
               serviceAccountName: obo-prometheus-operator-admission-webhook
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+                operator: Exists
       - label:
           app.kubernetes.io/component: operator
           app.kubernetes.io/name: observability-operator
@@ -579,6 +587,10 @@ spec:
                 runAsNonRoot: true
               serviceAccountName: observability-operator-sa
               terminationGracePeriodSeconds: 30
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/infra
+                operator: Exists
     strategy: deployment
   installModes:
   - supported: false

--- a/deploy/olm/kustomization.yaml
+++ b/deploy/olm/kustomization.yaml
@@ -31,6 +31,10 @@ patches:
                   - key: node-role.kubernetes.io/infra
                     operator: Exists
                 weight: 1
+          tolerations:
+          - effect: NoSchedule
+            key: node-role.kubernetes.io/infra
+            operator: Exists
   target:
     group: apps
     kind: Deployment


### PR DESCRIPTION
While the observability-operator, obo-prometheus-operator and obo-prometheus-operator-admission-webhook deployments are configured to be scheduled preferably on infra nodes, they lacked the required toleration that would enable them being scheduled properly.

This change fixes the issue by adding the expected toleration.

https://issues.redhat.com/browse/MON-3299