### PR TITLE
fix: update versions in bundle generation

### DIFF
--- a/bundle/manifests/monitoring.rhobs_alertmanagerconfigs.yaml
+++ b/bundle/manifests/monitoring.rhobs_alertmanagerconfigs.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-    operator.prometheus.io/version: 0.69.0-rhobs1
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operator.prometheus.io/version: 0.71.0-rhobs1
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: observability-operator
@@ -78,9 +78,9 @@ spec:
                             minLength: 1
                             type: string
                           regex:
-                            description: Whether to match on equality (false) or regular-expression
-                              (true). Deprecated as of AlertManager >= v0.22.0 where
-                              a user should use MatchType instead.
+                            description: 'Whether to match on equality (false) or
+                              regular-expression (true). Deprecated: for AlertManager
+                              >= v0.22.0, `matchType` should be used instead.'
                             type: boolean
                           value:
                             description: Label value to match.
@@ -111,9 +111,9 @@ spec:
                             minLength: 1
                             type: string
                           regex:
-                            description: Whether to match on equality (false) or regular-expression
-                              (true). Deprecated as of AlertManager >= v0.22.0 where
-                              a user should use MatchType instead.
+                            description: 'Whether to match on equality (false) or
+                              regular-expression (true). Deprecated: for AlertManager
+                              >= v0.22.0, `matchType` should be used instead.'
                             type: boolean
                           value:
                             description: Label value to match.
@@ -239,6 +239,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           httpConfig:
                             description: HTTP client configuration.
                             properties:
@@ -283,8 +284,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -305,8 +306,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -351,6 +352,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -360,8 +362,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -409,8 +412,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -433,17 +436,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -629,6 +633,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           authSecret:
                             description: The secret's key that contains the CRAM-MD5
                               secret. The secret needs to be in the same namespace
@@ -651,6 +656,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           authUsername:
                             description: The username to use for authentication.
                             type: string
@@ -880,8 +886,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -902,8 +908,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -948,6 +954,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -957,8 +964,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -1006,8 +1014,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -1030,17 +1038,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -1211,6 +1220,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                         required:
                         - webhookUrl
                         type: object
@@ -1252,6 +1262,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           apiURL:
                             description: The URL to send OpsGenie API requests to.
                             type: string
@@ -1324,8 +1335,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -1346,8 +1357,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -1392,6 +1403,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -1401,8 +1413,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -1450,8 +1463,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -1474,17 +1487,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -1772,8 +1786,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -1794,8 +1808,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -1840,6 +1854,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -1849,8 +1864,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -1898,8 +1914,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -1922,17 +1938,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -2135,6 +2152,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           sendResolved:
                             description: Whether or not to notify about resolved alerts.
                             type: boolean
@@ -2162,6 +2180,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           severity:
                             description: Severity of the incident.
                             type: string
@@ -2176,6 +2195,10 @@ spec:
                         description: PushoverConfig configures notifications via Pushover.
                           See https://prometheus.io/docs/alerting/latest/configuration/#pushover_config
                         properties:
+                          device:
+                            description: The name of a device to send the notification
+                              to
+                            type: string
                           expire:
                             description: How long your notification will continue
                               to be retried for, unless the user acknowledges the
@@ -2230,8 +2253,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -2252,8 +2275,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -2298,6 +2321,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -2307,8 +2331,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -2356,8 +2381,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -2380,17 +2405,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -2579,6 +2605,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           tokenFile:
                             description: The token file that contains the registered
                               application's API token, see https://pushover.net/apps.
@@ -2615,6 +2642,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           userKeyFile:
                             description: The user key file that contains the recipient
                               user's user key. Either `userKey` or `userKeyFile` is
@@ -2697,6 +2725,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           callbackId:
                             type: string
                           channel:
@@ -2778,8 +2807,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -2800,8 +2829,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -2846,6 +2875,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -2855,8 +2885,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -2904,8 +2935,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -2928,17 +2959,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -3172,8 +3204,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -3194,8 +3226,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -3240,6 +3272,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -3249,8 +3282,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -3298,8 +3332,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -3322,17 +3356,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -3599,6 +3634,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           botTokenFile:
                             description: "File to read the Telegram bot token from.
                               It is mutually exclusive with `botToken`. Either `botToken`
@@ -3656,8 +3692,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -3678,8 +3714,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -3724,6 +3760,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -3733,8 +3770,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -3782,8 +3820,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -3806,17 +3844,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -4002,6 +4041,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           apiUrl:
                             description: The VictorOps API URL.
                             type: string
@@ -4069,8 +4109,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -4091,8 +4131,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -4137,6 +4177,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -4146,8 +4187,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -4195,8 +4237,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -4219,17 +4261,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -4449,8 +4492,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -4471,8 +4514,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -4517,6 +4560,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -4526,8 +4570,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -4575,8 +4620,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -4599,17 +4644,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -4817,8 +4863,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -4839,8 +4885,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -4885,6 +4931,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -4894,8 +4941,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -4943,8 +4991,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -4967,17 +5015,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -5158,6 +5207,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       type: array
                     wechatConfigs:
@@ -5190,6 +5240,7 @@ spec:
                             required:
                             - key
                             type: object
+                            x-kubernetes-map-type: atomic
                           apiURL:
                             description: The WeChat API URL.
                             type: string
@@ -5240,8 +5291,8 @@ spec:
                                   BasicAuth takes precedence.
                                 properties:
                                   password:
-                                    description: The secret in the service monitor
-                                      namespace that contains the password for authentication.
+                                    description: '`password` specifies a key of a
+                                      Secret containing the password for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -5262,8 +5313,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   username:
-                                    description: The secret in the service monitor
-                                      namespace that contains the username for authentication.
+                                    description: '`username` specifies a key of a
+                                      Secret containing the username for authentication.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -5308,6 +5359,7 @@ spec:
                                 required:
                                 - key
                                 type: object
+                                x-kubernetes-map-type: atomic
                               followRedirects:
                                 description: FollowRedirects specifies whether the
                                   client should follow HTTP 3xx redirects.
@@ -5317,8 +5369,9 @@ spec:
                                   a token for the targets.
                                 properties:
                                   clientId:
-                                    description: The secret or configmap containing
-                                      the OAuth2 client id
+                                    description: '`clientId` specifies a key of a
+                                      Secret or ConfigMap containing the OAuth2 client''s
+                                      ID.'
                                     properties:
                                       configMap:
                                         description: ConfigMap containing data to
@@ -5366,8 +5419,8 @@ spec:
                                         x-kubernetes-map-type: atomic
                                     type: object
                                   clientSecret:
-                                    description: The secret containing the OAuth2
-                                      client secret
+                                    description: '`clientSecret` specifies a key of
+                                      a Secret containing the OAuth2 client''s secret.'
                                     properties:
                                       key:
                                         description: The key of the secret to select
@@ -5390,17 +5443,18 @@ spec:
                                   endpointParams:
                                     additionalProperties:
                                       type: string
-                                    description: Parameters to append to the token
-                                      URL
+                                    description: '`endpointParams` configures the
+                                      HTTP parameters to append to the token URL.'
                                     type: object
                                   scopes:
-                                    description: OAuth2 scopes used for the token
-                                      request
+                                    description: '`scopes` defines the OAuth2 scopes
+                                      used for the token request.'
                                     items:
                                       type: string
                                     type: array
                                   tokenUrl:
-                                    description: The URL to fetch the token from
+                                    description: '`tokenURL` configures the URL to
+                                      fetch the token from.'
                                     minLength: 1
                                     type: string
                                 required:
@@ -5620,9 +5674,9 @@ spec:
                           minLength: 1
                           type: string
                         regex:
-                          description: Whether to match on equality (false) or regular-expression
-                            (true). Deprecated as of AlertManager >= v0.22.0 where
-                            a user should use MatchType instead.
+                          description: 'Whether to match on equality (false) or regular-expression
+                            (true). Deprecated: for AlertManager >= v0.22.0, `matchType`
+                            should be used instead.'
                           type: boolean
                         value:
                           description: Label value to match.

--- a/bundle/manifests/monitoring.rhobs_alertmanagers.yaml
+++ b/bundle/manifests/monitoring.rhobs_alertmanagers.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-    operator.prometheus.io/version: 0.69.0-rhobs1
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operator.prometheus.io/version: 0.71.0-rhobs1
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: observability-operator
@@ -1060,8 +1060,8 @@ spec:
                               takes precedence.
                             properties:
                               password:
-                                description: The secret in the service monitor namespace
-                                  that contains the password for authentication.
+                                description: '`password` specifies a key of a Secret
+                                  containing the password for authentication.'
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must
@@ -1082,8 +1082,8 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               username:
-                                description: The secret in the service monitor namespace
-                                  that contains the username for authentication.
+                                description: '`username` specifies a key of a Secret
+                                  containing the username for authentication.'
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must
@@ -1136,8 +1136,8 @@ spec:
                               token for the targets.
                             properties:
                               clientId:
-                                description: The secret or configmap containing the
-                                  OAuth2 client id
+                                description: '`clientId` specifies a key of a Secret
+                                  or ConfigMap containing the OAuth2 client''s ID.'
                                 properties:
                                   configMap:
                                     description: ConfigMap containing data to use
@@ -1184,8 +1184,8 @@ spec:
                                     x-kubernetes-map-type: atomic
                                 type: object
                               clientSecret:
-                                description: The secret containing the OAuth2 client
-                                  secret
+                                description: '`clientSecret` specifies a key of a
+                                  Secret containing the OAuth2 client''s secret.'
                                 properties:
                                   key:
                                     description: The key of the secret to select from.  Must
@@ -1208,15 +1208,18 @@ spec:
                               endpointParams:
                                 additionalProperties:
                                   type: string
-                                description: Parameters to append to the token URL
+                                description: '`endpointParams` configures the HTTP
+                                  parameters to append to the token URL.'
                                 type: object
                               scopes:
-                                description: OAuth2 scopes used for the token request
+                                description: '`scopes` defines the OAuth2 scopes used
+                                  for the token request.'
                                 items:
                                   type: string
                                 type: array
                               tokenUrl:
-                                description: The URL to fetch the token from
+                                description: '`tokenURL` configures the URL to fetch
+                                  the token from.'
                                 minLength: 1
                                 type: string
                             required:
@@ -1569,7 +1572,7 @@ spec:
                 type: boolean
               baseImage:
                 description: 'Base image that is used to deploy pods, without tag.
-                  Deprecated: use ''image'' instead'
+                  Deprecated: use ''image'' instead.'
                 type: string
               clusterAdvertiseAddress:
                 description: 'ClusterAdvertiseAddress is the explicit address to advertise
@@ -1579,6 +1582,13 @@ spec:
               clusterGossipInterval:
                 description: Interval between gossip attempts.
                 pattern: ^(0|(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                type: string
+              clusterLabel:
+                description: Defines the identifier that uniquely identifies the Alertmanager
+                  cluster. You should only set it when the Alertmanager cluster includes
+                  Alertmanager instances which are external to this Alertmanager resource.
+                  In practice, the addresses of the external instances are provided
+                  via the `.spec.additionalPeers` field.
                 type: string
               clusterPeerTimeout:
                 description: Timeout for cluster peering.
@@ -4593,7 +4603,7 @@ spec:
                 description: 'SHA of Alertmanager container image to be deployed.
                   Defaults to the value of `version`. Similar to a tag, but the SHA
                   explicitly deploys an immutable container image. Version and Tag
-                  are ignored if SHA is set. Deprecated: use ''image'' instead.  The
+                  are ignored if SHA is set. Deprecated: use ''image'' instead. The
                   image digest can be specified as part of the image URL.'
                 type: string
               storage:
@@ -4601,8 +4611,8 @@ spec:
                   by the Alertmanager instances.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -5154,7 +5164,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes
@@ -5299,7 +5309,7 @@ spec:
               tag:
                 description: 'Tag of Alertmanager container image to be deployed.
                   Defaults to the value of `version`. Version is ignored if Tag is
-                  set. Deprecated: use ''image'' instead.  The image tag can be specified
+                  set. Deprecated: use ''image'' instead. The image tag can be specified
                   as part of the image URL.'
                 type: string
               tolerations:

--- a/bundle/manifests/monitoring.rhobs_podmonitors.yaml
+++ b/bundle/manifests/monitoring.rhobs_podmonitors.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-    operator.prometheus.io/version: 0.69.0-rhobs1
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operator.prometheus.io/version: 0.71.0-rhobs1
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: observability-operator
@@ -41,16 +41,23 @@ spec:
               by Prometheus.
             properties:
               attachMetadata:
-                description: Attaches node metadata to discovered targets. Requires
-                  Prometheus v2.35.0 and above.
+                description: "`attachMetadata` defines additional metadata which is
+                  added to the discovered targets. \n It requires Prometheus >= v2.37.0."
                 properties:
                   node:
-                    description: When set to true, Prometheus must have permissions
-                      to get Nodes.
+                    description: When set to true, Prometheus must have the `get`
+                      permission on the `Nodes` objects.
                     type: boolean
                 type: object
               jobLabel:
-                description: The label to use to retrieve the job name from.
+                description: "The label to use to retrieve the job name from. `jobLabel`
+                  selects the label from the associated Kubernetes `Pod` object which
+                  will be used as the `job` label for all metrics. \n For example
+                  if `jobLabel` is set to `foo` and the Kubernetes `Pod` object is
+                  labeled with `foo: bar`, then Prometheus adds the `job=\"bar\"`
+                  label to all ingested metrics. \n If the value of this field is
+                  empty, the `job` label of the metrics defaults to the namespace
+                  and name of the PodMonitor object (e.g. `<namespace>/<name>`)."
                 type: string
               keepDroppedTargets:
                 description: "Per-scrape limit on the number of targets dropped by
@@ -59,25 +66,23 @@ spec:
                 format: int64
                 type: integer
               labelLimit:
-                description: Per-scrape limit on number of labels that will be accepted
-                  for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: "Per-scrape limit on number of labels that will be accepted
+                  for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               labelNameLengthLimit:
-                description: Per-scrape limit on length of labels name that will be
-                  accepted for a sample. Only valid in Prometheus versions 2.27.0
-                  and newer.
+                description: "Per-scrape limit on length of labels name that will
+                  be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               labelValueLengthLimit:
-                description: Per-scrape limit on length of labels value that will
-                  be accepted for a sample. Only valid in Prometheus versions 2.27.0
-                  and newer.
+                description: "Per-scrape limit on length of labels value that will
+                  be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               namespaceSelector:
-                description: Selector to select which namespaces the Endpoints objects
-                  are discovered from.
+                description: Selector to select which namespaces the Kubernetes `Pods`
+                  objects are discovered from.
                 properties:
                   any:
                     description: Boolean describing whether all namespaces are selected
@@ -90,13 +95,15 @@ spec:
                     type: array
                 type: object
               podMetricsEndpoints:
-                description: A list of endpoints allowed as part of this PodMonitor.
+                description: List of endpoints part of this PodMonitor.
                 items:
-                  description: PodMetricsEndpoint defines a scrapeable endpoint of
-                    a Kubernetes Pod serving Prometheus metrics.
+                  description: PodMetricsEndpoint defines an endpoint serving Prometheus
+                    metrics to be scraped by Prometheus.
                   properties:
                     authorization:
-                      description: Authorization section for this endpoint
+                      description: "`authorization` configures the Authorization header
+                        credentials to use when scraping the target. \n Cannot be
+                        set at the same time as `basicAuth`, or `oauth2`."
                       properties:
                         credentials:
                           description: Selects a key of a Secret in the namespace
@@ -125,12 +132,13 @@ spec:
                           type: string
                       type: object
                     basicAuth:
-                      description: 'BasicAuth allow an endpoint to authenticate over
-                        basic authentication. More info: https://prometheus.io/docs/operating/configuration/#endpoint'
+                      description: "`basicAuth` configures the Basic Authentication
+                        credentials to use when scraping the target. \n Cannot be
+                        set at the same time as `authorization`, or `oauth2`."
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing
+                            the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -149,8 +157,8 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing
+                            the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -170,9 +178,11 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerTokenSecret:
-                      description: Secret to mount to read bearer token for scraping
-                        targets. The secret needs to be in the same namespace as the
-                        pod monitor and accessible by the Prometheus Operator.
+                      description: "`bearerTokenSecret` specifies a key of a Secret
+                        containing the bearer token for scraping targets. The secret
+                        needs to be in the same namespace as the PodMonitor object
+                        and readable by the Prometheus Operator. \n Deprecated: use
+                        `authorization` instead."
                       properties:
                         key:
                           description: The key of the secret to select from.  Must
@@ -191,32 +201,36 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     enableHttp2:
-                      description: Whether to enable HTTP2.
+                      description: '`enableHttp2` can be used to disable HTTP2 when
+                        scraping the target.'
                       type: boolean
                     filterRunning:
-                      description: 'Drop pods that are not running. (Failed, Succeeded).
-                        Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
+                      description: "When true, the pods which are not running (e.g.
+                        either in Failed or Succeeded state) are dropped during the
+                        target discovery. \n If unset, the filtering is enabled. \n
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase"
                       type: boolean
                     followRedirects:
-                      description: FollowRedirects configures whether scrape requests
-                        follow HTTP 3xx redirects.
+                      description: '`followRedirects` defines whether the scrape requests
+                        should follow HTTP 3xx redirects.'
                       type: boolean
                     honorLabels:
-                      description: HonorLabels chooses the metric's labels on collisions
-                        with target labels.
+                      description: When true, `honorLabels` preserves the metric's
+                        labels when they collide with the target's labels.
                       type: boolean
                     honorTimestamps:
-                      description: HonorTimestamps controls whether Prometheus respects
-                        the timestamps present in scraped data.
+                      description: '`honorTimestamps` controls whether Prometheus
+                        preserves the timestamps when exposed by the target.'
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped If
-                        not specified Prometheus' global scrape interval is used.
+                      description: "Interval at which Prometheus scrapes the metrics
+                        from the target. \n If empty, Prometheus uses the global scrape
+                        interval."
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
-                      description: MetricRelabelConfigs to apply to samples before
-                        ingestion.
+                      description: '`metricRelabelings` configures the relabeling
+                        rules to apply to the samples before ingestion.'
                       items:
                         description: "RelabelConfig allows dynamic rewriting of the
                           label set for targets, alerts, scraped samples and remote
@@ -292,12 +306,13 @@ spec:
                         type: object
                       type: array
                     oauth2:
-                      description: OAuth2 for the URL. Only valid in Prometheus versions
-                        2.27.0 and newer.
+                      description: "`oauth2` configures the OAuth2 settings to use
+                        when scraping the target. \n It requires Prometheus >= 2.27.0.
+                        \n Cannot be set at the same time as `authorization`, or `basicAuth`."
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2
-                            client id
+                          description: '`clientId` specifies a key of a Secret or
+                            ConfigMap containing the OAuth2 client''s ID.'
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -341,7 +356,8 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
+                          description: '`clientSecret` specifies a key of a Secret
+                            containing the OAuth2 client''s secret.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -362,15 +378,18 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
+                          description: '`endpointParams` configures the HTTP parameters
+                            to append to the token URL.'
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
+                          description: '`scopes` defines the OAuth2 scopes used for
+                            the token request.'
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
+                          description: '`tokenURL` configures the URL to fetch the
+                            token from.'
                           minLength: 1
                           type: string
                       required:
@@ -383,26 +402,27 @@ spec:
                         items:
                           type: string
                         type: array
-                      description: Optional HTTP URL parameters
+                      description: '`params` define optional HTTP URL parameters.'
                       type: object
                     path:
-                      description: HTTP path to scrape for metrics. If empty, Prometheus
-                        uses the default value (e.g. `/metrics`).
+                      description: "HTTP path from which to scrape for metrics. \n
+                        If empty, Prometheus uses the default value (e.g. `/metrics`)."
                       type: string
                     port:
-                      description: Name of the pod port this endpoint refers to. Mutually
-                        exclusive with targetPort.
+                      description: "Name of the Pod port which this endpoint refers
+                        to. \n It takes precedence over `targetPort`."
                       type: string
                     proxyUrl:
-                      description: ProxyURL eg http://proxyserver:2195 Directs scrapes
-                        to proxy through this endpoint.
+                      description: '`proxyURL` configures the HTTP Proxy URL (e.g.
+                        "http://proxyserver:2195") to go through when scraping the
+                        target.'
                       type: string
                     relabelings:
-                      description: 'RelabelConfigs to apply to samples before scraping.
-                        Prometheus Operator automatically adds relabelings for a few
-                        standard Kubernetes fields. The original scrape job''s name
-                        is available via the `__tmp_prometheus_job_name` label. More
-                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                      description: "`relabelings` configures the relabeling rules
+                        to apply the target's metadata labels. \n The Operator automatically
+                        adds relabelings for a few standard Kubernetes fields. \n
+                        The original scrape job's name is available via the `__tmp_prometheus_job_name`
+                        label. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                       items:
                         description: "RelabelConfig allows dynamic rewriting of the
                           label set for targets, alerts, scraped samples and remote
@@ -478,27 +498,31 @@ spec:
                         type: object
                       type: array
                     scheme:
-                      description: HTTP scheme to use for scraping. `http` and `https`
-                        are the expected values unless you rewrite the `__scheme__`
-                        label via relabeling. If empty, Prometheus uses the default
-                        value `http`.
+                      description: "HTTP scheme to use for scraping. \n `http` and
+                        `https` are the expected values unless you rewrite the `__scheme__`
+                        label via relabeling. \n If empty, Prometheus uses the default
+                        value `http`."
                       enum:
                       - http
                       - https
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended If not
-                        specified, the Prometheus global scrape interval is used.
+                      description: "Timeout after which Prometheus considers the scrape
+                        to be failed. \n If empty, Prometheus uses the global scrape
+                        timeout unless it is less than the target's scrape interval
+                        value in which the latter is used."
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: 'Deprecated: Use ''port'' instead.'
+                      description: "Name or number of the target port of the `Pod`
+                        object behind the Service, the port must be specified with
+                        container port property. \n Deprecated: use 'port' instead."
                       x-kubernetes-int-or-string: true
                     tlsConfig:
-                      description: TLS configuration to use when scraping the endpoint.
+                      description: TLS configuration to use when scraping the target.
                       properties:
                         ca:
                           description: Certificate authority used when verifying server
@@ -616,21 +640,27 @@ spec:
                           description: Used to verify the hostname for the targets.
                           type: string
                       type: object
+                    trackTimestampsStaleness:
+                      description: "`trackTimestampsStaleness` defines whether Prometheus
+                        tracks staleness of the metrics that have an explicit timestamp
+                        present in scraped data. Has no effect if `honorTimestamps`
+                        is false. \n It requires Prometheus >= v2.48.0."
+                      type: boolean
                   type: object
                 type: array
               podTargetLabels:
-                description: PodTargetLabels transfers labels on the Kubernetes Pod
-                  onto the target.
+                description: '`podTargetLabels` defines the labels which are transferred
+                  from the associated Kubernetes `Pod` object onto the ingested metrics.'
                 items:
                   type: string
                 type: array
               sampleLimit:
-                description: SampleLimit defines per-scrape limit on number of scraped
-                  samples that will be accepted.
+                description: '`sampleLimit` defines a per-scrape limit on the number
+                  of scraped samples that will be accepted.'
                 format: int64
                 type: integer
               selector:
-                description: Selector to select Pod objects.
+                description: Label selector to select the Kubernetes `Pod` objects.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -675,12 +705,11 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               targetLimit:
-                description: TargetLimit defines a limit on the number of scraped
-                  targets that will be accepted.
+                description: '`targetLimit` defines a limit on the number of scraped
+                  targets that will be accepted.'
                 format: int64
                 type: integer
             required:
-            - podMetricsEndpoints
             - selector
             type: object
         required:

--- a/bundle/manifests/monitoring.rhobs_probes.yaml
+++ b/bundle/manifests/monitoring.rhobs_probes.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-    operator.prometheus.io/version: 0.69.0-rhobs1
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operator.prometheus.io/version: 0.71.0-rhobs1
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: observability-operator
@@ -73,8 +73,8 @@ spec:
                   authentication. More info: https://prometheus.io/docs/operating/configuration/#endpoint'
                 properties:
                   password:
-                    description: The secret in the service monitor namespace that
-                      contains the password for authentication.
+                    description: '`password` specifies a key of a Secret containing
+                      the password for authentication.'
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -93,8 +93,8 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   username:
-                    description: The secret in the service monitor namespace that
-                      contains the username for authentication.
+                    description: '`username` specifies a key of a Secret containing
+                      the username for authentication.'
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -246,8 +246,8 @@ spec:
                   2.27.0 and newer.
                 properties:
                   clientId:
-                    description: The secret or configmap containing the OAuth2 client
-                      id
+                    description: '`clientId` specifies a key of a Secret or ConfigMap
+                      containing the OAuth2 client''s ID.'
                     properties:
                       configMap:
                         description: ConfigMap containing data to use for the targets.
@@ -288,7 +288,8 @@ spec:
                         x-kubernetes-map-type: atomic
                     type: object
                   clientSecret:
-                    description: The secret containing the OAuth2 client secret
+                    description: '`clientSecret` specifies a key of a Secret containing
+                      the OAuth2 client''s secret.'
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -309,15 +310,18 @@ spec:
                   endpointParams:
                     additionalProperties:
                       type: string
-                    description: Parameters to append to the token URL
+                    description: '`endpointParams` configures the HTTP parameters
+                      to append to the token URL.'
                     type: object
                   scopes:
-                    description: OAuth2 scopes used for the token request
+                    description: '`scopes` defines the OAuth2 scopes used for the
+                      token request.'
                     items:
                       type: string
                     type: array
                   tokenUrl:
-                    description: The URL to fetch the token from
+                    description: '`tokenURL` configures the URL to fetch the token
+                      from.'
                     minLength: 1
                     type: string
                 required:

--- a/bundle/manifests/monitoring.rhobs_prometheusagents.yaml
+++ b/bundle/manifests/monitoring.rhobs_prometheusagents.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-    operator.prometheus.io/version: 0.69.0-rhobs1
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operator.prometheus.io/version: 0.71.0-rhobs1
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: observability-operator
@@ -994,8 +994,8 @@ spec:
                       `bearerTokenFile`."
                     properties:
                       password:
-                        description: The secret in the service monitor namespace that
-                          contains the password for authentication.
+                        description: '`password` specifies a key of a Secret containing
+                          the password for authentication.'
                         properties:
                           key:
                             description: The key of the secret to select from.  Must
@@ -1014,8 +1014,8 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       username:
-                        description: The secret in the service monitor namespace that
-                          contains the username for authentication.
+                        description: '`username` specifies a key of a Secret containing
+                          the username for authentication.'
                         properties:
                           key:
                             description: The key of the secret to select from.  Must
@@ -1037,13 +1037,13 @@ spec:
                   bearerToken:
                     description: "*Warning: this field shouldn't be used because the
                       token value appears in clear-text. Prefer using `authorization`.*
-                      \n *Deprecated: this will be removed in a future release.*"
+                      \n Deprecated: this will be removed in a future release."
                     type: string
                   bearerTokenFile:
                     description: "File to read bearer token for accessing apiserver.
                       \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                      or `bearerToken`. \n *Deprecated: this will be removed in a
-                      future release. Prefer using `authorization`.*"
+                      or `bearerToken`. \n Deprecated: this will be removed in a future
+                      release. Prefer using `authorization`."
                     type: string
                   host:
                     description: Kubernetes API address consisting of a hostname or
@@ -4055,6 +4055,15 @@ spec:
                 - warn
                 - error
                 type: string
+              maximumStartupDurationSeconds:
+                description: Defines the maximum time that the `prometheus` container's
+                  startup probe will wait before being considered failed. The startup
+                  probe will return success after the WAL replay is complete. If set,
+                  the value should be greater than 60 (seconds). Otherwise it will
+                  be equal to 600 seconds (15 minutes).
+                format: int32
+                minimum: 60
+                type: integer
               minReadySeconds:
                 description: "Minimum number of seconds for which a newly created
                   Pod should be ready without any of its container crashing for it
@@ -4084,6 +4093,28 @@ spec:
                 description: When a Prometheus deployment is paused, no actions except
                   for deletion will be performed on the underlying objects.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: The field controls if and how PVCs are deleted during
+                  the lifecycle of a StatefulSet. The default behavior is all PVCs
+                  are retained. This is an alpha field from kubernetes 1.23 until
+                  1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC
+                  feature gate.
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      deleted. The default policy of `Retain` causes PVCs to not be
+                      affected by StatefulSet deletion. The `Delete` policy causes
+                      those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      scaled down. The default policy of `Retain` causes PVCs to not
+                      be affected by a scaledown. The `Delete` policy causes the associated
+                      PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: "PodMetadata configures labels and annotations which
                   are propagated to the Prometheus pods. \n The following items are
@@ -4345,6 +4376,14 @@ spec:
                   when the field is set to the empty string (`\"\"`). \n Default:
                   \"prometheus\""
                 type: string
+              reloadStrategy:
+                description: Defines the strategy used to reload the Prometheus configuration.
+                  If not specified, the configuration is reloaded using the /-/reload
+                  HTTP endpoint.
+                enum:
+                - HTTP
+                - ProcessSignal
+                type: string
               remoteWrite:
                 description: Defines the list of remote write configurations.
                 items:
@@ -4401,7 +4440,7 @@ spec:
                           type: string
                         managedIdentity:
                           description: ManagedIdentity defines the Azure User-assigned
-                            Managed identity.
+                            Managed identity. Cannot be set at the same time as `oauth`.
                           properties:
                             clientId:
                               description: The client id
@@ -4409,8 +4448,51 @@ spec:
                           required:
                           - clientId
                           type: object
-                      required:
-                      - managedIdentity
+                        oauth:
+                          description: "OAuth defines the oauth config that is being
+                            used to authenticate. Cannot be set at the same time as
+                            `managedIdentity`. \n It requires Prometheus >= v2.48.0."
+                          properties:
+                            clientId:
+                              description: '`clientID` is the clientId of the Azure
+                                Active Directory application that is being used to
+                                authenticate.'
+                              minLength: 1
+                              type: string
+                            clientSecret:
+                              description: '`clientSecret` specifies a key of a Secret
+                                containing the client secret of the Azure Active Directory
+                                application that is being used to authenticate.'
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            tenantId:
+                              description: '`tenantID` is the tenant ID of the Azure
+                                Active Directory application that is being used to
+                                authenticate.'
+                              minLength: 1
+                              pattern: ^[0-9a-zA-Z-.]+$
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecret
+                          - tenantId
+                          type: object
                       type: object
                     basicAuth:
                       description: "BasicAuth configuration for the URL. \n Cannot
@@ -4418,8 +4500,8 @@ spec:
                         or `azureAd`."
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing
+                            the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -4438,8 +4520,8 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing
+                            the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -4461,13 +4543,16 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read bearer token for the URL.
-                        \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        \n Deprecated: this will be removed in a future release. Prefer
+                        using `authorization`."
                       type: string
+                    enableHTTP2:
+                      description: Whether to enable HTTP2.
+                      type: boolean
                     headers:
                       additionalProperties:
                         type: string
@@ -4502,8 +4587,8 @@ spec:
                         `sigv4`, `authorization`, `basicAuth`, or `azureAd`."
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2
-                            client id
+                          description: '`clientId` specifies a key of a Secret or
+                            ConfigMap containing the OAuth2 client''s ID.'
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -4547,7 +4632,8 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
+                          description: '`clientSecret` specifies a key of a Secret
+                            containing the OAuth2 client''s secret.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -4568,15 +4654,18 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
+                          description: '`endpointParams` configures the HTTP parameters
+                            to append to the token URL.'
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
+                          description: '`scopes` defines the OAuth2 scopes used for
+                            the token request.'
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
+                          description: '`tokenURL` configures the URL to fetch the
+                            token from.'
                           minLength: 1
                           type: string
                       required:
@@ -5398,8 +5487,8 @@ spec:
                 description: Storage defines the storage used by Prometheus.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -5951,7 +6040,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes
@@ -6142,9 +6231,14 @@ spec:
               topologySpreadConstraints:
                 description: Defines the pod's topology spread constraints if specified.
                 items:
-                  description: TopologySpreadConstraint specifies how to spread matching
-                    pods among the given topology.
                   properties:
+                    additionalLabelSelectors:
+                      description: Defines what Prometheus Operator managed labels
+                        should be added to labelSelector on the topologySpreadConstraint.
+                      enum:
+                      - OnResource
+                      - OnShard
+                      type: string
                     labelSelector:
                       description: LabelSelector is used to find matching pods. Pods
                         that match this label selector are counted to determine the
@@ -8376,6 +8470,10 @@ spec:
                   Prometheus deployment (their labels match the selector).
                 format: int32
                 type: integer
+              selector:
+                description: The selector used to match the pods targeted by this
+                  Prometheus resource.
+                type: string
               shardStatuses:
                 description: The list has one entry per shard. Each entry provides
                   a summary of the shard status.
@@ -8414,6 +8512,10 @@ spec:
                 x-kubernetes-list-map-keys:
                 - shardID
                 x-kubernetes-list-type: map
+              shards:
+                description: Shards is the most recently observed number of shards.
+                format: int32
+                type: integer
               unavailableReplicas:
                 description: Total number of unavailable pods targeted by this Prometheus
                   deployment.
@@ -8437,6 +8539,10 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.shards
+        statusReplicasPath: .status.shards
       status: {}
 status:
   acceptedNames:

--- a/bundle/manifests/monitoring.rhobs_prometheuses.yaml
+++ b/bundle/manifests/monitoring.rhobs_prometheuses.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-    operator.prometheus.io/version: 0.69.0-rhobs1
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operator.prometheus.io/version: 0.71.0-rhobs1
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: observability-operator
@@ -1055,8 +1055,8 @@ spec:
                             `authorization` or `sigv4`."
                           properties:
                             password:
-                              description: The secret in the service monitor namespace
-                                that contains the password for authentication.
+                              description: '`password` specifies a key of a Secret
+                                containing the password for authentication.'
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must
@@ -1076,8 +1076,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             username:
-                              description: The secret in the service monitor namespace
-                                that contains the username for authentication.
+                              description: '`username` specifies a key of a Secret
+                                containing the username for authentication.'
                               properties:
                                 key:
                                   description: The key of the secret to select from.  Must
@@ -1100,8 +1100,8 @@ spec:
                         bearerTokenFile:
                           description: "File to read bearer token for Alertmanager.
                             \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                            or `sigv4`. \n *Deprecated: this will be removed in a
-                            future release. Prefer using `authorization`.*"
+                            or `sigv4`. \n Deprecated: this will be removed in a future
+                            release. Prefer using `authorization`."
                           type: string
                         enableHttp2:
                           description: Whether to enable HTTP2.
@@ -1342,9 +1342,9 @@ spec:
                 type: object
               allowOverlappingBlocks:
                 description: "AllowOverlappingBlocks enables vertical compaction and
-                  vertical query merge in Prometheus. \n *Deprecated: this flag has
+                  vertical query merge in Prometheus. \n Deprecated: this flag has
                   no effect for Prometheus >= 2.39.0 where overlapping blocks are
-                  enabled by default.*"
+                  enabled by default."
                 type: boolean
               apiserverConfig:
                 description: 'APIServerConfig allows specifying a host and auth methods
@@ -1392,8 +1392,8 @@ spec:
                       `bearerTokenFile`."
                     properties:
                       password:
-                        description: The secret in the service monitor namespace that
-                          contains the password for authentication.
+                        description: '`password` specifies a key of a Secret containing
+                          the password for authentication.'
                         properties:
                           key:
                             description: The key of the secret to select from.  Must
@@ -1412,8 +1412,8 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       username:
-                        description: The secret in the service monitor namespace that
-                          contains the username for authentication.
+                        description: '`username` specifies a key of a Secret containing
+                          the username for authentication.'
                         properties:
                           key:
                             description: The key of the secret to select from.  Must
@@ -1435,13 +1435,13 @@ spec:
                   bearerToken:
                     description: "*Warning: this field shouldn't be used because the
                       token value appears in clear-text. Prefer using `authorization`.*
-                      \n *Deprecated: this will be removed in a future release.*"
+                      \n Deprecated: this will be removed in a future release."
                     type: string
                   bearerTokenFile:
                     description: "File to read bearer token for accessing apiserver.
                       \n Cannot be set at the same time as `basicAuth`, `authorization`,
-                      or `bearerToken`. \n *Deprecated: this will be removed in a
-                      future release. Prefer using `authorization`.*"
+                      or `bearerToken`. \n Deprecated: this will be removed in a future
+                      release. Prefer using `authorization`."
                     type: string
                   host:
                     description: Kubernetes API address consisting of a hostname or
@@ -1595,7 +1595,7 @@ spec:
                     type: boolean
                 type: object
               baseImage:
-                description: '*Deprecated: use ''spec.image'' instead.*'
+                description: 'Deprecated: use ''spec.image'' instead.'
                 type: string
               bodySizeLimit:
                 description: BodySizeLimit defines per-scrape on response body size.
@@ -4486,6 +4486,15 @@ spec:
                 - warn
                 - error
                 type: string
+              maximumStartupDurationSeconds:
+                description: Defines the maximum time that the `prometheus` container's
+                  startup probe will wait before being considered failed. The startup
+                  probe will return success after the WAL replay is complete. If set,
+                  the value should be greater than 60 (seconds). Otherwise it will
+                  be equal to 600 seconds (15 minutes).
+                format: int32
+                minimum: 60
+                type: integer
               minReadySeconds:
                 description: "Minimum number of seconds for which a newly created
                   Pod should be ready without any of its container crashing for it
@@ -4515,6 +4524,28 @@ spec:
                 description: When a Prometheus deployment is paused, no actions except
                   for deletion will be performed on the underlying objects.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: The field controls if and how PVCs are deleted during
+                  the lifecycle of a StatefulSet. The default behavior is all PVCs
+                  are retained. This is an alpha field from kubernetes 1.23 until
+                  1.26 and a beta field from 1.26. It requires enabling the StatefulSetAutoDeletePVC
+                  feature gate.
+                properties:
+                  whenDeleted:
+                    description: WhenDeleted specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      deleted. The default policy of `Retain` causes PVCs to not be
+                      affected by StatefulSet deletion. The `Delete` policy causes
+                      those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: WhenScaled specifies what happens to PVCs created
+                      from StatefulSet VolumeClaimTemplates when the StatefulSet is
+                      scaled down. The default policy of `Retain` causes PVCs to not
+                      be affected by a scaledown. The `Delete` policy causes the associated
+                      PVCs for any excess pods above the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: "PodMetadata configures labels and annotations which
                   are propagated to the Prometheus pods. \n The following items are
@@ -4779,8 +4810,8 @@ spec:
               prometheusRulesExcludedFromEnforce:
                 description: 'Defines the list of PrometheusRule objects to which
                   the namespace label enforcement doesn''t apply. This is only relevant
-                  when `spec.enforcedNamespaceLabel` is set to true. *Deprecated:
-                  use `spec.excludedFromEnforcement` instead.*'
+                  when `spec.enforcedNamespaceLabel` is set to true. Deprecated: use
+                  `spec.excludedFromEnforcement` instead.'
                 items:
                   description: PrometheusRuleExcludeConfig enables users to configure
                     excluded PrometheusRule names and their namespaces to be ignored
@@ -4833,6 +4864,14 @@ spec:
                   can be set to a standard I/O stream, e.g. `/dev/stdout`, to log
                   query information to the default Prometheus log stream."
                 type: string
+              reloadStrategy:
+                description: Defines the strategy used to reload the Prometheus configuration.
+                  If not specified, the configuration is reloaded using the /-/reload
+                  HTTP endpoint.
+                enum:
+                - HTTP
+                - ProcessSignal
+                type: string
               remoteRead:
                 description: Defines the list of remote read configurations.
                 items:
@@ -4879,8 +4918,8 @@ spec:
                         be set at the same time as `authorization`, or `oauth2`."
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing
+                            the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -4899,8 +4938,8 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing
+                            the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -4922,12 +4961,12 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read the bearer token for the
-                        URL. \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        URL. \n Deprecated: this will be removed in a future release.
+                        Prefer using `authorization`."
                       type: string
                     filterExternalLabels:
                       description: "Whether to use the external labels as selectors
@@ -4958,8 +4997,8 @@ spec:
                         `authorization`, or `basicAuth`."
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2
-                            client id
+                          description: '`clientId` specifies a key of a Secret or
+                            ConfigMap containing the OAuth2 client''s ID.'
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -5003,7 +5042,8 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
+                          description: '`clientSecret` specifies a key of a Secret
+                            containing the OAuth2 client''s secret.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -5024,15 +5064,18 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
+                          description: '`endpointParams` configures the HTTP parameters
+                            to append to the token URL.'
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
+                          description: '`scopes` defines the OAuth2 scopes used for
+                            the token request.'
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
+                          description: '`tokenURL` configures the URL to fetch the
+                            token from.'
                           minLength: 1
                           type: string
                       required:
@@ -5251,7 +5294,7 @@ spec:
                           type: string
                         managedIdentity:
                           description: ManagedIdentity defines the Azure User-assigned
-                            Managed identity.
+                            Managed identity. Cannot be set at the same time as `oauth`.
                           properties:
                             clientId:
                               description: The client id
@@ -5259,8 +5302,51 @@ spec:
                           required:
                           - clientId
                           type: object
-                      required:
-                      - managedIdentity
+                        oauth:
+                          description: "OAuth defines the oauth config that is being
+                            used to authenticate. Cannot be set at the same time as
+                            `managedIdentity`. \n It requires Prometheus >= v2.48.0."
+                          properties:
+                            clientId:
+                              description: '`clientID` is the clientId of the Azure
+                                Active Directory application that is being used to
+                                authenticate.'
+                              minLength: 1
+                              type: string
+                            clientSecret:
+                              description: '`clientSecret` specifies a key of a Secret
+                                containing the client secret of the Azure Active Directory
+                                application that is being used to authenticate.'
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            tenantId:
+                              description: '`tenantID` is the tenant ID of the Azure
+                                Active Directory application that is being used to
+                                authenticate.'
+                              minLength: 1
+                              pattern: ^[0-9a-zA-Z-.]+$
+                              type: string
+                          required:
+                          - clientId
+                          - clientSecret
+                          - tenantId
+                          type: object
                       type: object
                     basicAuth:
                       description: "BasicAuth configuration for the URL. \n Cannot
@@ -5268,8 +5354,8 @@ spec:
                         or `azureAd`."
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing
+                            the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -5288,8 +5374,8 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing
+                            the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -5311,13 +5397,16 @@ spec:
                     bearerToken:
                       description: "*Warning: this field shouldn't be used because
                         the token value appears in clear-text. Prefer using `authorization`.*
-                        \n *Deprecated: this will be removed in a future release.*"
+                        \n Deprecated: this will be removed in a future release."
                       type: string
                     bearerTokenFile:
                       description: "File from which to read bearer token for the URL.
-                        \n *Deprecated: this will be removed in a future release.
-                        Prefer using `authorization`.*"
+                        \n Deprecated: this will be removed in a future release. Prefer
+                        using `authorization`."
                       type: string
+                    enableHTTP2:
+                      description: Whether to enable HTTP2.
+                      type: boolean
                     headers:
                       additionalProperties:
                         type: string
@@ -5352,8 +5441,8 @@ spec:
                         `sigv4`, `authorization`, `basicAuth`, or `azureAd`."
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2
-                            client id
+                          description: '`clientId` specifies a key of a Secret or
+                            ConfigMap containing the OAuth2 client''s ID.'
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -5397,7 +5486,8 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
+                          description: '`clientSecret` specifies a key of a Secret
+                            containing the OAuth2 client''s secret.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -5418,15 +5508,18 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
+                          description: '`endpointParams` configures the HTTP parameters
+                            to append to the token URL.'
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
+                          description: '`scopes` defines the OAuth2 scopes used for
+                            the token request.'
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
+                          description: '`tokenURL` configures the URL to fetch the
+                            token from.'
                           minLength: 1
                           type: string
                       required:
@@ -6358,8 +6451,8 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               sha:
-                description: '*Deprecated: use ''spec.image'' instead. The image''s
-                  digest can be specified as part of the image name.*'
+                description: 'Deprecated: use ''spec.image'' instead. The image''s
+                  digest can be specified as part of the image name.'
                 type: string
               shards:
                 description: "EXPERIMENTAL: Number of shards to distribute targets
@@ -6378,8 +6471,8 @@ spec:
                 description: Storage defines the storage used by Prometheus.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -6931,7 +7024,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes
@@ -7074,8 +7167,8 @@ spec:
                     type: object
                 type: object
               tag:
-                description: '*Deprecated: use ''spec.image'' instead. The image''s
-                  tag can be specified as part of the image name.*'
+                description: 'Deprecated: use ''spec.image'' instead. The image''s
+                  tag can be specified as part of the image name.'
                 type: string
               targetLimit:
                 description: TargetLimit defines a limit on the number of scraped
@@ -7112,7 +7205,7 @@ spec:
                       type: object
                     type: array
                   baseImage:
-                    description: '*Deprecated: use ''image'' instead.*'
+                    description: 'Deprecated: use ''image'' instead.'
                     type: string
                   blockSize:
                     default: 2h
@@ -7289,8 +7382,8 @@ spec:
                       when the operator was released."
                     type: string
                   listenLocal:
-                    description: '*Deprecated: use `grpcListenLocal` and `httpListenLocal`
-                      instead.*'
+                    description: 'Deprecated: use `grpcListenLocal` and `httpListenLocal`
+                      instead.'
                     type: boolean
                   logFormat:
                     description: Log format for the Thanos sidecar.
@@ -7397,12 +7490,12 @@ spec:
                         type: object
                     type: object
                   sha:
-                    description: '*Deprecated: use ''image'' instead.  The image digest
-                      can be specified as part of the image name.*'
+                    description: 'Deprecated: use ''image'' instead.  The image digest
+                      can be specified as part of the image name.'
                     type: string
                   tag:
-                    description: '*Deprecated: use ''image'' instead. The image''s
-                      tag can be specified as part of the image name.*'
+                    description: 'Deprecated: use ''image'' instead. The image''s
+                      tag can be specified as as part of the image name.'
                     type: string
                   tracingConfig:
                     description: "Defines the tracing configuration for the Thanos
@@ -7527,9 +7620,14 @@ spec:
               topologySpreadConstraints:
                 description: Defines the pod's topology spread constraints if specified.
                 items:
-                  description: TopologySpreadConstraint specifies how to spread matching
-                    pods among the given topology.
                   properties:
+                    additionalLabelSelectors:
+                      description: Defines what Prometheus Operator managed labels
+                        should be added to labelSelector on the topologySpreadConstraint.
+                      enum:
+                      - OnResource
+                      - OnShard
+                      type: string
                     labelSelector:
                       description: LabelSelector is used to find matching pods. Pods
                         that match this label selector are counted to determine the
@@ -9775,6 +9873,10 @@ spec:
                   Prometheus deployment (their labels match the selector).
                 format: int32
                 type: integer
+              selector:
+                description: The selector used to match the pods targeted by this
+                  Prometheus resource.
+                type: string
               shardStatuses:
                 description: The list has one entry per shard. Each entry provides
                   a summary of the shard status.
@@ -9813,6 +9915,10 @@ spec:
                 x-kubernetes-list-map-keys:
                 - shardID
                 x-kubernetes-list-type: map
+              shards:
+                description: Shards is the most recently observed number of shards.
+                format: int32
+                type: integer
               unavailableReplicas:
                 description: Total number of unavailable pods targeted by this Prometheus
                   deployment.
@@ -9836,6 +9942,10 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.shards
+        statusReplicasPath: .status.shards
       status: {}
 status:
   acceptedNames:

--- a/bundle/manifests/monitoring.rhobs_prometheusrules.yaml
+++ b/bundle/manifests/monitoring.rhobs_prometheusrules.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-    operator.prometheus.io/version: 0.69.0-rhobs1
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operator.prometheus.io/version: 0.71.0-rhobs1
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: observability-operator

--- a/bundle/manifests/monitoring.rhobs_scrapeconfigs.yaml
+++ b/bundle/manifests/monitoring.rhobs_scrapeconfigs.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-    operator.prometheus.io/version: 0.69.0-rhobs1
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operator.prometheus.io/version: 0.71.0-rhobs1
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: observability-operator
@@ -69,12 +69,79 @@ spec:
                       \n \"Basic\" is not a supported value. \n Default: \"Bearer\""
                     type: string
                 type: object
+              azureSDConfigs:
+                description: AzureSDConfigs defines a list of Azure service discovery
+                  configurations.
+                items:
+                  description: AzureSDConfig allow retrieving scrape targets from
+                    Azure VMs. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#azure_sd_config
+                  properties:
+                    authenticationMethod:
+                      description: '# The authentication method, either OAuth or ManagedIdentity.
+                        See https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview'
+                      enum:
+                      - OAuth
+                      - ManagedIdentity
+                      type: string
+                    clientID:
+                      description: Optional client ID. Only required with the OAuth
+                        authentication method.
+                      type: string
+                    clientSecret:
+                      description: Optional client secret. Only required with the
+                        OAuth authentication method.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    environment:
+                      description: The Azure environment.
+                      type: string
+                    port:
+                      description: The port to scrape metrics from. If using the public
+                        IP address, this must instead be specified in the relabeling
+                        rule.
+                      type: integer
+                    refreshInterval:
+                      description: RefreshInterval configures the refresh interval
+                        at which Prometheus will re-read the instance list.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    resourceGroup:
+                      description: Optional resource group name. Limits discovery
+                        to this resource group.
+                      type: string
+                    subscriptionID:
+                      description: The subscription ID. Always required.
+                      minLength: 1
+                      type: string
+                    tenantID:
+                      description: Optional tenant ID. Only required with the OAuth
+                        authentication method.
+                      type: string
+                  required:
+                  - subscriptionID
+                  type: object
+                type: array
               basicAuth:
                 description: BasicAuth information to use on every scrape request.
                 properties:
                   password:
-                    description: The secret in the service monitor namespace that
-                      contains the password for authentication.
+                    description: '`password` specifies a key of a Secret containing
+                      the password for authentication.'
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -93,8 +160,8 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   username:
-                    description: The secret in the service monitor namespace that
-                      contains the username for authentication.
+                    description: '`username` specifies a key of a Secret containing
+                      the username for authentication.'
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -120,7 +187,7 @@ spec:
                   description: ConsulSDConfig defines a Consul service discovery configuration
                     See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#consul_sd_config
                   properties:
-                    allow_stale:
+                    allowStale:
                       description: Allow stale Consul results (see https://www.consul.io/api/features/consistency.html).
                         Will reduce load on Consul. If unset, Prometheus uses its
                         default value.
@@ -160,8 +227,8 @@ spec:
                         the Consul Server. More info: https://prometheus.io/docs/operating/configuration/#endpoints'
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing
+                            the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -180,8 +247,8 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing
+                            the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -204,23 +271,24 @@ spec:
                       description: Consul Datacenter name, if not provided it will
                         use the local Consul Agent Datacenter.
                       type: string
-                    enable_http2:
+                    enableHTTP2:
                       description: Whether to enable HTTP2. If unset, Prometheus uses
                         its default value.
                       type: boolean
-                    follow_redirects:
+                    followRedirects:
                       description: Configure whether HTTP requests follow HTTP 3xx
                         redirects. If unset, Prometheus uses its default value.
                       type: boolean
                     namespace:
                       description: Namespaces are only supported in Consul Enterprise.
                       type: string
-                    no_proxy:
-                      description: Comma-separated string that can contain IPs, CIDR
-                        notation, domain names that should be excluded from proxying.
-                        IP and domain names can contain port numbers.
+                    noProxy:
+                      description: "`noProxy` is a comma-separated string that can
+                        contain IPs, CIDR notation, domain names that should be excluded
+                        from proxying. IP and domain names can contain port numbers.
+                        \n It requires Prometheus >= v2.43.0."
                       type: string
-                    node_meta:
+                    nodeMeta:
                       additionalProperties:
                         type: string
                       description: Node metadata key/value pairs to filter nodes for
@@ -231,8 +299,8 @@ spec:
                       description: Optional OAuth 2.0 configuration.
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2
-                            client id
+                          description: '`clientId` specifies a key of a Secret or
+                            ConfigMap containing the OAuth2 client''s ID.'
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -276,7 +344,8 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
+                          description: '`clientSecret` specifies a key of a Secret
+                            containing the OAuth2 client''s secret.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -297,15 +366,18 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
+                          description: '`endpointParams` configures the HTTP parameters
+                            to append to the token URL.'
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
+                          description: '`scopes` defines the OAuth2 scopes used for
+                            the token request.'
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
+                          description: '`tokenURL` configures the URL to fetch the
+                            token from.'
                           minLength: 1
                           type: string
                       required:
@@ -316,7 +388,7 @@ spec:
                     partition:
                       description: Admin Partitions are only supported in Consul Enterprise.
                       type: string
-                    proxy_connect_header:
+                    proxyConnectHeader:
                       additionalProperties:
                         description: SecretKeySelector selects a key of a Secret.
                         properties:
@@ -335,19 +407,24 @@ spec:
                         required:
                         - key
                         type: object
-                      description: Specifies headers to send to proxies during CONNECT
-                        requests.
+                        x-kubernetes-map-type: atomic
+                      description: "ProxyConnectHeader optionally specifies headers
+                        to send to proxies during CONNECT requests. \n It requires
+                        Prometheus >= v2.43.0."
                       type: object
                       x-kubernetes-map-type: atomic
-                    proxy_from_environment:
-                      description: Use proxy URL indicated by environment variables
-                        (HTTP_PROXY, https_proxy, HTTPs_PROXY, https_proxy, and no_proxy)
-                        If unset, Prometheus uses its default value.
+                    proxyFromEnvironment:
+                      description: "Whether to use the proxy configuration defined
+                        by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+                        If unset, Prometheus uses its default value. \n It requires
+                        Prometheus >= v2.43.0."
                       type: boolean
-                    proxy_url:
-                      description: Optional proxy URL.
+                    proxyUrl:
+                      description: "`proxyURL` defines the HTTP proxy server to use.
+                        \n It requires Prometheus >= v2.43.0."
+                      pattern: ^http(s)?://.+$
                       type: string
-                    refresh_interval:
+                    refreshInterval:
                       description: The time after which the provided names are refreshed.
                         On large setup it might be a good idea to increase this value
                         because the catalog will change all the time. If unset, Prometheus
@@ -372,7 +449,7 @@ spec:
                         type: string
                       type: array
                       x-kubernetes-list-type: atomic
-                    tag_separator:
+                    tagSeparator:
                       description: The string by which Consul tags are joined into
                         the tag label. If unset, Prometheus uses its default value.
                       type: string
@@ -521,6 +598,7 @@ spec:
                       required:
                       - key
                       type: object
+                      x-kubernetes-map-type: atomic
                   required:
                   - server
                   type: object
@@ -591,6 +669,7 @@ spec:
                       required:
                       - key
                       type: object
+                      x-kubernetes-map-type: atomic
                     filters:
                       description: 'Filters can be used optionally to filter the instance
                         list by other criteria. Available filter criteria can be found
@@ -645,6 +724,7 @@ spec:
                       required:
                       - key
                       type: object
+                      x-kubernetes-map-type: atomic
                   type: object
                 type: array
               fileSDConfigs:
@@ -673,6 +753,55 @@ spec:
                       type: string
                   required:
                   - files
+                  type: object
+                type: array
+              gceSDConfigs:
+                description: GCESDConfigs defines a list of GCE service discovery
+                  configurations.
+                items:
+                  description: "GCESDConfig configures scrape targets from GCP GCE
+                    instances. The private IP address is used by default, but may
+                    be changed to the public IP address with relabeling. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#gce_sd_config
+                    \n The GCE service discovery will load the Google Cloud credentials
+                    from the file specified by the GOOGLE_APPLICATION_CREDENTIALS
+                    environment variable. See https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform
+                    \n A pre-requisite for using GCESDConfig is that a Secret containing
+                    valid Google Cloud credentials is mounted into the Prometheus
+                    or PrometheusAgent pod via the `.spec.secrets` field and that
+                    the GOOGLE_APPLICATION_CREDENTIALS environment variable is set
+                    to /etc/prometheus/secrets/<secret-name>/<credentials-filename.json>."
+                  properties:
+                    filter:
+                      description: 'Filter can be used optionally to filter the instance
+                        list by other criteria Syntax of this filter is described
+                        in the filter query parameter section: https://cloud.google.com/compute/docs/reference/latest/instances/list'
+                      type: string
+                    port:
+                      description: The port to scrape metrics from. If using the public
+                        IP address, this must instead be specified in the relabeling
+                        rule.
+                      type: integer
+                    project:
+                      description: The Google Cloud Project ID
+                      minLength: 1
+                      type: string
+                    refreshInterval:
+                      description: RefreshInterval configures the refresh interval
+                        at which Prometheus will re-read the instance list.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    tagSeparator:
+                      description: The tag separator is used to separate the tags
+                        on concatenation
+                      type: string
+                    zone:
+                      description: The zone of the scrape targets. If you need multiple
+                        zones use multiple GCESDConfigs.
+                      minLength: 1
+                      type: string
+                  required:
+                  - project
+                  - zone
                   type: object
                 type: array
               honorLabels:
@@ -725,8 +854,8 @@ spec:
                         the target HTTP endpoint. More info: https://prometheus.io/docs/operating/configuration/#endpoints'
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing
+                            the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -745,8 +874,8 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing
+                            the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -765,6 +894,48 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
+                    noProxy:
+                      description: "`noProxy` is a comma-separated string that can
+                        contain IPs, CIDR notation, domain names that should be excluded
+                        from proxying. IP and domain names can contain port numbers.
+                        \n It requires Prometheus >= v2.43.0."
+                      type: string
+                    proxyConnectHeader:
+                      additionalProperties:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      description: "ProxyConnectHeader optionally specifies headers
+                        to send to proxies during CONNECT requests. \n It requires
+                        Prometheus >= v2.43.0."
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: "Whether to use the proxy configuration defined
+                        by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+                        If unset, Prometheus uses its default value. \n It requires
+                        Prometheus >= v2.43.0."
+                      type: boolean
+                    proxyUrl:
+                      description: "`proxyURL` defines the HTTP proxy server to use.
+                        \n It requires Prometheus >= v2.43.0."
+                      pattern: ^http(s)?://.+$
+                      type: string
                     refreshInterval:
                       description: RefreshInterval configures the refresh interval
                         at which Prometheus will re-query the endpoint to update the
@@ -912,12 +1083,272 @@ spec:
                   description: KubernetesSDConfig allows retrieving scrape targets
                     from Kubernetes' REST API. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config
                   properties:
+                    apiServer:
+                      description: The API server address consisting of a hostname
+                        or IP address followed by an optional port number. If left
+                        empty, Prometheus is assumed to run inside of the cluster.
+                        It will discover API servers automatically and use the pod's
+                        CA certificate and bearer token file at /var/run/secrets/kubernetes.io/serviceaccount/.
+                      type: string
+                    attachMetadata:
+                      description: Optional metadata to attach to discovered targets.
+                        It requires Prometheus >= v2.35.0 for `pod` role and Prometheus
+                        >= v2.37.0 for `endpoints` and `endpointslice` roles.
+                      properties:
+                        node:
+                          description: Attaches node metadata to discovered targets.
+                            When set to true, Prometheus must have the `get` permission
+                            on the `Nodes` objects. Only valid for Pod, Endpoint and
+                            Endpointslice roles.
+                          type: boolean
+                      type: object
+                    authorization:
+                      description: Authorization header to use on every scrape request.
+                        Cannot be set at the same time as `basicAuth`, or `oauth2`.
+                      properties:
+                        credentials:
+                          description: Selects a key of a Secret in the namespace
+                            that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type:
+                          description: "Defines the authentication type. The value
+                            is case-insensitive. \n \"Basic\" is not a supported value.
+                            \n Default: \"Bearer\""
+                          type: string
+                      type: object
+                    basicAuth:
+                      description: BasicAuth information to use on every scrape request.
+                        Cannot be set at the same time as `authorization`, or `oauth2`.
+                      properties:
+                        password:
+                          description: '`password` specifies a key of a Secret containing
+                            the password for authentication.'
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        username:
+                          description: '`username` specifies a key of a Secret containing
+                            the username for authentication.'
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    enableHTTP2:
+                      description: Whether to enable HTTP2.
+                      type: boolean
+                    followRedirects:
+                      description: Configure whether HTTP requests follow HTTP 3xx
+                        redirects.
+                      type: boolean
+                    namespaces:
+                      description: Optional namespace discovery. If omitted, Prometheus
+                        discovers targets across all namespaces.
+                      properties:
+                        names:
+                          description: List of namespaces where to watch for resources.
+                            If empty and `ownNamespace` isn't true, Prometheus watches
+                            for resources in all namespaces.
+                          items:
+                            type: string
+                          type: array
+                        ownNamespace:
+                          description: Includes the namespace in which the Prometheus
+                            pod exists to the list of watched namesapces.
+                          type: boolean
+                      type: object
+                    noProxy:
+                      description: "`noProxy` is a comma-separated string that can
+                        contain IPs, CIDR notation, domain names that should be excluded
+                        from proxying. IP and domain names can contain port numbers.
+                        \n It requires Prometheus >= v2.43.0."
+                      type: string
+                    oauth2:
+                      description: Optional OAuth 2.0 configuration. Cannot be set
+                        at the same time as `authorization`, or `basicAuth`.
+                      properties:
+                        clientId:
+                          description: '`clientId` specifies a key of a Secret or
+                            ConfigMap containing the OAuth2 client''s ID.'
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        clientSecret:
+                          description: '`clientSecret` specifies a key of a Secret
+                            containing the OAuth2 client''s secret.'
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        endpointParams:
+                          additionalProperties:
+                            type: string
+                          description: '`endpointParams` configures the HTTP parameters
+                            to append to the token URL.'
+                          type: object
+                        scopes:
+                          description: '`scopes` defines the OAuth2 scopes used for
+                            the token request.'
+                          items:
+                            type: string
+                          type: array
+                        tokenUrl:
+                          description: '`tokenURL` configures the URL to fetch the
+                            token from.'
+                          minLength: 1
+                          type: string
+                      required:
+                      - clientId
+                      - clientSecret
+                      - tokenUrl
+                      type: object
+                    proxyConnectHeader:
+                      additionalProperties:
+                        description: SecretKeySelector selects a key of a Secret.
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      description: "ProxyConnectHeader optionally specifies headers
+                        to send to proxies during CONNECT requests. \n It requires
+                        Prometheus >= v2.43.0."
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    proxyFromEnvironment:
+                      description: "Whether to use the proxy configuration defined
+                        by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+                        If unset, Prometheus uses its default value. \n It requires
+                        Prometheus >= v2.43.0."
+                      type: boolean
+                    proxyUrl:
+                      description: "`proxyURL` defines the HTTP proxy server to use.
+                        \n It requires Prometheus >= v2.43.0."
+                      pattern: ^http(s)?://.+$
+                      type: string
                     role:
                       description: Role of the Kubernetes entities that should be
                         discovered.
                       enum:
                       - Node
                       - node
+                      - Service
+                      - service
+                      - Pod
+                      - pod
+                      - Endpoints
+                      - endpoints
+                      - EndpointSlice
+                      - endpointslice
+                      - Ingress
+                      - ingress
                       type: string
                     selectors:
                       description: Selector to select objects.
@@ -929,11 +1360,20 @@ spec:
                           label:
                             type: string
                           role:
-                            description: K8SRole is role of the service in Kubernetes.
-                              Currently the only supported role is "Node".
+                            description: Role is role of the service in Kubernetes.
                             enum:
                             - Node
                             - node
+                            - Service
+                            - service
+                            - Pod
+                            - pod
+                            - Endpoints
+                            - endpoints
+                            - EndpointSlice
+                            - endpointslice
+                            - Ingress
+                            - ingress
                             type: string
                         required:
                         - role
@@ -942,6 +1382,125 @@ spec:
                       x-kubernetes-list-map-keys:
                       - role
                       x-kubernetes-list-type: map
+                    tlsConfig:
+                      description: TLS configuration to use on every scrape request.
+                      properties:
+                        ca:
+                          description: Certificate authority used when verifying server
+                            certificates.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description: Client certificate to present when doing client-authentication.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description: Disable target certificate validation.
+                          type: boolean
+                        keySecret:
+                          description: Secret containing the client key file for the
+                            targets.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        serverName:
+                          description: Used to verify the hostname for the targets.
+                          type: string
+                      type: object
                   required:
                   - role
                   type: object
@@ -1039,6 +1598,261 @@ spec:
                 description: MetricsPath HTTP path to scrape for metrics. If empty,
                   Prometheus uses the default value (e.g. /metrics).
                 type: string
+              noProxy:
+                description: "`noProxy` is a comma-separated string that can contain
+                  IPs, CIDR notation, domain names that should be excluded from proxying.
+                  IP and domain names can contain port numbers. \n It requires Prometheus
+                  >= v2.43.0."
+                type: string
+              openstackSDConfigs:
+                description: OpenStackSDConfigs defines a list of OpenStack service
+                  discovery configurations.
+                items:
+                  description: OpenStackSDConfig allow retrieving scrape targets from
+                    OpenStack Nova instances. See https://prometheus.io/docs/prometheus/latest/configuration/configuration/#openstack_sd_config
+                  properties:
+                    allTenants:
+                      description: Whether the service discovery should list all instances
+                        for all projects. It is only relevant for the 'instance' role
+                        and usually requires admin permissions.
+                      type: boolean
+                    applicationCredentialId:
+                      description: ApplicationCredentialID
+                      type: string
+                    applicationCredentialName:
+                      description: The ApplicationCredentialID or ApplicationCredentialName
+                        fields are required if using an application credential to
+                        authenticate. Some providers allow you to create an application
+                        credential to authenticate rather than a password.
+                      type: string
+                    applicationCredentialSecret:
+                      description: The applicationCredentialSecret field is required
+                        if using an application credential to authenticate.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    availability:
+                      description: Availability of the endpoint to connect to.
+                      enum:
+                      - Public
+                      - public
+                      - Admin
+                      - admin
+                      - Internal
+                      - internal
+                      type: string
+                    domainID:
+                      description: DomainID
+                      type: string
+                    domainName:
+                      description: At most one of domainId and domainName must be
+                        provided if using username with Identity V3. Otherwise, either
+                        are optional.
+                      type: string
+                    identityEndpoint:
+                      description: IdentityEndpoint specifies the HTTP endpoint that
+                        is required to work with the Identity API of the appropriate
+                        version.
+                      type: string
+                    password:
+                      description: Password for the Identity V2 and V3 APIs. Consult
+                        with your provider's control panel to discover your account's
+                        preferred method of authentication.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    port:
+                      description: The port to scrape metrics from. If using the public
+                        IP address, this must instead be specified in the relabeling
+                        rule.
+                      type: integer
+                    projectID:
+                      description: ProjectID
+                      type: string
+                    projectName:
+                      description: The ProjectId and ProjectName fields are optional
+                        for the Identity V2 API. Some providers allow you to specify
+                        a ProjectName instead of the ProjectId. Some require both.
+                        Your provider's authentication policies will determine how
+                        these fields influence authentication.
+                      type: string
+                    refreshInterval:
+                      description: Refresh interval to re-read the instance list.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
+                    region:
+                      description: The OpenStack Region.
+                      minLength: 1
+                      type: string
+                    role:
+                      description: The OpenStack role of entities that should be discovered.
+                      enum:
+                      - Instance
+                      - instance
+                      - Hypervisor
+                      - hypervisor
+                      type: string
+                    tlsConfig:
+                      description: TLS configuration applying to the target HTTP endpoint.
+                      properties:
+                        ca:
+                          description: Certificate authority used when verifying server
+                            certificates.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        cert:
+                          description: Client certificate to present when doing client-authentication.
+                          properties:
+                            configMap:
+                              description: ConfigMap containing data to use for the
+                                targets.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secret:
+                              description: Secret containing data to use for the targets.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        insecureSkipVerify:
+                          description: Disable target certificate validation.
+                          type: boolean
+                        keySecret:
+                          description: Secret containing the client key file for the
+                            targets.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        serverName:
+                          description: Used to verify the hostname for the targets.
+                          type: string
+                      type: object
+                    userid:
+                      description: UserID
+                      type: string
+                    username:
+                      description: Username is required if using Identity V2 API.
+                        Consult with your provider's control panel to discover your
+                        account's username. In Identity V3, either userid or a combination
+                        of username and domainId or domainName are needed
+                      type: string
+                  required:
+                  - region
+                  - role
+                  type: object
+                type: array
               params:
                 additionalProperties:
                   items:
@@ -1047,6 +1861,40 @@ spec:
                 description: Optional HTTP URL parameters
                 type: object
                 x-kubernetes-map-type: atomic
+              proxyConnectHeader:
+                additionalProperties:
+                  description: SecretKeySelector selects a key of a Secret.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                    optional:
+                      description: Specify whether the Secret or its key must be defined
+                      type: boolean
+                  required:
+                  - key
+                  type: object
+                  x-kubernetes-map-type: atomic
+                description: "ProxyConnectHeader optionally specifies headers to send
+                  to proxies during CONNECT requests. \n It requires Prometheus >=
+                  v2.43.0."
+                type: object
+                x-kubernetes-map-type: atomic
+              proxyFromEnvironment:
+                description: "Whether to use the proxy configuration defined by environment
+                  variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY). If unset, Prometheus
+                  uses its default value. \n It requires Prometheus >= v2.43.0."
+                type: boolean
+              proxyUrl:
+                description: "`proxyURL` defines the HTTP proxy server to use. \n
+                  It requires Prometheus >= v2.43.0."
+                pattern: ^http(s)?://.+$
+                type: string
               relabelings:
                 description: 'RelabelConfigs defines how to rewrite the target''s
                   labels before scraping. Prometheus Operator automatically adds relabelings
@@ -1284,6 +2132,12 @@ spec:
                     description: Used to verify the hostname for the targets.
                     type: string
                 type: object
+              trackTimestampsStaleness:
+                description: TrackTimestampsStaleness whether Prometheus tracks staleness
+                  of the metrics that have an explicit timestamp present in scraped
+                  data. Has no effect if `honorTimestamps` is false. It requires Prometheus
+                  >= v2.48.0.
+                type: boolean
             type: object
         required:
         - spec

--- a/bundle/manifests/monitoring.rhobs_servicemonitors.yaml
+++ b/bundle/manifests/monitoring.rhobs_servicemonitors.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-    operator.prometheus.io/version: 0.69.0-rhobs1
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operator.prometheus.io/version: 0.71.0-rhobs1
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: observability-operator
@@ -41,22 +41,24 @@ spec:
               by Prometheus.
             properties:
               attachMetadata:
-                description: Attaches node metadata to discovered targets. Requires
-                  Prometheus v2.37.0 and above.
+                description: "`attachMetadata` defines additional metadata which is
+                  added to the discovered targets. \n It requires Prometheus >= v2.37.0."
                 properties:
                   node:
-                    description: When set to true, Prometheus must have permissions
-                      to get Nodes.
+                    description: When set to true, Prometheus must have the `get`
+                      permission on the `Nodes` objects.
                     type: boolean
                 type: object
               endpoints:
-                description: A list of endpoints allowed as part of this ServiceMonitor.
+                description: List of endpoints part of this ServiceMonitor.
                 items:
-                  description: Endpoint defines a scrapeable endpoint serving Prometheus
-                    metrics.
+                  description: Endpoint defines an endpoint serving Prometheus metrics
+                    to be scraped by Prometheus.
                   properties:
                     authorization:
-                      description: Authorization section for this endpoint
+                      description: "`authorization` configures the Authorization header
+                        credentials to use when scraping the target. \n Cannot be
+                        set at the same time as `basicAuth`, or `oauth2`."
                       properties:
                         credentials:
                           description: Selects a key of a Secret in the namespace
@@ -85,12 +87,13 @@ spec:
                           type: string
                       type: object
                     basicAuth:
-                      description: 'BasicAuth allow an endpoint to authenticate over
-                        basic authentication More info: https://prometheus.io/docs/operating/configuration/#endpoints'
+                      description: "`basicAuth` configures the Basic Authentication
+                        credentials to use when scraping the target. \n Cannot be
+                        set at the same time as `authorization`, or `oauth2`."
                       properties:
                         password:
-                          description: The secret in the service monitor namespace
-                            that contains the password for authentication.
+                          description: '`password` specifies a key of a Secret containing
+                            the password for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -109,8 +112,8 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         username:
-                          description: The secret in the service monitor namespace
-                            that contains the username for authentication.
+                          description: '`username` specifies a key of a Secret containing
+                            the username for authentication.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -130,12 +133,15 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                     bearerTokenFile:
-                      description: File to read bearer token for scraping targets.
+                      description: "File to read bearer token for scraping the target.
+                        \n Deprecated: use `authorization` instead."
                       type: string
                     bearerTokenSecret:
-                      description: Secret to mount to read bearer token for scraping
-                        targets. The secret needs to be in the same namespace as the
-                        service monitor and accessible by the Prometheus Operator.
+                      description: "`bearerTokenSecret` specifies a key of a Secret
+                        containing the bearer token for scraping targets. The secret
+                        needs to be in the same namespace as the ServiceMonitor object
+                        and readable by the Prometheus Operator. \n Deprecated: use
+                        `authorization` instead."
                       properties:
                         key:
                           description: The key of the secret to select from.  Must
@@ -154,32 +160,36 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     enableHttp2:
-                      description: Whether to enable HTTP2.
+                      description: '`enableHttp2` can be used to disable HTTP2 when
+                        scraping the target.'
                       type: boolean
                     filterRunning:
-                      description: 'Drop pods that are not running. (Failed, Succeeded).
-                        Enabled by default. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase'
+                      description: "When true, the pods which are not running (e.g.
+                        either in Failed or Succeeded state) are dropped during the
+                        target discovery. \n If unset, the filtering is enabled. \n
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase"
                       type: boolean
                     followRedirects:
-                      description: FollowRedirects configures whether scrape requests
-                        follow HTTP 3xx redirects.
+                      description: '`followRedirects` defines whether the scrape requests
+                        should follow HTTP 3xx redirects.'
                       type: boolean
                     honorLabels:
-                      description: HonorLabels chooses the metric's labels on collisions
-                        with target labels.
+                      description: When true, `honorLabels` preserves the metric's
+                        labels when they collide with the target's labels.
                       type: boolean
                     honorTimestamps:
-                      description: HonorTimestamps controls whether Prometheus respects
-                        the timestamps present in scraped data.
+                      description: '`honorTimestamps` controls whether Prometheus
+                        preserves the timestamps when exposed by the target.'
                       type: boolean
                     interval:
-                      description: Interval at which metrics should be scraped If
-                        not specified Prometheus' global scrape interval is used.
+                      description: "Interval at which Prometheus scrapes the metrics
+                        from the target. \n If empty, Prometheus uses the global scrape
+                        interval."
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     metricRelabelings:
-                      description: MetricRelabelConfigs to apply to samples before
-                        ingestion.
+                      description: '`metricRelabelings` configures the relabeling
+                        rules to apply to the samples before ingestion.'
                       items:
                         description: "RelabelConfig allows dynamic rewriting of the
                           label set for targets, alerts, scraped samples and remote
@@ -255,12 +265,13 @@ spec:
                         type: object
                       type: array
                     oauth2:
-                      description: OAuth2 for the URL. Only valid in Prometheus versions
-                        2.27.0 and newer.
+                      description: "`oauth2` configures the OAuth2 settings to use
+                        when scraping the target. \n It requires Prometheus >= 2.27.0.
+                        \n Cannot be set at the same time as `authorization`, or `basicAuth`."
                       properties:
                         clientId:
-                          description: The secret or configmap containing the OAuth2
-                            client id
+                          description: '`clientId` specifies a key of a Secret or
+                            ConfigMap containing the OAuth2 client''s ID.'
                           properties:
                             configMap:
                               description: ConfigMap containing data to use for the
@@ -304,7 +315,8 @@ spec:
                               x-kubernetes-map-type: atomic
                           type: object
                         clientSecret:
-                          description: The secret containing the OAuth2 client secret
+                          description: '`clientSecret` specifies a key of a Secret
+                            containing the OAuth2 client''s secret.'
                           properties:
                             key:
                               description: The key of the secret to select from.  Must
@@ -325,15 +337,18 @@ spec:
                         endpointParams:
                           additionalProperties:
                             type: string
-                          description: Parameters to append to the token URL
+                          description: '`endpointParams` configures the HTTP parameters
+                            to append to the token URL.'
                           type: object
                         scopes:
-                          description: OAuth2 scopes used for the token request
+                          description: '`scopes` defines the OAuth2 scopes used for
+                            the token request.'
                           items:
                             type: string
                           type: array
                         tokenUrl:
-                          description: The URL to fetch the token from
+                          description: '`tokenURL` configures the URL to fetch the
+                            token from.'
                           minLength: 1
                           type: string
                       required:
@@ -346,26 +361,27 @@ spec:
                         items:
                           type: string
                         type: array
-                      description: Optional HTTP URL parameters
+                      description: params define optional HTTP URL parameters.
                       type: object
                     path:
-                      description: HTTP path to scrape for metrics. If empty, Prometheus
-                        uses the default value (e.g. `/metrics`).
+                      description: "HTTP path from which to scrape for metrics. \n
+                        If empty, Prometheus uses the default value (e.g. `/metrics`)."
                       type: string
                     port:
-                      description: Name of the service port this endpoint refers to.
-                        Mutually exclusive with targetPort.
+                      description: "Name of the Service port which this endpoint refers
+                        to. \n It takes precedence over `targetPort`."
                       type: string
                     proxyUrl:
-                      description: ProxyURL eg http://proxyserver:2195 Directs scrapes
-                        to proxy through this endpoint.
+                      description: '`proxyURL` configures the HTTP Proxy URL (e.g.
+                        "http://proxyserver:2195") to go through when scraping the
+                        target.'
                       type: string
                     relabelings:
-                      description: 'RelabelConfigs to apply to samples before scraping.
-                        Prometheus Operator automatically adds relabelings for a few
-                        standard Kubernetes fields. The original scrape job''s name
-                        is available via the `__tmp_prometheus_job_name` label. More
-                        info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                      description: "`relabelings` configures the relabeling rules
+                        to apply the target's metadata labels. \n The Operator automatically
+                        adds relabelings for a few standard Kubernetes fields. \n
+                        The original scrape job's name is available via the `__tmp_prometheus_job_name`
+                        label. \n More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config"
                       items:
                         description: "RelabelConfig allows dynamic rewriting of the
                           label set for targets, alerts, scraped samples and remote
@@ -441,30 +457,31 @@ spec:
                         type: object
                       type: array
                     scheme:
-                      description: HTTP scheme to use for scraping. `http` and `https`
-                        are the expected values unless you rewrite the `__scheme__`
-                        label via relabeling. If empty, Prometheus uses the default
-                        value `http`.
+                      description: "HTTP scheme to use for scraping. \n `http` and
+                        `https` are the expected values unless you rewrite the `__scheme__`
+                        label via relabeling. \n If empty, Prometheus uses the default
+                        value `http`."
                       enum:
                       - http
                       - https
                       type: string
                     scrapeTimeout:
-                      description: Timeout after which the scrape is ended If not
-                        specified, the Prometheus global scrape timeout is used unless
-                        it is less than `Interval` in which the latter is used.
+                      description: "Timeout after which Prometheus considers the scrape
+                        to be failed. \n If empty, Prometheus uses the global scrape
+                        timeout unless it is less than the target's scrape interval
+                        value in which the latter is used."
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
                     targetPort:
                       anyOf:
                       - type: integer
                       - type: string
-                      description: Name or number of the target port of the Pod behind
-                        the Service, the port must be specified with container port
-                        property. Mutually exclusive with port.
+                      description: "Name or number of the target port of the `Pod`
+                        object behind the Service, the port must be specified with
+                        container port property. \n Deprecated: use `port` instead."
                       x-kubernetes-int-or-string: true
                     tlsConfig:
-                      description: TLS configuration to use when scraping the endpoint
+                      description: TLS configuration to use when scraping the target.
                       properties:
                         ca:
                           description: Certificate authority used when verifying server
@@ -594,16 +611,23 @@ spec:
                           description: Used to verify the hostname for the targets.
                           type: string
                       type: object
+                    trackTimestampsStaleness:
+                      description: "`trackTimestampsStaleness` defines whether Prometheus
+                        tracks staleness of the metrics that have an explicit timestamp
+                        present in scraped data. Has no effect if `honorTimestamps`
+                        is false. \n It requires Prometheus >= v2.48.0."
+                      type: boolean
                   type: object
                 type: array
               jobLabel:
-                description: "JobLabel selects the label from the associated Kubernetes
-                  service which will be used as the `job` label for all metrics. \n
-                  For example: If in `ServiceMonitor.spec.jobLabel: foo` and in `Service.metadata.labels.foo:
-                  bar`, then the `job=\"bar\"` label is added to all metrics. \n If
-                  the value of this field is empty or if the label doesn't exist for
-                  the given Service, the `job` label of the metrics defaults to the
-                  name of the Kubernetes Service."
+                description: "`jobLabel` selects the label from the associated Kubernetes
+                  `Service` object which will be used as the `job` label for all metrics.
+                  \n For example if `jobLabel` is set to `foo` and the Kubernetes
+                  `Service` object is labeled with `foo: bar`, then Prometheus adds
+                  the `job=\"bar\"` label to all ingested metrics. \n If the value
+                  of this field is empty or if the label doesn't exist for the given
+                  Service, the `job` label of the metrics defaults to the name of
+                  the associated Kubernetes `Service`."
                 type: string
               keepDroppedTargets:
                 description: "Per-scrape limit on the number of targets dropped by
@@ -612,24 +636,22 @@ spec:
                 format: int64
                 type: integer
               labelLimit:
-                description: Per-scrape limit on number of labels that will be accepted
-                  for a sample. Only valid in Prometheus versions 2.27.0 and newer.
+                description: "Per-scrape limit on number of labels that will be accepted
+                  for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               labelNameLengthLimit:
-                description: Per-scrape limit on length of labels name that will be
-                  accepted for a sample. Only valid in Prometheus versions 2.27.0
-                  and newer.
+                description: "Per-scrape limit on length of labels name that will
+                  be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               labelValueLengthLimit:
-                description: Per-scrape limit on length of labels value that will
-                  be accepted for a sample. Only valid in Prometheus versions 2.27.0
-                  and newer.
+                description: "Per-scrape limit on length of labels value that will
+                  be accepted for a sample. \n It requires Prometheus >= v2.27.0."
                 format: int64
                 type: integer
               namespaceSelector:
-                description: Selector to select which namespaces the Kubernetes Endpoints
+                description: Selector to select which namespaces the Kubernetes `Endpoints`
                   objects are discovered from.
                 properties:
                   any:
@@ -643,18 +665,18 @@ spec:
                     type: array
                 type: object
               podTargetLabels:
-                description: PodTargetLabels transfers labels on the Kubernetes `Pod`
-                  onto the created metrics.
+                description: '`podTargetLabels` defines the labels which are transferred
+                  from the associated Kubernetes `Pod` object onto the ingested metrics.'
                 items:
                   type: string
                 type: array
               sampleLimit:
-                description: SampleLimit defines per-scrape limit on number of scraped
-                  samples that will be accepted.
+                description: '`sampleLimit` defines a per-scrape limit on the number
+                  of scraped samples that will be accepted.'
                 format: int64
                 type: integer
               selector:
-                description: Selector to select Endpoints objects.
+                description: Label selector to select the Kubernetes `Endpoints` objects.
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -699,18 +721,18 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               targetLabels:
-                description: TargetLabels transfers labels from the Kubernetes `Service`
-                  onto the created metrics.
+                description: '`targetLabels` defines the labels which are transferred
+                  from the associated Kubernetes `Service` object onto the ingested
+                  metrics.'
                 items:
                   type: string
                 type: array
               targetLimit:
-                description: TargetLimit defines a limit on the number of scraped
-                  targets that will be accepted.
+                description: '`targetLimit` defines a limit on the number of scraped
+                  targets that will be accepted.'
                 format: int64
                 type: integer
             required:
-            - endpoints
             - selector
             type: object
         required:

--- a/bundle/manifests/monitoring.rhobs_thanosrulers.yaml
+++ b/bundle/manifests/monitoring.rhobs_thanosrulers.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.1
-    operator.prometheus.io/version: 0.69.0-rhobs1
+    controller-gen.kubebuilder.io/version: v0.13.0
+    operator.prometheus.io/version: 0.71.0-rhobs1
   creationTimestamp: null
   labels:
     app.kubernetes.io/part-of: observability-operator
@@ -4291,8 +4291,8 @@ spec:
                 description: Storage spec to specify how storage shall be used.
                 properties:
                   disableMountSubPath:
-                    description: '*Deprecated: subPath usage will be removed in a
-                      future release.*'
+                    description: 'Deprecated: subPath usage will be removed in a future
+                      release.'
                     type: boolean
                   emptyDir:
                     description: 'EmptyDirVolumeSource to be used by the StatefulSet.
@@ -4844,7 +4844,7 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: '*Deprecated: this field is never set.*'
+                        description: 'Deprecated: this field is never set.'
                         properties:
                           accessModes:
                             description: 'accessModes contains the actual access modes

--- a/bundle/manifests/obo-prometheus-operator-admission-webhook_policy_v1_poddisruptionbudget.yaml
+++ b/bundle/manifests/obo-prometheus-operator-admission-webhook_policy_v1_poddisruptionbudget.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: prometheus-operator-admission-webhook
     app.kubernetes.io/part-of: observability-operator
-    app.kubernetes.io/version: 0.69.0-rhobs1
+    app.kubernetes.io/version: 0.71.0-rhobs1
   name: obo-prometheus-operator-admission-webhook
 spec:
   minAvailable: 1

--- a/bundle/manifests/obo-prometheus-operator-admission-webhook_v1_service.yaml
+++ b/bundle/manifests/obo-prometheus-operator-admission-webhook_v1_service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app.kubernetes.io/name: prometheus-operator-admission-webhook
     app.kubernetes.io/part-of: observability-operator
-    app.kubernetes.io/version: 0.69.0-rhobs1
+    app.kubernetes.io/version: 0.71.0-rhobs1
   name: obo-prometheus-operator-admission-webhook
 spec:
   ports:

--- a/bundle/manifests/obo-prometheus-operator_v1_service.yaml
+++ b/bundle/manifests/obo-prometheus-operator_v1_service.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: observability-operator
-    app.kubernetes.io/version: 0.69.0-rhobs1
+    app.kubernetes.io/version: 0.71.0-rhobs1
   name: obo-prometheus-operator
 spec:
   clusterIP: None

--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:0.0.29
-    createdAt: "2024-01-22T13:28:58Z"
+    createdAt: "2024-01-23T14:08:25Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
@@ -219,6 +219,13 @@ spec:
           - get
           - list
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - patch
+          - create
         - apiGroups:
           - networking.k8s.io
           resources:
@@ -424,7 +431,7 @@ spec:
           app.kubernetes.io/component: controller
           app.kubernetes.io/name: prometheus-operator
           app.kubernetes.io/part-of: observability-operator
-          app.kubernetes.io/version: 0.69.0-rhobs1
+          app.kubernetes.io/version: 0.71.0-rhobs1
         name: obo-prometheus-operator
         spec:
           replicas: 1
@@ -443,7 +450,7 @@ spec:
                 app.kubernetes.io/component: controller
                 app.kubernetes.io/name: prometheus-operator
                 app.kubernetes.io/part-of: observability-operator
-                app.kubernetes.io/version: 0.69.0-rhobs1
+                app.kubernetes.io/version: 0.71.0-rhobs1
             spec:
               affinity:
                 nodeAffinity:
@@ -456,11 +463,14 @@ spec:
               automountServiceAccountToken: true
               containers:
               - args:
-                - --prometheus-config-reloader=quay.io/rhobs/obo-prometheus-config-reloader:v0.69.0-rhobs1
+                - --prometheus-config-reloader=quay.io/rhobs/obo-prometheus-config-reloader:v0.71.0-rhobs1
                 - --prometheus-instance-selector=app.kubernetes.io/managed-by=observability-operator
                 - --alertmanager-instance-selector=app.kubernetes.io/managed-by=observability-operator
                 - --thanos-ruler-instance-selector=app.kubernetes.io/managed-by=observability-operator
-                image: quay.io/rhobs/obo-prometheus-operator:v0.69.0-rhobs1
+                env:
+                - name: GOGC
+                  value: "30"
+                image: quay.io/rhobs/obo-prometheus-operator:v0.71.0-rhobs1
                 name: prometheus-operator
                 ports:
                 - containerPort: 8080
@@ -490,7 +500,7 @@ spec:
       - label:
           app.kubernetes.io/name: prometheus-operator-admission-webhook
           app.kubernetes.io/part-of: observability-operator
-          app.kubernetes.io/version: 0.69.0-rhobs1
+          app.kubernetes.io/version: 0.71.0-rhobs1
         name: obo-prometheus-operator-admission-webhook
         spec:
           replicas: 2
@@ -508,7 +518,7 @@ spec:
               labels:
                 app.kubernetes.io/name: prometheus-operator-admission-webhook
                 app.kubernetes.io/part-of: observability-operator
-                app.kubernetes.io/version: 0.69.0-rhobs1
+                app.kubernetes.io/version: 0.71.0-rhobs1
             spec:
               affinity:
                 nodeAffinity:
@@ -533,7 +543,7 @@ spec:
                 - --web.enable-tls=true
                 - --web.cert-file=/tmp/k8s-webhook-server/serving-certs/tls.crt
                 - --web.key-file=/tmp/k8s-webhook-server/serving-certs/tls.key
-                image: quay.io/rhobs/obo-admission-webhook:v0.69.0-rhobs1
+                image: quay.io/rhobs/obo-admission-webhook:v0.71.0-rhobs1
                 name: prometheus-operator-admission-webhook
                 ports:
                 - containerPort: 8443
@@ -590,6 +600,9 @@ spec:
               containers:
               - args:
                 - --namespace=$(NAMESPACE)
+                - --images=alertmanager=quay.io/prometheus/alertmanager:v0.26.0
+                - --images=prometheus=quay.io/prometheus/prometheus:v2.49.1
+                - --images=thanos=quay.io/thanos/thanos:v0.33.0
                 env:
                 - name: NAMESPACE
                   valueFrom:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -96,7 +96,8 @@ func main() {
 
 	setupLog.Info("running with arguments",
 		"namespace", namespace,
-		"metrics-bind-address", metricsAddr)
+		"metrics-bind-address", metricsAddr,
+		"images", images)
 
 	imgMap, err := validateImages(images)
 	if err != nil {

--- a/deploy/dependencies/kustomization.yaml
+++ b/deploy/dependencies/kustomization.yaml
@@ -4,34 +4,34 @@ kind: Kustomization
 resources:
 
 # CRDs
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_alertmanagers.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_podmonitors.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_probes.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_prometheuses.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_prometheusrules.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_servicemonitors.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_thanosrulers.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_prometheusagents.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_alertmanagerconfigs.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_scrapeconfigs.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_alertmanagers.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_podmonitors.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_probes.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_prometheuses.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_prometheusrules.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_servicemonitors.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_thanosrulers.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_prometheusagents.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_alertmanagerconfigs.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/prometheus-operator-crd/monitoring.rhobs_scrapeconfigs.yaml
 
 # PO Deployment
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/rbac/prometheus-operator/prometheus-operator-service-account.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/rbac/prometheus-operator/prometheus-operator-service.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/rbac/prometheus-operator/prometheus-operator-deployment.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/rbac/prometheus-operator/prometheus-operator-cluster-role-binding.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/rbac/prometheus-operator/prometheus-operator-cluster-role.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/rbac/prometheus-operator/prometheus-operator-service-account.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/rbac/prometheus-operator/prometheus-operator-service.yaml
 
 
 
 # Admission Webhook Deployment
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/admission-webhook/deployment.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/admission-webhook/service-account.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/admission-webhook/deployment.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/admission-webhook/service-account.yaml
 # NOTE: a service although automatically created by OLM for webhooks still
 # requires admission-webhook/service as the port generated by OLM uses 443
 # but assumes targetPort to be 443 as opposed to "https" port of webhook - 8443
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/admission-webhook/service.yaml
-- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.69.0-rhobs1/example/admission-webhook/pod-disruption-budget.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/admission-webhook/service.yaml
+- https://raw.githubusercontent.com/rhobs/obo-prometheus-operator/v0.71.0-rhobs1/example/admission-webhook/pod-disruption-budget.yaml
 
 - admission-webhook/cluster-role.yaml
 - admission-webhook/cluster-role-binding.yaml
@@ -63,9 +63,9 @@ patches:
           spec:
             containers:
               - name: prometheus-operator
-                image: quay.io/rhobs/obo-prometheus-operator:v0.69.0-rhobs1
+                image: quay.io/rhobs/obo-prometheus-operator:v0.71.0-rhobs1
                 args:
-                  - --prometheus-config-reloader=quay.io/rhobs/obo-prometheus-config-reloader:v0.69.0-rhobs1
+                  - --prometheus-config-reloader=quay.io/rhobs/obo-prometheus-config-reloader:v0.71.0-rhobs1
                   - --prometheus-instance-selector=app.kubernetes.io/managed-by=observability-operator
                   - --alertmanager-instance-selector=app.kubernetes.io/managed-by=observability-operator
                   - --thanos-ruler-instance-selector=app.kubernetes.io/managed-by=observability-operator

--- a/deploy/operator/kustomization.yaml
+++ b/deploy/operator/kustomization.yaml
@@ -10,10 +10,34 @@ resources:
 images:
 - name: observability-operator
   newName: observability-operator
-  newTag: 0.0.20
+  newTag: 0.0.29
 namespace: operators
 
 patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --images=alertmanager=quay.io/prometheus/alertmanager:v0.26.0
+  target:
+    group: apps
+    kind: Deployment
+    version: v1
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --images=prometheus=quay.io/prometheus/prometheus:v2.49.1
+  target:
+    group: apps
+    kind: Deployment
+    version: v1
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --images=thanos=quay.io/thanos/thanos:v0.33.0
+  target:
+    group: apps
+    kind: Deployment
+    version: v1
 - patch: |-
     - op: add
       path: /spec/template/spec/containers/0/resources

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -674,6 +674,7 @@ const oboManagedFieldsJson = `
   "f:externalLabels": {
     "f:key": {}
   },
+  "f:image": {},
   "f:logLevel": {},
   "f:podMetadata": {
     "f:labels": {


### PR DESCRIPTION
We missed updating to the new prometheus-operator version in the bundle. Additionally this sets the new `--images` cli args for the operator deployment.