### PR TITLE
test: prometheus scale down e2e test

### DIFF
--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -361,7 +361,7 @@ func (f *Framework) AssertPrometheusReplicaStatus(name, namespace string, expect
 			return true, nil
 
 		}); wait.Interrupted(err) {
-			t.Fatal(fmt.Errorf("Prometheus %s/%s was not scaled down to %d", namespace, name, expectedReplicas))
+			t.Fatal(fmt.Errorf("Prometheus %s/%s has unexpected number of replicas, got %d, expected %d", namespace, name, prom.Status.Replicas, expectedReplicas))
 		}
 	}
 }

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -582,7 +582,7 @@ func prometheusScaleDown(t *testing.T) {
 
 	err = f.UpdateWithRetry(t, ms, framework.SetPrometheusReplicas(0))
 	assert.NilError(t, err, "failed to update a monitoring stack")
-	f.AssertPrometheusReplicaStatus(ms.Name, ms.Namespace, numOfRep)
+	f.AssertPrometheusReplicaStatus(ms.Name, ms.Namespace, 0)
 }
 
 func assertPrometheusManagedFields(t *testing.T) {


### PR DESCRIPTION
This should fix test failure [COO-79](https://issues.redhat.com/browse/COO-79)
`monitoring_stack_controller_test.go:585: assertion failed: 0 (prom.Status.Replicas int32) != 1 (int32)`
Also fix
[COO-84](https://issues.redhat.com/browse/COO-84) [QE] Case Alertmanager_runs_in_HA_mode is not stable
`monitoring_stack_controller_test.go:99: statefulsets.apps "alertmanager-alerting" not found`