### PR TITLE
chore: update GitHub actions to setup-go@v5

### DIFF
--- a/.github/e2e-tests-olm/action.yaml
+++ b/.github/e2e-tests-olm/action.yaml
@@ -23,11 +23,10 @@ runs:
         wait: 300s
         config: ./hack/kind/config.yaml
 
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
         check-latest: true
-        cache: true
 
     - name: Install required tools
       uses: ./.github/tools-cache

--- a/.github/olm-publish/action.yaml
+++ b/.github/olm-publish/action.yaml
@@ -11,11 +11,10 @@ runs:
   using: composite
   steps:
   - name: Setup Go environment
-    uses: actions/setup-go@v3
+    uses: actions/setup-go@v5
     with:
       go-version-file: 'go.mod'
       check-latest: true
-      cache: true
 
   - name: Install tools
     uses: ./.github/tools-cache

--- a/.github/osd-test-harness-publish/action.yaml
+++ b/.github/osd-test-harness-publish/action.yaml
@@ -11,11 +11,10 @@ runs:
   using: composite
   steps:
   - name: Setup Go environment
-    uses: actions/setup-go@v3
+    uses: actions/setup-go@v5
     with:
       go-version-file: 'go.mod'
       check-latest: true
-      cache: true
 
   - name: Install tools
     uses: ./.github/tools-cache

--- a/.github/package-operator-publish/action.yaml
+++ b/.github/package-operator-publish/action.yaml
@@ -15,11 +15,10 @@ runs:
       fetch-depth: 0
 
   - name: Setup Go environment
-    uses: actions/setup-go@v3
+    uses: actions/setup-go@v5
     with:
       go-version-file: 'go.mod'
       check-latest: true
-      cache: true
 
   - name: Install tools
     uses: ./.github/tools-cache

--- a/.github/tools-cache/action.yaml
+++ b/.github/tools-cache/action.yaml
@@ -1,9 +1,9 @@
 name: tools-cache
-description: Caches develoment tools
+description: Caches development tools
 runs:
   using: composite
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       id: tools-cache
       with:
         path: ./tmp/bin
@@ -14,7 +14,7 @@ runs:
       shell: bash
       run: make tools
 
-    - name: Show version info of tools
+    - name: Show versions of the installed tools
       shell: bash
       run: |
         ls ./tmp/bin

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,9 +1,10 @@
-name: checks
+name: Pre-submit tests
 on:
   pull_request:
 
 jobs:
   commit-lint:
+    name: Lint the commit messages
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -12,15 +13,15 @@ jobs:
       - uses: wagoid/commitlint-github-action@v6
 
   github-actions-yaml-lint:
+    name: Lint Github Action
     runs-on: ubuntu-latest
-    name: Github Actions yaml linter
     steps:
       - uses: actions/checkout@v4
       - uses: reviewdog/action-actionlint@v1
 
   lint:
+    name: Lint code
     runs-on: ubuntu-latest
-    name: Run all lints
     steps:
       - uses: actions/checkout@v4
 
@@ -28,26 +29,22 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          cache: true
 
       - name: Use tools cache
         uses: ./.github/tools-cache
 
-      - name: golangci-lint
+      - name: Lint Go code
         run: make lint-golang
 
-      - name: jsonnet-fmt
-        run: make fmt-jsonnet && git diff --exit-code
+      - name: Lint Jsonnet code
+        run: make fmt-jsonnet lint-jsonnet && git diff --exit-code
 
-      - name: jsonnet-lint
-        run: make lint-jsonnet
-
-      - name: shellcheck
+      - name: Lint Shell scripts
         run: make lint-shell
 
   generate:
+    name: Verify generated code
     runs-on: ubuntu-latest
-    name: Generate and format
     steps:
       - uses: actions/checkout@v4
 
@@ -55,11 +52,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          cache: true
 
-      - run: make --always-make generate && git diff --exit-code
-
-      - run: make --always-make bundle && git diff --exit-code
+      - run: make --always-make generate bundle && git diff --exit-code
 
   tool-versions:
     runs-on: ubuntu-latest
@@ -71,14 +65,14 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          cache: true
 
-      - name: Use tools cache
+      - name: Install tools
         uses: ./.github/tools-cache
 
       - run: make --always-make tools && git diff --exit-code
 
   build-bundle-image:
+    name: Build bundle image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -97,6 +91,7 @@ jobs:
         run: make bundle-image
 
   e2e-tests-olm:
+    name: Run end-to-end tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 # Decide between Pre-Release and Development Release
-name: release
+name: Release
 on:
   push:
     branches: [main]
@@ -33,7 +33,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          cache: true
 
       - name: Set version
         id: version
@@ -98,7 +97,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          cache: true
 
       - name: Generate release notes
         run: |
@@ -142,7 +140,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
           check-latest: true
-          cache: true
 
       - name: Set version
         id: version


### PR DESCRIPTION
This change updates all actions to use actions/setup-go@v5. In this version, caching is enabled by default hence it removes all `cache: true` occurrences.