### PR TITLE
ci: bundle dockerfile is needed for prow job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /tmp
-bundle.Dockerfile
 RELEASE_BODY.md
 jsonnet/vendor
 deploy/package-operator/package/crds

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,0 +1,21 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=observability-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=development
+LABEL operators.operatorframework.io.bundle.channel.default.v1=development
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.24.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=unknown
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY bundle/manifests /manifests/
+COPY bundle/metadata /metadata/
+COPY bundle/tests/scorecard /tests/scorecard/


### PR DESCRIPTION
Submit then bundle.Dockerfile.

Checked several operator repositories, they contain the docker file, such as
https://github.com/openshift/open-telemetry-opentelemetry-operator