### PR TITLE
fix: use thanos default port in service and containerPort

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -4,7 +4,7 @@ inputs:
   kind-version:
     description: "kind version"
     required: false
-    default: 'v0.14.0'
+    default: 'v0.20.0'
   kind-image:
     description: "kind version"
     required: false

--- a/pkg/controllers/monitoring/thanos-querier/components.go
+++ b/pkg/controllers/monitoring/thanos-querier/components.go
@@ -26,8 +26,6 @@ func thanosComponentReconcilers(thanos *msoapi.ThanosQuerier, sidecarUrls []stri
 func newThanosQuerierDeployment(name string, spec *msoapi.ThanosQuerier, sidecarUrls []string, thanosCfg ThanosConfiguration) *appsv1.Deployment {
 	args := []string{
 		"query",
-		"--grpc-address=127.0.0.1:10901",
-		"--http-address=127.0.0.1:9090",
 		"--log.format=logfmt",
 		"--query.replica-label=prometheus_replica",
 		"--query.auto-downsampling",
@@ -71,7 +69,7 @@ func newThanosQuerierDeployment(name string, spec *msoapi.ThanosQuerier, sidecar
 							Image: thanosCfg.Image,
 							Ports: []corev1.ContainerPort{
 								{
-									ContainerPort: 9090,
+									ContainerPort: 10902,
 									Name:          "metrics",
 								},
 							},
@@ -116,7 +114,7 @@ func newService(name string, namespace string) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Port: 9090,
+					Port: 10902,
 					Name: "http",
 				},
 			},

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -842,7 +842,7 @@ func namespaceSelectorTest(t *testing.T) {
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	//nolint
-	if pollErr := wait.Poll(15*time.Second, framework.DefaultTestTimeout, func() (bool, error) {
+	if pollErr := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, framework.DefaultTestTimeout, true, func(ctx context.Context) (bool, error) {
 		err := f.StartServicePortForward(ms.Name+"-prometheus", e2eTestNamespace, "9090", stopChan)
 		return err == nil, nil
 	}); pollErr != nil {

--- a/test/e2e/thanos_querier_controller_test.go
+++ b/test/e2e/thanos_querier_controller_test.go
@@ -76,13 +76,13 @@ func singleStackWithSidecar(t *testing.T) {
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	if err := wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, true, func(ctx context.Context) (bool, error) {
-		err = f.StartServicePortForward(name, e2eTestNamespace, "9090", stopChan)
+		err = f.StartServicePortForward(name, e2eTestNamespace, "10902", stopChan)
 		return err == nil, nil
 	}); wait.Interrupted(err) {
 		t.Fatal(err)
 	}
 
-	promClient := framework.NewPrometheusClient("http://localhost:9090")
+	promClient := framework.NewPrometheusClient("http://localhost:10902")
 	expectedResults := map[string]int{
 		"prometheus_build_info": 2, // must return from both prometheus pods
 	}


### PR DESCRIPTION
Before thanos was only listening on localhost. Relying on the default setting allows user to modify that via server side apply and add a proxy chain.

Fixes: https://issues.redhat.com/browse/COO-14