### PR TITLE
test: enhance TestMonitoringStackController/stack_spec_are_reflected_…

### DIFF
--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -269,7 +269,7 @@ func (f *Framework) GetStackWhenAvailable(t *testing.T, name, namespace string) 
 	}
 	var lastErr error
 
-	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, DefaultTestTimeout, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, DefaultTestTimeout+10*time.Second, true, func(ctx context.Context) (bool, error) {
 		lastErr = nil
 		err := f.K8sClient.Get(context.Background(), key, &ms)
 		if err != nil {


### PR DESCRIPTION
fix #342
Reproduced case failure by changing DefaultTestTimeout as 30
https://github.com/rhobs/observability-operator/actions/runs/5972651257/job/16203531633