### PR TITLE
chore: add observability ui team members to contributors

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -13,6 +13,8 @@ aliases:
     - jgbernalp
     - alanconway
     - periklis
+    - peteryurkovich
+    - zhuje
   maintainers:
     - jan--f
     - danielmellado


### PR DESCRIPTION
Add myself and @zhuje to the contributors list. Once [COO-242](https://www.google.com/url?q=https://issues.redhat.com/browse/COO-242) has been finalized we can be moved down to a lower directory level if desired. 