### PR TITLE
fix: failed to get metric when install upstream ObO on OCP

### DIFF
--- a/test/run-e2e-ocp.sh
+++ b/test/run-e2e-ocp.sh
@@ -68,6 +68,10 @@ enable_ocp() {
 
 	oc apply -f "$CSV_JSON_FILE"
 	rm -f "$CSV_JSON_FILE"
+
+	# enable platform monitoring
+	oc label ns "$OPERATORS_NS" openshift.io/cluster-monitoring=true
+
 	oc wait --for=condition=Established crd/uiplugins.observability.openshift.io --timeout=60s
 	ok "Enable OCP mode successfully"
 }


### PR DESCRIPTION
enable platform monitoring
fix issue [COO-618](https://issues.redhat.com/browse/COO-618)