### PR TITLE
COO-818: feat: add schema configuration for logging view plugin

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:1.1.0
-    createdAt: "2025-04-03T07:29:49Z"
+    createdAt: "2025-05-09T09:01:23Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operatorframework.io/cluster-monitoring: "true"

--- a/bundle/manifests/observability.openshift.io_uiplugins.yaml
+++ b/bundle/manifests/observability.openshift.io_uiplugins.yaml
@@ -128,6 +128,16 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  schema:
+                    description: |-
+                      Schema is the schema to use for logs querying and display.
+
+                      Defatults to "viaq" if not specified.
+                    enum:
+                    - viaq
+                    - otel
+                    - select
+                    type: string
                   timeout:
                     description: |-
                       Timeout is the maximum duration before a query timeout.

--- a/deploy/crds/common/observability.openshift.io_uiplugins.yaml
+++ b/deploy/crds/common/observability.openshift.io_uiplugins.yaml
@@ -128,6 +128,16 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  schema:
+                    description: |-
+                      Schema is the schema to use for logs querying and display.
+
+                      Defatults to "viaq" if not specified.
+                    enum:
+                    - viaq
+                    - otel
+                    - select
+                    type: string
                   timeout:
                     description: |-
                       Timeout is the maximum duration before a query timeout.

--- a/docs/api.md
+++ b/docs/api.md
@@ -4280,6 +4280,17 @@ It always references a LokiStack in the "openshift-logging" namespace.<br/>
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>schema</b></td>
+        <td>enum</td>
+        <td>
+          Schema is the schema to use for logs querying and display.
+
+Defatults to "viaq" if not specified.<br/>
+          <br/>
+            <i>Enum</i>: viaq, otel, select<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>timeout</b></td>
         <td>string</td>
         <td>

--- a/pkg/apis/uiplugin/v1alpha1/types.go
+++ b/pkg/apis/uiplugin/v1alpha1/types.go
@@ -119,6 +119,15 @@ type LoggingConfig struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OCP Console Query Timeout",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:ocpConsoleTimeout"}
 	// +kubebuilder:validation:Pattern:="^([0-9]+)([sm]{0,1})$"
 	Timeout string `json:"timeout,omitempty"`
+
+	// Schema is the schema to use for logs querying and display.
+	//
+	// Defatults to "viaq" if not specified.
+	//
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="OCP Console Logs Schema",xDescriptors={"urn:alm:descriptor:com.tectonic.ui:ocpConsoleLogsSchema"}
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=viaq;otel;select
+	Schema string `json:"schema,omitempty"`
 }
 
 // LokiStackReference is used to configure a reference to a LokiStack that should be used

--- a/pkg/controllers/uiplugin/logging.go
+++ b/pkg/controllers/uiplugin/logging.go
@@ -24,6 +24,7 @@ import (
 type loggingConfig struct {
 	LogsLimit int32         `yaml:"logsLimit,omitempty"`
 	Timeout   time.Duration `yaml:"timeout,omitempty"`
+	Schema    string        `yaml:"schema,omitempty"`
 }
 
 func createLoggingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, image string, features []string, ctx context.Context, dk dynamic.Interface) (*UIPluginInfo, error) {
@@ -133,7 +134,7 @@ func marshalLoggingPluginConfig(cfg *uiv1alpha1.LoggingConfig) (string, error) {
 		return "", nil
 	}
 
-	if cfg.LogsLimit == 0 && cfg.Timeout == "" {
+	if cfg.LogsLimit == 0 && cfg.Timeout == "" && cfg.Schema == "" {
 		return "", nil
 	}
 
@@ -149,6 +150,7 @@ func marshalLoggingPluginConfig(cfg *uiv1alpha1.LoggingConfig) (string, error) {
 	pluginCfg := loggingConfig{
 		LogsLimit: cfg.LogsLimit,
 		Timeout:   timeout,
+		Schema:    cfg.Schema,
 	}
 
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/COO-818

Adds a schema field to the logging view plugin to add support for OTEL labels

Requires https://github.com/openshift/logging-view-plugin/pull/277 from the plugin side