### PR TITLE
COO-318: add uiplugin support annotations when created

### DIFF
--- a/pkg/controllers/uiplugin/compatibility_matrix.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix.go
@@ -11,6 +11,15 @@ import (
 	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
 )
 
+type SupportLevel string
+
+var (
+	DevPreview          SupportLevel = "DevPreview"
+	TechPreview         SupportLevel = "TechPreview"
+	GeneralAvailability SupportLevel = "GeneralAvailability"
+	Experimental_SSA    SupportLevel = "Experimental-SSA"
+)
+
 type CompatibilityEntry struct {
 	PluginType uiv1alpha1.UIPluginType
 	// Minimal OpenShift version supporting this plugin (inclusive).
@@ -22,6 +31,7 @@ type CompatibilityEntry struct {
 	// Maximal ACM version supporting this plugin (exclusive).
 	MaxAcmVersion string
 	ImageKey      string
+	SupportLevel  SupportLevel
 	Features      []string
 }
 
@@ -36,6 +46,7 @@ var compatibilityMatrix = []CompatibilityEntry{
 		MinAcmVersion:     "",
 		MaxAcmVersion:     "",
 		Features:          []string{},
+		SupportLevel:      DevPreview,
 	},
 	{
 		PluginType: uiv1alpha1.TypeTroubleshootingPanel,
@@ -47,6 +58,7 @@ var compatibilityMatrix = []CompatibilityEntry{
 		ImageKey:          "ui-troubleshooting-panel",
 		MinAcmVersion:     "",
 		MaxAcmVersion:     "",
+		SupportLevel:      TechPreview,
 		Features:          []string{},
 	},
 	{
@@ -56,6 +68,7 @@ var compatibilityMatrix = []CompatibilityEntry{
 		ImageKey:          "ui-distributed-tracing",
 		MinAcmVersion:     "",
 		MaxAcmVersion:     "",
+		SupportLevel:      TechPreview,
 		Features:          []string{},
 	},
 	{
@@ -65,6 +78,7 @@ var compatibilityMatrix = []CompatibilityEntry{
 		ImageKey:          "ui-logging",
 		MinAcmVersion:     "",
 		MaxAcmVersion:     "",
+		SupportLevel:      GeneralAvailability,
 		Features:          []string{},
 	},
 	{
@@ -74,6 +88,7 @@ var compatibilityMatrix = []CompatibilityEntry{
 		ImageKey:          "ui-logging",
 		MinAcmVersion:     "",
 		MaxAcmVersion:     "",
+		SupportLevel:      GeneralAvailability,
 		Features: []string{
 			"dev-console",
 		},
@@ -85,6 +100,7 @@ var compatibilityMatrix = []CompatibilityEntry{
 		ImageKey:          "ui-logging",
 		MinAcmVersion:     "",
 		MaxAcmVersion:     "",
+		SupportLevel:      GeneralAvailability,
 		Features: []string{
 			"dev-console",
 			"alerts",
@@ -97,6 +113,7 @@ var compatibilityMatrix = []CompatibilityEntry{
 		ImageKey:          "ui-logging",
 		MinAcmVersion:     "",
 		MaxAcmVersion:     "",
+		SupportLevel:      GeneralAvailability,
 		Features: []string{
 			"dev-console",
 			"alerts",
@@ -110,6 +127,7 @@ var compatibilityMatrix = []CompatibilityEntry{
 		ImageKey:          "ui-monitoring",
 		MinAcmVersion:     "v2.11",
 		MaxAcmVersion:     "",
+		SupportLevel:      DevPreview,
 		Features: []string{
 			"acm-alerting",
 		},

--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -40,11 +40,7 @@ var pluginTypeToConsoleName = map[uiv1alpha1.UIPluginType]string{
 	uiv1alpha1.TypeLogging:              "logging-view-plugin",
 }
 
-func PluginInfoBuilder(ctx context.Context, k client.Client, plugin *uiv1alpha1.UIPlugin, pluginConf UIPluginsConfiguration, clusterVersion string, acmVersion string) (*UIPluginInfo, error) {
-	compatibilityInfo, err := lookupImageAndFeatures(plugin.Spec.Type, clusterVersion, acmVersion)
-	if err != nil {
-		return nil, err
-	}
+func PluginInfoBuilder(ctx context.Context, k client.Client, plugin *uiv1alpha1.UIPlugin, pluginConf UIPluginsConfiguration, compatibilityInfo CompatibilityEntry) (*UIPluginInfo, error) {
 
 	image := pluginConf.Images[compatibilityInfo.ImageKey]
 	if image == "" {


### PR DESCRIPTION
This PR looks to address [COO-318](https://issues.redhat.com/browse/COO-318) by adding support level annotations to the UIPlugins based on their type after they are created.

This adds an extra couple of reconciliations for each plugin, but doesn't trigger a reconciliation loop and is able to stabilize. 