### PR TITLE
fix: use framework default timeout in ns tests

### DIFF
--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -855,7 +855,7 @@ func namespaceSelectorTest(t *testing.T) {
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	//nolint
-	if pollErr := wait.Poll(15*time.Second, 5*time.Minute, func() (bool, error) {
+	if pollErr := wait.Poll(15*time.Second, framework.DefaultTestTimeout, func() (bool, error) {
 		err := f.StartServicePortForward(ms.Name+"-prometheus", e2eTestNamespace, "9090", stopChan)
 		return err == nil, nil
 	}); pollErr != nil {
@@ -863,7 +863,7 @@ func namespaceSelectorTest(t *testing.T) {
 	}
 
 	promClient := framework.NewPrometheusClient("http://localhost:9090")
-	if pollErr := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
+	if pollErr := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, framework.DefaultTestTimeout, true, func(ctx context.Context) (bool, error) {
 		query := `version{pod="prometheus-example-app",namespace=~"test-ns-.*"}`
 		result, err := promClient.Query(query)
 		if err != nil {


### PR DESCRIPTION
This PR makes it so DefaultTimeout is used accordingly among the
different tests and assertions.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>
