### PR TITLE
OSD-28131: Deploying COO in place of OBO on SC clusters

### DIFF
--- a/deploy/olm/syncselector-template.yaml
+++ b/deploy/olm/syncselector-template.yaml
@@ -50,7 +50,6 @@ objects:
             operator: In
             values:
               - management-cluster
-              - service-cluster
       resourceApplyMode: Sync
       resources:
         - apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
This PR removes OBO subscription from Hypershift service clusters (SCs)

The following MR install COO on those clusters:
https://gitlab.cee.redhat.com/service/osd-fleet-manager/-/merge_requests/1043

This MR must be merged after above PR