### PR TITLE
docs: fix dashboard plugin name in example

### DIFF
--- a/docs/user-guides/observability-ui-plugins.md
+++ b/docs/user-guides/observability-ui-plugins.md
@@ -28,7 +28,7 @@ To enable the console dashboards plugin, create a `UIPlugin` CR. The following e
 apiVersion: observability.openshift.io/v1alpha1
 kind: UIPlugin
 metadata:
-  name: ui-dashboards
+  name: dashboards
 spec:
   type: Dashboards
 ```


### PR DESCRIPTION
Since we validate the name of UIPlugins to ensure only one is deployed, the example in the docs should reflect the correct name to allow for users to copy it 