### PR TITLE
WIP: fix: Normalize canonicalMaxClusterVersion (e.g. v4.15.0-0 instead of v4.15.0)

### DIFF
--- a/pkg/controllers/uiplugin/compatibility_matrix.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix.go
@@ -3,6 +3,7 @@ package uiplugin
 import (
 	"context"
 	"fmt"
+	// "log"
 	"strings"
 
 	"golang.org/x/mod/semver"
@@ -160,7 +161,7 @@ func lookupImageAndFeatures(pluginType uiv1alpha1.UIPluginType, clusterVersion s
 
 func compareClusterVersion(entry CompatibilityEntry, clusterVersion string, pluginType uiv1alpha1.UIPluginType) (CompatibilityEntry, error) {
 	canonicalMinClusterVersion := fmt.Sprintf("%s-0", semver.Canonical(entry.MinClusterVersion))
-	canonicalMaxClusterVersion := semver.Canonical(entry.MaxClusterVersion)
+	canonicalMaxClusterVersion := fmt.Sprintf("%s-0", semver.Canonical(entry.MaxClusterVersion))
 
 	if entry.MaxClusterVersion == "" && semver.Compare(clusterVersion, canonicalMinClusterVersion) >= 0 {
 		return entry, nil

--- a/pkg/controllers/uiplugin/compatibility_matrix_test.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix_test.go
@@ -124,6 +124,28 @@ func TestLookupImageAndFeatures(t *testing.T) {
 		},
 		{
 			pluginType:     uiv1alpha1.TypeLogging,
+			clusterVersion: "v4.15.0-0.nightly-2024-06-06-064349",
+			expectedKey:    "ui-logging",
+			expectedErr:    nil,
+			expectedFeatures: []string{
+				"dev-console",
+				"alerts",
+				"dev-alerts",
+			},
+		},
+		{
+			pluginType:     uiv1alpha1.TypeLogging,
+			clusterVersion: "4.15.46",
+			expectedKey:    "ui-logging",
+			expectedErr:    nil,
+			expectedFeatures: []string{
+				"dev-console",
+				"alerts",
+				"dev-alerts",
+			},
+		},
+		{
+			pluginType:     uiv1alpha1.TypeLogging,
 			clusterVersion: "v4.16.9",
 			expectedKey:    "ui-logging",
 			expectedErr:    nil,
@@ -185,6 +207,18 @@ func TestLookupImageAndFeatures(t *testing.T) {
 		},
 		{
 			pluginType:     uiv1alpha1.TypeDistributedTracing,
+			clusterVersion: "v4.15.0-0.nightly-2024-06-06-064349",
+			expectedKey:    "ui-distributed-tracing",
+			expectedErr:    nil,
+		},
+		{
+			pluginType:     uiv1alpha1.TypeDistributedTracing,
+			clusterVersion: "v4.15.46",
+			expectedKey:    "ui-distributed-tracing",
+			expectedErr:    nil,
+		},
+		{
+			pluginType:     uiv1alpha1.TypeDistributedTracing,
 			clusterVersion: "4.24.0-0.nightly-2024-03-11-200348",
 			expectedKey:    "ui-distributed-tracing",
 			expectedErr:    nil,
@@ -230,6 +264,8 @@ func TestLookupImageAndFeatures(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("%s/%s", tc.pluginType, tc.clusterVersion), func(t *testing.T) {
 			info, err := lookupImageAndFeatures(tc.pluginType, tc.clusterVersion)
+
+			t.Log(info)
 
 			if tc.expectedErr != nil {
 				assert.Error(t, err, tc.expectedErr.Error())


### PR DESCRIPTION
### Description 

This PR tries to fix  `compareClusterVersion` so OCP cluster version  >= 4.15.0-0 returns `ImageKey:          "ui-logging",`. 


### JIRA
[[COO1.1] - OCP4.15 - ui-logging-pf4 (v6.0) is deployed instead of ui-logging (v6.1)](https://issues.redhat.com/browse/COO-749)

### Context 

```
# compatibility_matrix.go 
....

var compatibilityMatrix = []CompatibilityEntry{
        ...
	{
		PluginType:        uiv1alpha1.TypeLogging,
		MinClusterVersion: "v4.14",
		MaxClusterVersion: "v4.15",
		ImageKey:          "ui-logging-pf4",
		SupportLevel:      GeneralAvailability,
		Features: []string{
			"dev-console",
			"alerts",
			"dev-alerts",
		},
	},
	{
		PluginType:        uiv1alpha1.TypeLogging,
		MinClusterVersion: "v4.15",
		MaxClusterVersion: "",
		ImageKey:          "ui-logging",
		SupportLevel:      GeneralAvailability,
		Features: []string{
			"dev-console",
			"alerts",
			"dev-alerts",
		},
	},
        ...
} 

```


**Before** 
`canonicalMaxClusterVersion := semver.Canonical(entry.MaxClusterVersion)`
(e.g canonicalMaxClusterVersion = v4.15.0) 

**After**
`canonicalMaxClusterVersion := fmt.Sprintf("%s-0", semver.Canonical(entry.MaxClusterVersion))`
(e.g canonicalMaxClusterVersion = v4.15.0-0) 



