### PR TITLE
apis: provide option to enable otlp/http receiver

### DIFF
--- a/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
+++ b/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
@@ -111,6 +111,12 @@ spec:
                   replicas: 2
                 description: Define prometheus config
                 properties:
+                  enableOtlpHttpReceiver:
+                    description: |-
+                      Enable Prometheus to accept OpenTelemetry Metrics via the otlp/http protocol.
+                      Defaults to the value of `false`.
+                      The resulting endpoint is /api/v1/otlp/v1/metrics.
+                    type: boolean
                   enableRemoteWriteReceiver:
                     description: Enable Prometheus to be used as a receiver for the
                       Prometheus remote write protocol. Defaults to the value of `false`.

--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:0.1.0
-    createdAt: "2024-04-09T09:36:18Z"
+    createdAt: "2024-04-11T14:33:28Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operators.operatorframework.io/builder: operator-sdk-v1.34.1

--- a/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
+++ b/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
@@ -111,6 +111,12 @@ spec:
                   replicas: 2
                 description: Define prometheus config
                 properties:
+                  enableOtlpHttpReceiver:
+                    description: |-
+                      Enable Prometheus to accept OpenTelemetry Metrics via the otlp/http protocol.
+                      Defaults to the value of `false`.
+                      The resulting endpoint is /api/v1/otlp/v1/metrics.
+                    type: boolean
                   enableRemoteWriteReceiver:
                     description: Enable Prometheus to be used as a receiver for the
                       Prometheus remote write protocol. Defaults to the value of `false`.

--- a/docs/api.md
+++ b/docs/api.md
@@ -285,6 +285,15 @@ Define prometheus config
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>enableOtlpHttpReceiver</b></td>
+        <td>boolean</td>
+        <td>
+          Enable Prometheus to accept OpenTelemetry Metrics via the otlp/http protocol.
+Defaults to the value of `false`.
+The resulting endpoint is /api/v1/otlp/v1/metrics.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>enableRemoteWriteReceiver</b></td>
         <td>boolean</td>
         <td>

--- a/pkg/apis/monitoring/v1alpha1/types.go
+++ b/pkg/apis/monitoring/v1alpha1/types.go
@@ -184,6 +184,11 @@ type PrometheusConfig struct {
 	// Enable Prometheus to be used as a receiver for the Prometheus remote write protocol. Defaults to the value of `false`.
 	// +optional
 	EnableRemoteWriteReceiver bool `json:"enableRemoteWriteReceiver,omitempty"`
+	// Enable Prometheus to accept OpenTelemetry Metrics via the otlp/http protocol.
+	// Defaults to the value of `false`.
+	// The resulting endpoint is /api/v1/otlp/v1/metrics.
+	// +optional
+	EnableOtlpHttpReceiver *bool `json:"enableOtlpHttpReceiver,omitempty"`
 	// Default interval between scrapes.
 	// +optional
 	ScrapeInterval *monv1.Duration `json:"scrapeInterval,omitempty"`

--- a/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -218,6 +218,11 @@ func (in *PrometheusConfig) DeepCopyInto(out *PrometheusConfig) {
 			(*out)[key] = val
 		}
 	}
+	if in.EnableOtlpHttpReceiver != nil {
+		in, out := &in.EnableOtlpHttpReceiver, &out.EnableOtlpHttpReceiver
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ScrapeInterval != nil {
 		in, out := &in.ScrapeInterval, &out.ScrapeInterval
 		*out = new(monitoringv1.Duration)

--- a/pkg/controllers/monitoring/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components.go
@@ -183,6 +183,12 @@ func newPrometheus(
 				RemoteWrite:               config.RemoteWrite,
 				ExternalLabels:            config.ExternalLabels,
 				EnableRemoteWriteReceiver: config.EnableRemoteWriteReceiver,
+				EnableFeatures: func() []string {
+					if config.EnableOtlpHttpReceiver != nil && *config.EnableOtlpHttpReceiver {
+						return []string{"otlp-write-receiver"}
+					}
+					return []string{}
+				}(),
 			},
 			Retention:             ms.Spec.Retention,
 			RuleSelector:          prometheusSelector,

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -622,6 +622,7 @@ func assertPrometheusManagedFields(t *testing.T) {
 			"key": "value",
 		},
 		EnableRemoteWriteReceiver: true,
+		EnableOtlpHttpReceiver:    func(b bool) *bool { return &b }(true),
 	}
 	ms.Spec.NamespaceSelector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{
@@ -689,6 +690,7 @@ const oboManagedFieldsJson = `
   "f:probeNamespaceSelector": {},
   "f:probeSelector": {},
   "f:remoteWrite": {},
+  "f:enableFeatures": {},
   "f:replicas": {},
   "f:resources": {},
   "f:retention": {},


### PR DESCRIPTION
This PR adds an option to enable a featuregate on prometheus to accept data on the otlp/http ingestion path.

Is that something we can a here or should it be an option to accept multiple featuregates?

TODO:
- [x] call `make generte` (currently it panics)

cc @simonpasquier 