### PR TITLE
chore: edit OWNERS maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,17 +4,21 @@ aliases:
     - tremes
     - danielmellado
     - simonpasquier
-    - sthaha
     - slashpai
-    - JoaoBraveCoding
     - thibaultmg
     - machine424
     - rexagod
     - lihongyan1
     - marioferh
+    - jgbernalp
+    - alanconway
+    - periklis
   maintainers:
     - jan--f
     - danielmellado
     - simonpasquier
-    - sthaha
     - slashpai
+    - marioferh
+    - jgbernalp
+    - alanconway
+    - periklis


### PR DESCRIPTION
Given that Observability Operator is growing in terms of componentes,
once the initial bootstrap has been done, and before we properly split
this into different owners files I'm adding some folks to take care of
specific dashboards and korrel8r parts.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>
