### PR TITLE
ci: bump test/Dockerfile go image base

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,5 +1,5 @@
 ###  Builder ###
-FROM golang:1.19  as builder
+FROM golang:1.20  as builder
 
 ENV PKG=/workspace
 WORKDIR ${PKG}


### PR DESCRIPTION
sigs.k8s.io/controller-runtime@0.16.3 requires go1.20.