### PR TITLE
chore: build static Go binaries

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,7 @@ COPY cmd/operator/main.go cmd/operator/main.go
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/operator/main.go
+RUN GOOS=linux GOARCH=amd64 go build -a -tags netgo,osusergo -o manager cmd/operator/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -19,7 +19,7 @@ COPY pkg/ pkg/
 COPY test/ test/
 
 # compile test into e2e.test binary
-RUN go test -c ./test/e2e/
+RUN go test -c -tags netgo,osusergo ./test/e2e/
 
 ###  Runner  ###
 


### PR DESCRIPTION
This change adds the `-tags netgo,osusergo` argument to Go commands to get fully-static binaries.