### PR TITLE
docs: add schema field for ui logging

### DIFF
--- a/docs/user-guides/observability-ui-plugins.md
+++ b/docs/user-guides/observability-ui-plugins.md
@@ -132,6 +132,7 @@ spec:
       name: logging-loki
     logsLimit: 50
     timeout: 30s
+    schema: otel
 ```
 
 ### Monitoring


### PR DESCRIPTION
Add missing `schema` field for the ui logging plugin example