### PR TITLE
COO-181: fix: Change only the console plugins to avoid mutating existing cluster configuration

### DIFF
--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -245,22 +245,7 @@ func (rm resourceManager) registerPluginWithConsole(ctx context.Context, pluginI
 	clusterPlugins := append(cluster.Spec.Plugins, pluginInfo.ConsoleName)
 
 	// Register the plugin with the console
-	cluster = &operatorv1.Console{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: operatorv1.GroupVersion.String(),
-			Kind:       "Console",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "cluster",
-		},
-		Spec: operatorv1.ConsoleSpec{
-			OperatorSpec: operatorv1.OperatorSpec{
-				ManagementState: operatorv1.Managed,
-			},
-			Plugins:       clusterPlugins,
-			Customization: *cluster.Spec.Customization.DeepCopy(),
-		},
-	}
+	cluster.Spec.Plugins = clusterPlugins
 
 	if err := reconciler.NewMerger(cluster).Reconcile(ctx, rm.k8sClient, rm.scheme); err != nil {
 		return err


### PR DESCRIPTION
This PR adjusts the merge object so only console plugins are changed in the console resource to avoid affecting other fields.