### PR TITLE
fix: add channel marker back into index file

### DIFF
--- a/.github/tools
+++ b/.github/tools
@@ -13,4 +13,4 @@ jsonnetfmt v0.17.0
 jsonnet-lint v0.17.0
 jb v0.4.0
 gojsontoyaml 0.0.1
-shellcheck 0.9.0
+shellcheck 0.10.0

--- a/Makefile.tools
+++ b/Makefile.tools
@@ -56,7 +56,7 @@ JSONNET_VENDOR = jsonnet/vendor
 JSONNETFMT_ARGS = -n 2 --max-blank-lines 2 --string-style s --comment-style s
 
 SHELLCHECK = $(TOOLS_DIR)/shellcheck
-SHELLCHECK_VERSION = 0.9.0
+SHELLCHECK_VERSION = 0.10.0
 
 $(TOOLS_DIR):
 	@mkdir -p $(TOOLS_DIR)

--- a/olm/observability-operator-index/index.yaml
+++ b/olm/observability-operator-index/index.yaml
@@ -56,6 +56,7 @@ entries:
   replaces: observability-operator.v0.0.27
 - name: observability-operator.v0.0.28
   replaces: observability-operator.v0.0.28-rc
+### CANDIDATE_CHANNEL_MARKER ###
 name: candidate
 package: observability-operator
 schema: olm.channel
@@ -318,6 +319,7 @@ entries:
   replaces: observability-operator.v0.0.29-240118173426
 - name: observability-operator.v0.0.29-240122104019
   replaces: observability-operator.v0.0.29-240122093649
+### DEVELOPMENT_CHANNEL_MARKER ###
 name: development
 package: observability-operator
 schema: olm.channel
@@ -350,6 +352,7 @@ entries:
   replaces: observability-operator.v0.0.25
 - name: observability-operator.v0.0.28
   replaces: observability-operator.v0.0.27
+### STABLE_CHANNEL_MARKER ###
 name: stable
 package: observability-operator
 schema: olm.channel


### PR DESCRIPTION
These were removed in 1875b9e99d14b7a84b59d0ab23ae939da27e6061 and are needed for release automation via olm/update-channels.sh.

Fixes: https://issues.redhat.com/browse/COO-17