### PR TITLE
chore: flag PrometheusAgent CRD as internal

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,14 +42,16 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:0.4.0
-    createdAt: "2024-08-29T09:10:03Z"
+    createdAt: "2024-08-30T12:02:05Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
     operators.operatorframework.io/internal-objects: |-
       [
-        "prometheuses.monitoring.rhobs", "alertmanagers.monitoring.rhobs",
-        "thanosrulers.monitoring.rhobs"
+        "prometheuses.monitoring.rhobs",
+        "alertmanagers.monitoring.rhobs",
+        "thanosrulers.monitoring.rhobs",
+        "prometheusagents.monitoring.rhobs",
       ]
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/rhobs/observability-operator

--- a/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
+++ b/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
@@ -13,8 +13,10 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.24.0
     operators.operatorframework.io/internal-objects: |-
       [
-        "prometheuses.monitoring.rhobs", "alertmanagers.monitoring.rhobs",
-        "thanosrulers.monitoring.rhobs"
+        "prometheuses.monitoring.rhobs",
+        "alertmanagers.monitoring.rhobs",
+        "thanosrulers.monitoring.rhobs",
+        "prometheusagents.monitoring.rhobs",
       ]
     repository: 'https://github.com/rhobs/observability-operator'
   name: observability-operator.v0.0.0

--- a/deploy/package-operator/dependencies/kustomization.yaml
+++ b/deploy/package-operator/dependencies/kustomization.yaml
@@ -70,12 +70,3 @@ patchesStrategicMerge:
       labels:
         app.kubernetes.io/name: prometheus-operator-admission-webhook
     $patch: delete
-  # patchesJson6902:
-  # - path: patches/admission-webhook-service-namespace.yaml
-  #   target:
-  #     kind: ValidatingWebhookConfiguration
-  #     name: prometheusrules.monitoring.rhobs
-  # - path: patches/admission-webhook-service-namespace.yaml
-  #   target:
-  #     kind: ValidatingWebhookConfiguration
-  #     name: alertmanagerconfigs.monitoring.rhobs


### PR DESCRIPTION
This is aligned with the other CRDs like Prometheus and Alertmanager.