### PR TITLE
COO-183: Prevent Reconcile Loop for Troubleshooting Panel UIPlugin

### DIFF
--- a/pkg/controllers/uiplugin/troubleshooting_panel.go
+++ b/pkg/controllers/uiplugin/troubleshooting_panel.go
@@ -44,7 +44,7 @@ func createTroubleshootingPanelPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace
 			{
 				Type:      osv1alpha1.ProxyTypeService,
 				Alias:     "korrel8r",
-				Authorize: false,
+				Authorize: true,
 				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
 					Name:      korrel8rSvcName,
 					Namespace: namespace,


### PR DESCRIPTION
Although the troubleshooting panel will deploy after #501, it reconciles in a loop.

Since the UIPlugin proxy spec is still of type v1alpha1, when it is created it gets converted to use v1 instead. Having `authorize: false` creates a v1 version that is different enough from from the v1alpha1 to cause a reconciliation. However, the conversion again happens leading to a loop.
