### PR TITLE
feat: deploying COO in place of OBO on SC clusters

### DIFF
--- a/deploy/olm/syncselector-template.yaml
+++ b/deploy/olm/syncselector-template.yaml
@@ -96,6 +96,41 @@ objects:
   - apiVersion: hive.openshift.io/v1
     kind: SelectorSyncSet
     metadata:
+      name: cluster-observability-operator-hypershift
+    spec:
+      clusterDeploymentSelector:
+        matchLabels:
+          api.openshift.com/managed: 'true'
+        matchExpressions:
+          - key: ext-hypershift.openshift.io/cluster-type
+            operator: In
+            values:
+              - service-cluster
+      resourceApplyMode: Sync
+      resources:
+        - apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            labels:
+              operators.coreos.com/cluster-observability-operator.openshift-operators: ""
+            name: cluster-observability-operator
+            namespace: openshift-operators
+          spec:
+            channel: stable
+            name: cluster-observability-operator
+            source: redhat-operators
+            sourceNamespace: openshift-marketplace
+            config:
+              resources:
+                limits:
+                  cpu: ${RESOURCE_LIMIT_CPU}
+                  memory: ${RESOURCE_LIMIT_MEMORY}
+                requests:
+                  cpu: ${RESOURCE_REQUEST_CPU}
+                  memory: ${RESOURCE_REQUEST_MEMORY}
+  - apiVersion: hive.openshift.io/v1
+    kind: SelectorSyncSet
+    metadata:
       name: observability-operator-rhoam
     spec:
       clusterDeploymentSelector:


### PR DESCRIPTION
Follow up of this PR: https://github.com/rhobs/observability-operator/pull/667

It was actually a bad idea to deploy COO through `osd-fleet-manager` as discussed [there](https://github.com/rhobs/observability-operator/pull/667#discussion_r2007813490).

Indeed `osd-fleet-manager` come too late in the install process of (Hypershift) SC clusters.
Typically ACM will be installed before COO is installed... but ACM needs to deploy OBO/COO specific service monitor which is only possible if COO is installed before ACM.