### PR TITLE
fix: update github workflow to use node>=16

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -25,10 +25,10 @@ runs:
     - uses: azure/setup-kubectl@v3
 
     - name: Start Kind
-      uses: engineerd/setup-kind@v0.5.0
+      uses: helm/kind-action@v1.7.0
       with:
         version: ${{ inputs.kind-version }}
-        image: ${{ inputs.kind-image }}
+        node_image: ${{ inputs.kind-image }}
         wait: 300s
         config: ./hack/kind/config.yaml
 


### PR DESCRIPTION
GitHub workflow is giving off a warning about the node version used for
some of the actions (engineerd/setup-kind) being deprecated. This commit
changes the plugin to helm/kind-action to avoid that.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>
