### PR TITLE
Add Clusterrole to allow Korrel8r to view all signal data

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -271,6 +271,25 @@ spec:
           - ""
           resources:
           - configmaps
+          - endpoints
+          - events
+          - namespaces
+          - nodes
+          - persistentvolumeclaims
+          - persistentvolumes
+          - pods
+          - replicationcontrollers
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
           - serviceaccounts
           - services
           verbs:
@@ -307,6 +326,17 @@ spec:
         - apiGroups:
           - apps
           resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
           - deployments
           verbs:
           - create
@@ -314,6 +344,23 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - config.openshift.io
@@ -364,6 +411,34 @@ spec:
           - infrastructure
           verbs:
           - get
+        - apiGroups:
+          - loki.grafana.com
+          resources:
+          - application
+          - audit
+          - infrastructure
+          - network
+          verbs:
+          - get
+        - apiGroups:
+          - monitoring.coreos.com
+          resourceNames:
+          - main
+          resources:
+          - alertmanagers/api
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - monitoring.coreos.com
+          resourceNames:
+          - k8s
+          resources:
+          - prometheuses/api
+          verbs:
+          - create
+          - get
+          - update
         - apiGroups:
           - monitoring.rhobs
           resources:
@@ -439,6 +514,15 @@ spec:
           - patch
           - update
         - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          - networkpolicies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - observability.openshift.io
           resources:
           - uiplugins
@@ -481,6 +565,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -495,6 +580,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -520,6 +606,15 @@ spec:
           - securitycontextconstraints
           verbs:
           - use
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          - volumeattachments
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - tempo.grafana.com
           resources:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -43,7 +43,7 @@ var defaultImages = map[string]string{
 	"ui-troubleshooting-panel": "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v0.1.0",
 	"ui-distributed-tracing":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.1.0",
 	"ui-logging":               "quay.io/openshift-logging/logging-view-plugin:6.0.0",
-	"korrel8r":                 "quay.io/korrel8r/korrel8r:0.6.5",
+	"korrel8r":                 "quay.io/korrel8r/korrel8r:0.6.6",
 }
 
 func imagesUsed() []string {

--- a/deploy/operator/observability-operator-cluster-role.yaml
+++ b/deploy/operator/observability-operator-cluster-role.yaml
@@ -8,6 +8,25 @@ rules:
   - ""
   resources:
   - configmaps
+  - endpoints
+  - events
+  - namespaces
+  - nodes
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - replicationcontrollers
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
   - serviceaccounts
   - services
   verbs:
@@ -44,6 +63,17 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - deployments
   verbs:
   - create
@@ -51,6 +81,23 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - config.openshift.io
@@ -101,6 +148,34 @@ rules:
   - infrastructure
   verbs:
   - get
+- apiGroups:
+  - loki.grafana.com
+  resources:
+  - application
+  - audit
+  - infrastructure
+  - network
+  verbs:
+  - get
+- apiGroups:
+  - monitoring.coreos.com
+  resourceNames:
+  - main
+  resources:
+  - alertmanagers/api
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - monitoring.coreos.com
+  resourceNames:
+  - k8s
+  resources:
+  - prometheuses/api
+  verbs:
+  - create
+  - get
+  - update
 - apiGroups:
   - monitoring.rhobs
   resources:
@@ -176,6 +251,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - observability.openshift.io
   resources:
   - uiplugins
@@ -218,6 +302,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -232,6 +317,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -257,6 +343,15 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - tempo.grafana.com
   resources:

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -75,6 +75,20 @@ const (
 // RBAC for logging view plugin
 // +kubebuilder:rbac:groups=loki.grafana.com,resources=application;infrastructure;audit,verbs=get
 
+// RBAC for korrel8r
+//+kubebuilder:rbac:groups=apps,resources=daemonsets;deployments;replicasets;statefulsets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps;endpoints;events;namespaces;nodes;persistentvolumeclaims;persistentvolumes;pods;replicationcontrollers;secrets;serviceaccounts;services,verbs=get;list;watch
+//+kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
+//+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
+//+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses;volumeattachments,verbs=get;list;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies;ingresses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=loki.grafana.com,resources=application;infrastructure;audit;network,verbs=get
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,resourceNames=k8s,verbs=get;create;update
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers/api,resourceNames=main,verbs=get;list
+
+// RegisterWithManager registers the controller with Manager
 func RegisterWithManager(mgr ctrl.Manager, opts Options) error {
 	logger := ctrl.Log.WithName("observability-ui")
 


### PR DESCRIPTION
This PR creates the required clusterroles and clusterrolebindingss, so that korrel8r can query all the required resources
Adds additional clusterrolebinding and rolebinding so that korrel8r can connect to Prometheus endpoints and retrieve relevant data. 
All of the roles and rolebindings are created within the operator