### PR TITLE
feat: restrict UIPlugin CRD names to allow a single instance per type

### DIFF
--- a/bundle/manifests/observability.openshift.io_uiplugins.yaml
+++ b/bundle/manifests/observability.openshift.io_uiplugins.yaml
@@ -251,6 +251,16 @@ spec:
             - conditions
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: UIPlugin name must be 'logging' if type is Logging
+          rule: self.spec.type != 'Logging' || self.metadata.name == 'logging'
+        - message: UIPlugin name must be 'troubleshooting-panel' if type is TroubleshootingPanel
+          rule: self.spec.type != 'TroubleshootingPanel' || self.metadata.name ==
+            'troubleshooting-panel'
+        - message: UIPlugin name must be 'distributed-tracing' if type is DistributedTracing
+          rule: self.spec.type != 'DistributedTracing' || self.metadata.name == 'distributed-tracing'
+        - message: UIPlugin name must be 'dashboards' if type is Dashboards
+          rule: self.spec.type != 'Dashboards' || self.metadata.name == 'dashboards'
     served: true
     storage: true
     subresources:

--- a/deploy/crds/common/observability.openshift.io_uiplugins.yaml
+++ b/deploy/crds/common/observability.openshift.io_uiplugins.yaml
@@ -251,6 +251,16 @@ spec:
             - conditions
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: UIPlugin name must be 'logging' if type is Logging
+          rule: self.spec.type != 'Logging' || self.metadata.name == 'logging'
+        - message: UIPlugin name must be 'troubleshooting-panel' if type is TroubleshootingPanel
+          rule: self.spec.type != 'TroubleshootingPanel' || self.metadata.name ==
+            'troubleshooting-panel'
+        - message: UIPlugin name must be 'distributed-tracing' if type is DistributedTracing
+          rule: self.spec.type != 'DistributedTracing' || self.metadata.name == 'distributed-tracing'
+        - message: UIPlugin name must be 'dashboards' if type is Dashboards
+          rule: self.spec.type != 'Dashboards' || self.metadata.name == 'dashboards'
     served: true
     storage: true
     subresources:

--- a/pkg/apis/uiplugin/v1alpha1/types.go
+++ b/pkg/apis/uiplugin/v1alpha1/types.go
@@ -15,6 +15,10 @@ import (
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:validation:XValidation:rule="self.spec.type != 'Logging' || self.metadata.name == 'logging'",message="UIPlugin name must be 'logging' if type is Logging"
+// +kubebuilder:validation:XValidation:rule="self.spec.type != 'TroubleshootingPanel' || self.metadata.name == 'troubleshooting-panel'",message="UIPlugin name must be 'troubleshooting-panel' if type is TroubleshootingPanel"
+// +kubebuilder:validation:XValidation:rule="self.spec.type != 'DistributedTracing' || self.metadata.name == 'distributed-tracing'",message="UIPlugin name must be 'distributed-tracing' if type is DistributedTracing"
+// +kubebuilder:validation:XValidation:rule="self.spec.type != 'Dashboards' || self.metadata.name == 'dashboards'",message="UIPlugin name must be 'dashboards' if type is Dashboards"
 type UIPlugin struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
[OU-402](https://issues.redhat.com/browse/OU-402)
[COO-164](https://issues.redhat.com/browse/COO-164)

This PR adds a pattern restriction for the UIPlugin name so only a single instance of a specific plugin is allowed