### PR TITLE
fix: Some typos and reconciliation of optional UIPlugin components

### DIFF
--- a/pkg/apis/uiplugin/v1alpha1/types.go
+++ b/pkg/apis/uiplugin/v1alpha1/types.go
@@ -35,7 +35,7 @@ type UIPluginList struct {
 type UIPluginType string
 
 const (
-	// Dashboards deploys the Dashboards Dynamic Plugin for OpenShift Console.
+	// TypeDashboards deploys the Dashboards Dynamic Plugin for OpenShift Console.
 	TypeDashboards UIPluginType = "Dashboards"
 )
 

--- a/pkg/controllers/uiplugin/compatibility_matrix.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix.go
@@ -34,7 +34,7 @@ func getImageKeyForPluginType(pluginType uiv1alpha1.UIPluginType, clusterVersion
 
 	// No console plugins are supported before 4.11
 	if semver.Compare(clusterVersion, "v4.11") < 0 {
-		return "", fmt.Errorf("dynamic pluings not supported before 4.11")
+		return "", fmt.Errorf("dynamic plugins not supported before 4.11")
 	}
 
 	for _, entry := range compatibilityMatrix {

--- a/pkg/controllers/uiplugin/compatibility_matrix.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix.go
@@ -43,7 +43,7 @@ func getImageKeyForPluginType(pluginType uiv1alpha1.UIPluginType, clusterVersion
 				return entry.ImageKey, nil
 			}
 
-			if semver.Compare(clusterVersion, entry.MinClusterVersion) >= 0 && semver.Compare(clusterVersion, entry.MaxClusterVersion) < 0 {
+			if semver.Compare(clusterVersion, entry.MinClusterVersion) >= 0 && semver.Compare(clusterVersion, entry.MaxClusterVersion) <= 0 {
 				return entry.ImageKey, nil
 			}
 		}

--- a/pkg/controllers/uiplugin/compatibility_matrix_test.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix_test.go
@@ -20,7 +20,7 @@ func TestCompatibilityMatrixSpec(t *testing.T) {
 			pluginType:     uiv1alpha1.TypeDashboards,
 			clusterVersion: "4.10",
 			expectedKey:    "",
-			expectedErr:    fmt.Errorf("dynamic pluings not supported before 4.11"),
+			expectedErr:    fmt.Errorf("dynamic plugins not supported before 4.11"),
 		},
 		{
 			pluginType:     uiv1alpha1.TypeDashboards,

--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -22,18 +22,24 @@ const (
 )
 
 func pluginComponentReconcilers(plugin *uiv1alpha1.UIPlugin, pluginInfo UIPluginInfo) []reconciler.Reconciler {
-	hasRole := pluginInfo.Role != nil
-	hasRoleBinding := pluginInfo.RoleBinding != nil
 	namespace := pluginInfo.ResourceNamespace
 
-	return []reconciler.Reconciler{
+	components := []reconciler.Reconciler{
 		reconciler.NewUpdater(newServiceAccount(pluginInfo, namespace), plugin),
-		reconciler.NewOptionalUpdater(newRole(pluginInfo), plugin, hasRole),
-		reconciler.NewOptionalUpdater(newRoleBinding(pluginInfo), plugin, hasRoleBinding),
 		reconciler.NewUpdater(newDeployment(pluginInfo, namespace), plugin),
 		reconciler.NewUpdater(newService(pluginInfo, namespace), plugin),
 		reconciler.NewUpdater(newConsolePlugin(pluginInfo, namespace), plugin),
 	}
+
+	if pluginInfo.Role != nil {
+		components = append(components, reconciler.NewUpdater(newRole(pluginInfo), plugin))
+	}
+
+	if pluginInfo.RoleBinding != nil {
+		components = append(components, reconciler.NewUpdater(newRoleBinding(pluginInfo), plugin))
+	}
+
+	return components
 }
 
 func newServiceAccount(info UIPluginInfo, namespace string) *corev1.ServiceAccount {


### PR DESCRIPTION
These commits have been extracted from #477, so that they can be separately reviewed and merged quicker.

PTAL @jgbernalp 