### PR TITLE
feat: update RBAC to include listing TempoMonolithic CRs

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:0.3.5
-    createdAt: "2024-08-07T10:19:11Z"
+    createdAt: "2024-08-09T13:29:41Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
@@ -618,6 +618,7 @@ spec:
         - apiGroups:
           - tempo.grafana.com
           resources:
+          - tempomonolithics
           - tempostacks
           verbs:
           - list

--- a/deploy/operator/observability-operator-cluster-role.yaml
+++ b/deploy/operator/observability-operator-cluster-role.yaml
@@ -355,6 +355,7 @@ rules:
 - apiGroups:
   - tempo.grafana.com
   resources:
+  - tempomonolithics
   - tempostacks
   verbs:
   - list

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -71,7 +71,7 @@ const (
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;list;watch
 
 // RBAC for distributed tracing
-// +kubebuilder:rbac:groups=tempo.grafana.com,resources=tempostacks,verbs=list
+// +kubebuilder:rbac:groups=tempo.grafana.com,resources=tempostacks;tempomonolithics,verbs=list
 
 // RBAC for logging view plugin
 // +kubebuilder:rbac:groups=loki.grafana.com,resources=application;infrastructure;audit,verbs=get

--- a/pkg/controllers/uiplugin/distributed_tracing.go
+++ b/pkg/controllers/uiplugin/distributed_tracing.go
@@ -90,7 +90,7 @@ func createDistributedTracingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, 
 				Rules: []rbacv1.PolicyRule{
 					{
 						APIGroups: []string{"tempo.grafana.com"},
-						Resources: []string{"tempostacks"},
+						Resources: []string{"tempostacks", "tempomonolithics"},
 						Verbs:     []string{"list"},
 					},
 				},


### PR DESCRIPTION
Update RBAC to include listing TempoMonolithic CRs.
Soon the Distributed Tracing UI Plugin will support Tempo deployments in monolithic mode (TempoMonolithic CR).

https://issues.redhat.com/browse/OU-490

cc @jgbernalp 