### PR TITLE
 COO-179: fix: compatibility matrix version validation

### DIFF
--- a/pkg/controllers/uiplugin/compatibility_matrix.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix.go
@@ -92,11 +92,11 @@ func lookupImageAndFeatures(pluginType uiv1alpha1.UIPluginType, clusterVersion s
 
 	for _, entry := range compatibilityMatrix {
 		if entry.PluginType == pluginType {
-			if entry.MaxClusterVersion == "" && semver.Compare(clusterVersion, entry.MinClusterVersion) >= 0 {
-				return entry, nil
-			}
+			canonicalMinClusterVersion := fmt.Sprintf("%s-0", semver.Canonical(entry.MinClusterVersion))
 
-			if semver.Compare(clusterVersion, entry.MinClusterVersion) >= 0 && semver.Compare(clusterVersion, entry.MaxClusterVersion) <= 0 {
+			if entry.MaxClusterVersion == "" && semver.Compare(clusterVersion, canonicalMinClusterVersion) >= 0 {
+				return entry, nil
+			} else if semver.Compare(clusterVersion, canonicalMinClusterVersion) >= 0 && semver.Compare(clusterVersion, entry.MaxClusterVersion) <= 0 {
 				return entry, nil
 			}
 		}

--- a/pkg/controllers/uiplugin/compatibility_matrix_test.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix_test.go
@@ -11,10 +11,11 @@ import (
 
 func TestLookupImageAndFeatures(t *testing.T) {
 	tt := []struct {
-		pluginType     uiv1alpha1.UIPluginType
-		clusterVersion string
-		expectedKey    string
-		expectedErr    error
+		pluginType       uiv1alpha1.UIPluginType
+		clusterVersion   string
+		expectedKey      string
+		expectedErr      error
+		expectedFeatures []string
 	}{
 		{
 			pluginType:     uiv1alpha1.TypeDashboards,
@@ -33,6 +34,16 @@ func TestLookupImageAndFeatures(t *testing.T) {
 			clusterVersion: "4.24.0-0.nightly-2024-03-11-200348",
 			expectedKey:    "ui-dashboards",
 			expectedErr:    nil,
+		},
+		{
+			pluginType:     uiv1alpha1.TypeLogging,
+			clusterVersion: "4.13",
+			expectedKey:    "ui-logging",
+			expectedErr:    nil,
+			expectedFeatures: []string{
+				"dev-console",
+				"alerts",
+			},
 		},
 		{
 			pluginType:     uiv1alpha1.TypeLogging,
@@ -84,12 +95,28 @@ func TestLookupImageAndFeatures(t *testing.T) {
 			expectedKey:    "",
 			expectedErr:    fmt.Errorf("no compatible image found for plugin type non-existent-plugin and cluster version v4.24.0-0.nightly-2024-03-11-200348"),
 		},
+		{
+			pluginType:     uiv1alpha1.TypeDistributedTracing,
+			clusterVersion: "4.16.0-rc.3",
+			expectedKey:    "ui-distributed-tracing",
+			expectedErr:    nil,
+		},
+		{
+			pluginType:     uiv1alpha1.TypeTroubleshootingPanel,
+			clusterVersion: "v4.16.0-0.nightly-2024-06-06-064349",
+			expectedKey:    "ui-troubleshooting-panel",
+			expectedErr:    nil,
+		},
 	}
 
 	for _, tc := range tt {
 		info, err := lookupImageAndFeatures(tc.pluginType, tc.clusterVersion)
 
 		assert.Equal(t, tc.expectedKey, info.ImageKey)
+
+		if tc.expectedFeatures != nil {
+			assert.DeepEqual(t, tc.expectedFeatures, info.Features)
+		}
 
 		if tc.expectedErr != nil {
 			assert.Error(t, err, tc.expectedErr.Error())


### PR DESCRIPTION
This PR fixes the min version semver validation for allowing plugins to be enabled in nightly cluster versions.

[COO-179](https://issues.redhat.com//browse/COO-179)