### PR TITLE
COO-483: feat: add "Enable cluster monitoring" checkbox to OCP console

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,9 +42,10 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:0.4.2
-    createdAt: "2024-11-15T07:47:01Z"
+    createdAt: "2024-11-18T09:45:14Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
+    operatorframework.io/cluster-monitoring: "true"
     operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/internal-objects: |-
       [

--- a/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
+++ b/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
@@ -19,6 +19,7 @@ metadata:
         "prometheusagents.monitoring.rhobs"
       ]
     repository: 'https://github.com/rhobs/observability-operator'
+    operatorframework.io/cluster-monitoring: "true"
   name: observability-operator.v0.0.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
This change adds the 'operatorframework.io/cluster-monitoring=true' annotation to the operator's CSV.