### PR TITLE
fix: avoid trying to run UI plugins as root

### DIFF
--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -269,6 +269,7 @@ func newDeployment(info UIPluginInfo, namespace string, config *uiv1alpha1.Deplo
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							SecurityContext: &corev1.SecurityContext{
 								RunAsNonRoot:             ptr.To(bool(true)),
+								RunAsUser:                ptr.To(int64(1000)),
 								AllowPrivilegeEscalation: ptr.To(bool(false)),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{


### PR DESCRIPTION
When trying to use the troubleshooting-panel UIPlugin, I was getting:

```
container has runAsNonRoot and image will run as root
(pod: "troubleshooting-panel-...
 container: troubleshooting-panel)'
 reason: CreateContainerConfigError
```

I guess it's because the troubleshooting panel is build without setting the non-root user https://github.com/openshift/troubleshooting-panel-console-plugin/blob/main/Dockerfile.

I'm not sure why anyone else wasn't hitting this issue… I was running this against OCP 4.16.