### PR TITLE
feat: add Incidents backend

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -45,6 +45,7 @@ var defaultImages = map[string]string{
 	"ui-logging":               "quay.io/openshift-observability-ui/logging-view-plugin:v6.0.0",
 	"ui-monitoring":            "quay.io/openshift-observability-ui/monitoring-console-plugin:latest",
 	"korrel8r":                 "quay.io/korrel8r/korrel8r:0.7.4",
+	"health-analyzer":          "quay.io/openshiftanalytics/cluster-health-analyzer:latest",
 }
 
 func imagesUsed() []string {

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -89,6 +89,11 @@ const (
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,resourceNames=k8s,verbs=get;create;update
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers/api,resourceNames=main,verbs=get;list
 
+// RBAC for Health Analyzer
+//+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+//+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;update;patch;delete
+
 const finalizerName = "uiplugin.observability.openshift.io/finalizer"
 
 // RegisterWithManager registers the controller with Manager

--- a/pkg/controllers/uiplugin/health_analyzer.go
+++ b/pkg/controllers/uiplugin/health_analyzer.go
@@ -1,0 +1,215 @@
+package uiplugin
+
+import (
+	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+)
+
+const (
+	name            = "health-analyzer"
+	volumeMountName = name + "-tls"
+)
+
+func newHealthAnalyzerPrometheusRole(namespace string) *rbacv1.Role {
+	role := &rbacv1.Role{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+			Kind:       "Role",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-k8s",
+			Namespace: namespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"services", "endpoints", "pods"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	}
+	return role
+}
+
+func newHealthAnalyzerPrometheusRoleBinding(namespace string) *rbacv1.RoleBinding {
+	roleBinding := &rbacv1.RoleBinding{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: rbacv1.SchemeGroupVersion.String(),
+			Kind:       "RoleBinding",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "prometheus-k8s",
+			Namespace: namespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.SchemeGroupVersion.Group,
+			Kind:     "Role",
+			Name:     "prometheus-k8s",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "prometheus-k8s",
+				Namespace: "openshift-monitoring",
+			},
+		},
+	}
+	return roleBinding
+}
+
+func newHealthAnalyzerService(namespace string) *corev1.Service {
+	service := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"service.beta.openshift.io/serving-cert-secret-name": volumeMountName,
+			},
+			Labels: componentLabels(name),
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "metrics",
+					Port:       8443,
+					TargetPort: intstr.FromString("metrics"),
+				},
+			},
+			Selector: map[string]string{
+				"app.kubernetes.io/instance": name,
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	return service
+}
+
+func newHealthAnalyzerDeployment(namespace string, serviceAccountName string, pluginInfo UIPluginInfo) *appsv1.Deployment {
+	deploy := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    componentLabels(name),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(1)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/instance": name,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: componentLabels(name),
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName:           serviceAccountName,
+					AutomountServiceAccountToken: ptr.To(true),
+					Containers: []corev1.Container{
+						{
+							Name:            name,
+							Image:           pluginInfo.HealthAnalyzerImage,
+							ImagePullPolicy: corev1.PullAlways,
+							Args: []string{
+								"--tls-cert-file=/etc/tls/private/tls.crt",
+								"--tls-private-key-file=/etc/tls/private/tls.key",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "PROM_URL",
+									Value: "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/",
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot:             ptr.To(true),
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 8443,
+									Name:          "metrics",
+								},
+							},
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									MountPath: "/etc/tls/private",
+									Name:      volumeMountName,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: volumeMountName,
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: volumeMountName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return deploy
+}
+
+func newHealthAnalyzerServiceMonitor(namespace string) *monv1.ServiceMonitor {
+	serviceMonitor := &monv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: monv1.SchemeGroupVersion.String(),
+			Kind:       "ServiceMonitor",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: monv1.ServiceMonitorSpec{
+			Endpoints: []monv1.Endpoint{
+				{
+					Interval: "30s",
+					Port:     "metrics",
+					Scheme:   "https",
+					TLSConfig: &monv1.TLSConfig{
+						SafeTLSConfig: monv1.SafeTLSConfig{
+							ServerName: ptr.To(name + "." + namespace + ".svc"),
+						},
+						CAFile:   "/etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt",
+						CertFile: "/etc/prometheus/secrets/metrics-client-certs/tls.crt",
+						KeyFile:  "/etc/prometheus/secrets/metrics-client-certs/tls.key",
+					},
+				},
+			},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/instance": name,
+				},
+			},
+		},
+	}
+
+	return serviceMonitor
+}

--- a/pkg/controllers/uiplugin/monitoring.go
+++ b/pkg/controllers/uiplugin/monitoring.go
@@ -181,7 +181,7 @@ func addAcmAlertingProxy(pluginInfo *UIPluginInfo, name string, namespace string
 	)
 }
 
-func createMonitoringPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, image string, features []string, clusterVersion string) (*UIPluginInfo, error) {
+func createMonitoringPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, image string, features []string, clusterVersion string, healthAnalyzerImage string) (*UIPluginInfo, error) {
 	config := plugin.Spec.Monitoring
 	if config == nil {
 		return nil, fmt.Errorf("monitoring configuration can not be empty for plugin type %s", plugin.Spec.Type)
@@ -211,6 +211,7 @@ func createMonitoringPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, im
 		features = append(features, "perses-dashboards")
 	}
 	if isValidIncidentsConfig {
+		pluginInfo.HealthAnalyzerImage = healthAnalyzerImage
 		features = append(features, "incidents")
 	}
 	addFeatureFlags(pluginInfo, features)

--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -17,6 +17,7 @@ import (
 type UIPluginInfo struct {
 	Image               string
 	Korrel8rImage       string
+	HealthAnalyzerImage string
 	LokiServiceNames    map[string]string
 	TempoServiceNames   map[string]string
 	Name                string
@@ -160,7 +161,7 @@ func PluginInfoBuilder(ctx context.Context, k client.Client, plugin *uiv1alpha1.
 		return createLoggingPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features)
 
 	case uiv1alpha1.TypeMonitoring:
-		return createMonitoringPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, clusterVersion)
+		return createMonitoringPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, clusterVersion, pluginConf.Images["health-analyzer"])
 	}
 
 	return nil, fmt.Errorf("plugin type not supported: %s", plugin.Spec.Type)


### PR DESCRIPTION
This PR adds the Incidents backend.

When the `incidents` feature flag is set, the UIPlugin controller installs the [Health Analyzer](https://github.com/openshift/cluster-health-analyzer)  and the resources associated with it.

Fixes: OBSINTA-471