### PR TITLE
COO-152: fix: Add finalizer to cleanup the console after UIPlugin is deleted

### DIFF
--- a/pkg/controllers/uiplugin/compatibility_matrix_test.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix_test.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/mod/semver"
 	"gotest.tools/v3/assert"
 
-	"github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
 	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
 )
 
@@ -32,7 +31,7 @@ func TestCompatibilityMatrixVersions(t *testing.T) {
 
 // Ensure that there's only one empty max version per plugin.
 func TestCompatibilityMatrixMaxVersions(t *testing.T) {
-	cm := map[v1alpha1.UIPluginType]struct{}{}
+	cm := map[uiv1alpha1.UIPluginType]struct{}{}
 	for _, v := range compatibilityMatrix {
 		if v.MaxClusterVersion != "" {
 			continue

--- a/pkg/controllers/uiplugin/distributed_tracing.go
+++ b/pkg/controllers/uiplugin/distributed_tracing.go
@@ -34,7 +34,7 @@ func createDistributedTracingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, 
 	pluginInfo := &UIPluginInfo{
 		Image:             image,
 		Name:              plugin.Name,
-		ConsoleName:       "distributed-tracing-console-plugin",
+		ConsoleName:       pluginTypeToConsoleName[plugin.Spec.Type],
 		DisplayName:       "Distributed Tracing Console Plugin",
 		ResourceNamespace: namespace,
 		ExtraArgs:         extraArgs,

--- a/pkg/controllers/uiplugin/logging.go
+++ b/pkg/controllers/uiplugin/logging.go
@@ -48,7 +48,7 @@ func createLoggingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, image
 	pluginInfo := &UIPluginInfo{
 		Image:             image,
 		Name:              name,
-		ConsoleName:       "logging-view-plugin",
+		ConsoleName:       pluginTypeToConsoleName[plugin.Spec.Type],
 		DisplayName:       "Logging View",
 		ExtraArgs:         extraArgs,
 		ResourceNamespace: namespace,

--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -32,6 +32,13 @@ type UIPluginInfo struct {
 	ResourceNamespace   string
 }
 
+var pluginTypeToConsoleName = map[uiv1alpha1.UIPluginType]string{
+	uiv1alpha1.TypeDashboards:           "console-dashboards-plugin",
+	uiv1alpha1.TypeTroubleshootingPanel: "console-troubleshooting-plugin",
+	uiv1alpha1.TypeDistributedTracing:   "console-distributed-tracing-plugin",
+	uiv1alpha1.TypeLogging:              "console-logging-plugin",
+}
+
 func PluginInfoBuilder(ctx context.Context, k client.Client, plugin *uiv1alpha1.UIPlugin, pluginConf UIPluginsConfiguration, clusterVersion string) (*UIPluginInfo, error) {
 	compatibilityInfo, err := lookupImageAndFeatures(plugin.Spec.Type, clusterVersion)
 	if err != nil {
@@ -53,7 +60,7 @@ func PluginInfoBuilder(ctx context.Context, k client.Client, plugin *uiv1alpha1.
 		pluginInfo := &UIPluginInfo{
 			Image:             image,
 			Name:              name,
-			ConsoleName:       "console-dashboards-plugin",
+			ConsoleName:       pluginTypeToConsoleName[plugin.Spec.Type],
 			DisplayName:       "Console Enhanced Dashboards",
 			ResourceNamespace: namespace,
 			LegacyProxies: []osv1alpha1.ConsolePluginProxy{

--- a/pkg/controllers/uiplugin/troubleshooting_panel.go
+++ b/pkg/controllers/uiplugin/troubleshooting_panel.go
@@ -40,7 +40,7 @@ func createTroubleshootingPanelPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace
 	pluginInfo := &UIPluginInfo{
 		Image:             image,
 		Name:              plugin.Name,
-		ConsoleName:       "troubleshooting-panel-console-plugin",
+		ConsoleName:       pluginTypeToConsoleName[plugin.Spec.Type],
 		DisplayName:       "Troubleshooting Panel Console Plugin",
 		ResourceNamespace: namespace,
 		LokiServiceNames:  make(map[string]string),


### PR DESCRIPTION
This PR 

- Extracts the plugin console names into a map, so the console name can be obtained from the plugin type
- Adds a finalizer to the UIPlugin so it can be removed from console resource when the plugin is deleted, it uses the console name from the map to do so