### PR TITLE
COO-225: fix: Add support for ConsolePlugin v1

### DIFF
--- a/pkg/controllers/uiplugin/components_test.go
+++ b/pkg/controllers/uiplugin/components_test.go
@@ -1,0 +1,56 @@
+package uiplugin
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestIsVersionAheadOrEqual(t *testing.T) {
+	testCases := []struct {
+		clusterVersion     string
+		nextClusterVersion string
+		expected           bool
+	}{
+		{
+			clusterVersion:     "v4.18",
+			nextClusterVersion: "v4.17",
+			expected:           true,
+		},
+		{
+			clusterVersion:     "v4.17",
+			nextClusterVersion: "v4.17",
+			expected:           true,
+		},
+		{
+			clusterVersion:     "v4.16",
+			nextClusterVersion: "v4.17",
+			expected:           false,
+		},
+		{
+			clusterVersion:     "4.18",
+			nextClusterVersion: "v4.17",
+			expected:           true,
+		},
+		{
+			clusterVersion:     "4.17.0-0.nightly-2024-07-09-121045",
+			nextClusterVersion: "v4.17",
+			expected:           true,
+		},
+		{
+			clusterVersion:     "4.16.0-0.nightly-2024-07-09-121045",
+			nextClusterVersion: "v4.17",
+			expected:           false,
+		},
+		{
+			clusterVersion:     "v4.18",
+			nextClusterVersion: "",
+			expected:           false,
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := isVersionAheadOrEqual(tc.clusterVersion, tc.nextClusterVersion)
+		assert.Equal(t, tc.expected, actual)
+	}
+}

--- a/pkg/controllers/uiplugin/distributed_tracing.go
+++ b/pkg/controllers/uiplugin/distributed_tracing.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	osv1 "github.com/openshift/api/console/v1"
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -37,7 +38,7 @@ func createDistributedTracingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, 
 		DisplayName:       "Distributed Tracing Console Plugin",
 		ResourceNamespace: namespace,
 		ExtraArgs:         extraArgs,
-		Proxies: []osv1alpha1.ConsolePluginProxy{
+		LegacyProxies: []osv1alpha1.ConsolePluginProxy{
 			{
 				Type:      osv1alpha1.ProxyTypeService,
 				Alias:     "backend",
@@ -45,7 +46,21 @@ func createDistributedTracingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, 
 				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
 					Name:      name,
 					Namespace: namespace,
-					Port:      9443,
+					Port:      port,
+				},
+			},
+		},
+		Proxies: []osv1.ConsolePluginProxy{
+			{
+				Alias:         "backend",
+				Authorization: "UserToken",
+				Endpoint: osv1.ConsolePluginProxyEndpoint{
+					Type: osv1.ProxyTypeService,
+					Service: &osv1.ConsolePluginProxyServiceConfig{
+						Name:      name,
+						Namespace: namespace,
+						Port:      port,
+					},
 				},
 			},
 		},

--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	osv1 "github.com/openshift/api/console/v1"
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -21,7 +22,8 @@ type UIPluginInfo struct {
 	ConsoleName         string
 	DisplayName         string
 	ExtraArgs           []string
-	Proxies             []osv1alpha1.ConsolePluginProxy
+	LegacyProxies       []osv1alpha1.ConsolePluginProxy
+	Proxies             []osv1.ConsolePluginProxy
 	Role                *rbacv1.Role
 	RoleBinding         *rbacv1.RoleBinding
 	ClusterRoles        []*rbacv1.ClusterRole
@@ -54,7 +56,7 @@ func PluginInfoBuilder(ctx context.Context, k client.Client, plugin *uiv1alpha1.
 			ConsoleName:       "console-dashboards-plugin",
 			DisplayName:       "Console Enhanced Dashboards",
 			ResourceNamespace: namespace,
-			Proxies: []osv1alpha1.ConsolePluginProxy{
+			LegacyProxies: []osv1alpha1.ConsolePluginProxy{
 				{
 					Type:      osv1alpha1.ProxyTypeService,
 					Alias:     "backend",
@@ -62,7 +64,21 @@ func PluginInfoBuilder(ctx context.Context, k client.Client, plugin *uiv1alpha1.
 					Service: osv1alpha1.ConsolePluginProxyServiceConfig{
 						Name:      name,
 						Namespace: namespace,
-						Port:      9443,
+						Port:      port,
+					},
+				},
+			},
+			Proxies: []osv1.ConsolePluginProxy{
+				{
+					Alias:         "backend",
+					Authorization: "UserToken",
+					Endpoint: osv1.ConsolePluginProxyEndpoint{
+						Type: osv1.ProxyTypeService,
+						Service: &osv1.ConsolePluginProxyServiceConfig{
+							Name:      name,
+							Namespace: namespace,
+							Port:      port,
+						},
 					},
 				},
 			},

--- a/pkg/controllers/uiplugin/troubleshooting_panel.go
+++ b/pkg/controllers/uiplugin/troubleshooting_panel.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	osv1 "github.com/openshift/api/console/v1"
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +45,7 @@ func createTroubleshootingPanelPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace
 		ResourceNamespace: namespace,
 		LokiServiceNames:  make(map[string]string),
 		ExtraArgs:         extraArgs,
-		Proxies: []osv1alpha1.ConsolePluginProxy{
+		LegacyProxies: []osv1alpha1.ConsolePluginProxy{
 			{
 				Type:      osv1alpha1.ProxyTypeService,
 				Alias:     "korrel8r",
@@ -52,7 +53,21 @@ func createTroubleshootingPanelPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace
 				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
 					Name:      korrel8rSvcName,
 					Namespace: namespace,
-					Port:      9443,
+					Port:      port,
+				},
+			},
+		},
+		Proxies: []osv1.ConsolePluginProxy{
+			{
+				Alias:         "korrel8r",
+				Authorization: "UserToken",
+				Endpoint: osv1.ConsolePluginProxyEndpoint{
+					Type: osv1.ProxyTypeService,
+					Service: &osv1.ConsolePluginProxyServiceConfig{
+						Name:      korrel8rSvcName,
+						Namespace: namespace,
+						Port:      port,
+					},
 				},
 			},
 		},

--- a/pkg/operator/scheme.go
+++ b/pkg/operator/scheme.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	osv1 "github.com/openshift/api/console/v1"
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	monitoringv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
@@ -23,6 +24,7 @@ func NewScheme(cfg *OperatorConfiguration) *runtime.Scheme {
 	utilruntime.Must(uiv1alpha1.AddToScheme(scheme))
 
 	if cfg.FeatureGates.OpenShift.Enabled {
+		utilruntime.Must(osv1.AddToScheme(scheme))
 		utilruntime.Must(osv1alpha1.AddToScheme(scheme))
 		utilruntime.Must(operatorv1.AddToScheme(scheme))
 	}


### PR DESCRIPTION
This PR adds support for ConsolePlugin CR v1 for OCP 4.17. For older versions the v1alpha1 support was kept