### PR TITLE
test:thanos querier e2e test - wait for deployment to be ready

### DIFF
--- a/test/e2e/thanos_querier_controller_test.go
+++ b/test/e2e/thanos_querier_controller_test.go
@@ -72,6 +72,7 @@ func singleStackWithSidecar(t *testing.T) {
 	thanosService := corev1.Service{}
 	f.GetResourceWithRetry(t, name, tq.Namespace, &thanosService)
 
+	f.AssertDeploymentReady(name, tq.Namespace, framework.WithTimeout(5*time.Minute))(t)
 	// Assert prometheus instance can be queried
 	stopChan := make(chan struct{})
 	defer close(stopChan)


### PR DESCRIPTION
This should fix the test failing with:

```
E0322 09:17:13.829822   42915 portforward.go:409] an error occurred forwarding 10902 -> 10902: error forwarding port 10902 to pod b607bb8a7641f1f305367d46323a9525283056d28cb3d86ac85cc8d0b5bc59e5, uid : sandbox b607bb8a7641f1f305367d46323a9525283056d28cb3d86ac85cc8d0b5bc59e5 is not running
panic: lost connection to pod
```