### PR TITLE
COO-117: fix: remove invalid owner ref on cluster role

### DIFF
--- a/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
+++ b/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
@@ -139,8 +139,7 @@ func newAlertManagerClusterRole(ms *stack.MonitoringStack, rbacResourceName stri
 			Kind:       "ClusterRole",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      rbacResourceName,
-			Namespace: ms.Namespace,
+			Name: rbacResourceName,
 		},
 		Rules: []rbacv1.PolicyRule{{
 			APIGroups:     []string{"security.openshift.io"},

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -25,7 +25,6 @@ type Updater struct {
 }
 
 func (r Updater) Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
-
 	if r.resourceOwner.GetNamespace() == r.resource.GetNamespace() {
 		if err := controllerutil.SetControllerReference(r.resourceOwner, r.resource, scheme); err != nil {
 			return fmt.Errorf("%s/%s (%s): updater failed to set owner reference: %w",
@@ -39,6 +38,7 @@ func (r Updater) Reconcile(ctx context.Context, c client.Client, scheme *runtime
 			r.resource.GetNamespace(), r.resource.GetName(),
 			r.resource.GetObjectKind().GroupVersionKind().String(), err)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Cluster roles aren't namespace-scoped and can't have namespace-scoped owner references.

Closes [COO-117](https://issues.redhat.com//browse/COO-117)