### PR TITLE
fix: install shellcheck for lint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint-jsonnet: $(JSONNET_LINT) jsonnet-vendor
 	| xargs -n 1 -- $(JSONNET_LINT) -J $(JSONNET_VENDOR)
 
 .PHONY: lint-shell
-lint-shell:
+lint-shell: $(SHELLCHECK)
 	find -name "*.sh" -print0 | xargs --null $(SHELLCHECK)
 
 .PHONY: fmt-jsonnet


### PR DESCRIPTION
Small fix extracted from #477 