### PR TITLE
COO-186: fix: add korrel8r proxy configuration to logging view plugin

### DIFF
--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -25,6 +25,7 @@ const (
 	port                   = 9443
 	serviceAccountSuffix   = "-sa"
 	servingCertVolumeName  = "serving-cert"
+	korrel8rName           = "korrel8r"
 	Korrel8rConfigFileName = "korrel8r.yaml"
 	Korrel8rConfigMountDir = "/config/"
 	OpenshiftLoggingNs     = "openshift-logging"
@@ -79,12 +80,11 @@ func pluginComponentReconcilers(plugin *uiv1alpha1.UIPlugin, pluginInfo UIPlugin
 	}
 
 	if pluginInfo.Korrel8rImage != "" {
-		kname := "korrel8r"
-		components = append(components, reconciler.NewUpdater(newKorrel8rService(kname, namespace), plugin))
-		korrel8rCm, err := newKorrel8rConfigMap(kname, namespace, pluginInfo)
+		components = append(components, reconciler.NewUpdater(newKorrel8rService(korrel8rName, namespace), plugin))
+		korrel8rCm, err := newKorrel8rConfigMap(korrel8rName, namespace, pluginInfo)
 		if err == nil && korrel8rCm != nil {
 			components = append(components, reconciler.NewUpdater(korrel8rCm, plugin))
-			components = append(components, reconciler.NewUpdater(newKorrel8rDeployment(kname, namespace, pluginInfo), plugin))
+			components = append(components, reconciler.NewUpdater(newKorrel8rDeployment(korrel8rName, namespace, pluginInfo), plugin))
 		}
 	}
 

--- a/pkg/controllers/uiplugin/logging.go
+++ b/pkg/controllers/uiplugin/logging.go
@@ -62,6 +62,16 @@ func createLoggingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, image
 					Port:      8080,
 				},
 			},
+			{
+				Type:      "Service",
+				Alias:     "korrel8r",
+				Authorize: true,
+				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
+					Name:      korrel8rName,
+					Namespace: namespace,
+					Port:      port,
+				},
+			},
 		},
 		ConfigMap: &corev1.ConfigMap{
 			TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
This PR adds the korrel8r proxy configuration so the the logging view plugin can discover korrel8r and correlation links are shown.