### PR TITLE
fix: mktemp command expects a template string that includes a minimum…

### DIFF
--- a/test/run-e2e-ocp.sh
+++ b/test/run-e2e-ocp.sh
@@ -54,7 +54,7 @@ install_obo() {
 enable_ocp() {
   # Get ObO CSV json file
 	CSV_NAME=$(oc -n "$OPERATORS_NS" get sub observability-operator -o jsonpath='{.status.installedCSV}')
-	CSV_JSON_FILE=$(mktemp /tmp/"$CSV_NAME".json)
+	CSV_JSON_FILE=$(mktemp /tmp/"$CSV_NAME"XXXXXX.json)
 	if [ -e "$CSV_JSON_FILE" ]; then
 		rm -f "$CSV_JSON_FILE"
 	fi


### PR DESCRIPTION
… of six X characters on some os

The change fix issue [COO-491](https://issues.redhat.com/browse/COO-491)
