### PR TITLE
fix: github action failure to set up do in olm publish

### DIFF
--- a/.github/olm-publish/action.yaml
+++ b/.github/olm-publish/action.yaml
@@ -10,6 +10,11 @@ inputs:
 runs:
   using: composite
   steps:
+  - name: Clean Go module cache
+    run: |
+      shell: bash
+      go clean -modcache
+      rm -rf ~/go/pkg/mod
   - name: Setup Go environment
     uses: actions/setup-go@v5
     with:


### PR DESCRIPTION
The issue leads that no new bundle and catalog image generated and pushed to quay after PR merged
Such as 
https://github.com/rhobs/observability-operator/actions/runs/14902238105/job/41857694406 
