### PR TITLE
fix: default goal in makefile and add goal for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ all: operator
 
 ## Development
 
+.PHONY: test-unit
+test-unit:
+	go test -cover ./cmd/... ./pkg/...
+
 .PHONY: lint
 lint: lint-golang lint-jsonnet lint-shell
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ OSD_E2E_TEST_HARNESS_IMG=$(IMAGE_BASE)-test-harness:$(VERSION)
 OSD_E2E_TEST_HARNESS_IMG_LATEST=$(IMAGE_BASE)-test-harness:latest
 
 # running `make` builds the operator (default target)
-all: operator
+.DEFAULT_GOAL := operator
 
 ## Development
 


### PR DESCRIPTION
Three changes, but all in the Makefile:

- Fix git command to ignore external diff tools
- Fix definition of default target
- Add a target for unit tests (optional, but I like being able to run tests with a simple command)

I can split this up into separate PRs, if you like.