### PR TITLE
 COO-749 and COO-748: Fix compatibility_matrix so OCP v4.15.0-0.nightly deploys logging and distributed-tracing image containing PF5

### DIFF
--- a/pkg/controllers/uiplugin/compatibility_matrix.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix.go
@@ -160,7 +160,7 @@ func lookupImageAndFeatures(pluginType uiv1alpha1.UIPluginType, clusterVersion s
 
 func compareClusterVersion(entry CompatibilityEntry, clusterVersion string, pluginType uiv1alpha1.UIPluginType) (CompatibilityEntry, error) {
 	canonicalMinClusterVersion := fmt.Sprintf("%s-0", semver.Canonical(entry.MinClusterVersion))
-	canonicalMaxClusterVersion := semver.Canonical(entry.MaxClusterVersion)
+	canonicalMaxClusterVersion := fmt.Sprintf("%s-0", semver.Canonical(entry.MaxClusterVersion))
 
 	if entry.MaxClusterVersion == "" && semver.Compare(clusterVersion, canonicalMinClusterVersion) >= 0 {
 		return entry, nil

--- a/pkg/controllers/uiplugin/compatibility_matrix_test.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix_test.go
@@ -124,6 +124,28 @@ func TestLookupImageAndFeatures(t *testing.T) {
 		},
 		{
 			pluginType:     uiv1alpha1.TypeLogging,
+			clusterVersion: "v4.15.0-0.nightly-2024-06-06-064349",
+			expectedKey:    "ui-logging",
+			expectedErr:    nil,
+			expectedFeatures: []string{
+				"dev-console",
+				"alerts",
+				"dev-alerts",
+			},
+		},
+		{
+			pluginType:     uiv1alpha1.TypeLogging,
+			clusterVersion: "4.15.46",
+			expectedKey:    "ui-logging",
+			expectedErr:    nil,
+			expectedFeatures: []string{
+				"dev-console",
+				"alerts",
+				"dev-alerts",
+			},
+		},
+		{
+			pluginType:     uiv1alpha1.TypeLogging,
 			clusterVersion: "v4.16.9",
 			expectedKey:    "ui-logging",
 			expectedErr:    nil,
@@ -180,6 +202,18 @@ func TestLookupImageAndFeatures(t *testing.T) {
 		{
 			pluginType:     uiv1alpha1.TypeDistributedTracing,
 			clusterVersion: "4.15",
+			expectedKey:    "ui-distributed-tracing",
+			expectedErr:    nil,
+		},
+		{
+			pluginType:     uiv1alpha1.TypeDistributedTracing,
+			clusterVersion: "v4.15.0-0.nightly-2024-06-06-064349",
+			expectedKey:    "ui-distributed-tracing",
+			expectedErr:    nil,
+		},
+		{
+			pluginType:     uiv1alpha1.TypeDistributedTracing,
+			clusterVersion: "v4.15.46",
 			expectedKey:    "ui-distributed-tracing",
 			expectedErr:    nil,
 		},


### PR DESCRIPTION
### JIRA
[[COO1.1] - OCP4.15 - ui-logging-pf4 (v6.0) is deployed instead of ui-logging (v6.1)](https://issues.redhat.com/browse/COO-749)

[[COO1.1] - OCP4.15 - ui-distributed-tracing-pf4 (v0.3) is deployed instead of ui-distributed-tracing (v0.4)](https://issues.redhat.com/browse/COO-748)

### Description 
Fix compatibility matrix to catch the edge case where clusterVersion is `v4.15.0-0.nightly`. 

The compatibility_matrix is returning the incorrect image when clusterVersion v4.15.0-0.nightly. It should be returning with imageKey `ui-logging` and `ui-distributed-tracing` when clusterVersion v4.15.0-0.nightly. 

Normalizing/standardizing the string format allows semver to compare lexically compare v4.15.0-0.nightly > v4.15.0-0. This allows the compatibility matrix to return `ImageKey: "ui-logging"`.  

**Before** 
v4.14.0-0 < v4.15.0-0.nightly < v4.15.0 = ui-logging-pf4
`canonicalMaxClusterVersion := semver.Canonical(entry.MaxClusterVersion)`
(e.g canonicalMaxClusterVersion = v4.15.0) 

**After**
v4.15.0-0 < v4.15.0-0.nightly  =ui-logging
`canonicalMaxClusterVersion := fmt.Sprintf("%s-0", semver.Canonical(entry.MaxClusterVersion))`
(e.g canonicalMaxClusterVersion = v4.15.0-0) 

```
	{
		PluginType:        uiv1alpha1.TypeLogging,
		MinClusterVersion: "v4.14",
		MaxClusterVersion: "v4.15",
		ImageKey:          "ui-logging-pf4",
		SupportLevel:      GeneralAvailability,
		Features: []string{
			"dev-console",
			"alerts",
			"dev-alerts",
		},
	},
	{
		PluginType:        uiv1alpha1.TypeLogging,
		MinClusterVersion: "v4.15",
		MaxClusterVersion: "",
		ImageKey:          "ui-logging",
		SupportLevel:      GeneralAvailability,
		Features: []string{
			"dev-console",
			"alerts",
			"dev-alerts",
		},
	},
```

### Screenshots
<img width="1846" alt="image" src="https://github.com/user-attachments/assets/867b47c4-f08e-476f-acb3-5cf622986e69" />
Figure. OCP version is 4.15.0-0.nightly which evaluates to the correct image `/distributed-tracing-console-plugin:v.0.4.0`
