### PR TITLE
chore: add OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - maintainers
+reviewers:
+  - maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,20 @@
+aliases:
+  contributors:
+    - jan--f
+    - tremes
+    - danielmellado
+    - simonpasquier
+    - sthaha
+    - slashpai
+    - JoaoBraveCoding
+    - thibaultmg
+    - machine424
+    - rexagod
+    - lihongyan1
+    - marioferh
+  maintainers:
+    - jan--f
+    - danielmellado
+    - simonpasquier
+    - sthaha
+    - slashpai

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - contributors
+reviewers:
+  - contributors

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - contributors
+reviewers:
+  - contributors

--- a/jsonnet/OWNERS
+++ b/jsonnet/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - contributors
+reviewers:
+  - contributors

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - contributors
+reviewers:
+  - contributors

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - contributors
+reviewers:
+  - contributors


### PR DESCRIPTION
The OWNERS files are very simple and need to only be placed in the right locations. Actual membership is managed through OWNERS_ALIASES. Currently this reflects the github groups `observability-operator-contributors` `observability-operator-maintainers`.
The current setup allows reviews and approvals by contributors to code, but requires maintainer review for changes to build artifacts.