### PR TITLE
fix: update distributed_tracing.go to include a service proxy

### DIFF
--- a/pkg/controllers/uiplugin/distributed_tracing.go
+++ b/pkg/controllers/uiplugin/distributed_tracing.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -36,6 +37,18 @@ func createDistributedTracingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, 
 		DisplayName:       "Distributed Tracing Console Plugin",
 		ResourceNamespace: namespace,
 		ExtraArgs:         extraArgs,
+		Proxies: []osv1alpha1.ConsolePluginProxy{
+			{
+				Type:      osv1alpha1.ProxyTypeService,
+				Alias:     "backend",
+				Authorize: true,
+				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
+					Name:      name,
+					Namespace: namespace,
+					Port:      9443,
+				},
+			},
+		},
 		ConfigMap: &corev1.ConfigMap{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: corev1.SchemeGroupVersion.String(),


### PR DESCRIPTION
Updates are needed to reflect the changes in PR: https://github.com/openshift/distributed-tracing-console-plugin/pull/15, which allows the distributed-tracing-console-plugin to use this proxy service  at the endpoint : `/api/proxy/plugin/distributed-tracing-console-plugin/backend`