### PR TITLE
feat: add monitoring-plugin stream 0.4 and 0.5

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -46,9 +46,10 @@ var defaultImages = map[string]string{
 	"ui-distributed-tracing":     "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v1.0.0",
 	"ui-logging-pf4":             "quay.io/openshift-observability-ui/logging-view-plugin:v6.0.0",
 	"ui-logging":                 "quay.io/openshift-observability-ui/logging-view-plugin:v6.1.0",
-	"ui-monitoring":              "quay.io/openshift-observability-ui/monitoring-console-plugin:release-coo-1.1",
 	"korrel8r":                   "quay.io/korrel8r/korrel8r:release-coo-1.2",
 	"health-analyzer":            "quay.io/openshiftanalytics/cluster-health-analyzer:v0.5.0",
+	"ui-monitoring-pf5":          "quay.io/openshift-observability-ui/monitoring-console-plugin:v0.4.0",
+	"ui-monitoring":              "quay.io/openshift-observability-ui/monitoring-console-plugin:v0.5.0",
 	"perses":                     "quay.io/persesdev/perses:v0.50.3",
 }
 

--- a/pkg/controllers/uiplugin/compatibility_matrix.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix.go
@@ -133,6 +133,16 @@ var compatibilityMatrix = []CompatibilityEntry{
 	{
 		PluginType:        uiv1alpha1.TypeMonitoring,
 		MinClusterVersion: "v4.15",
+		MaxClusterVersion: "v4.19",
+		ImageKey:          "ui-monitoring-pf5",
+		SupportLevel:      TechPreview,
+		// feature flags for montioring are dynamically injected
+		// based on the cluster version and and UIPlugin CR configurations
+		Features: []string{},
+	},
+	{
+		PluginType:        uiv1alpha1.TypeMonitoring,
+		MinClusterVersion: "v4.19",
 		MaxClusterVersion: "",
 		ImageKey:          "ui-monitoring",
 		SupportLevel:      TechPreview,

--- a/pkg/controllers/uiplugin/compatibility_matrix_test.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix_test.go
@@ -262,13 +262,27 @@ func TestLookupImageAndFeatures(t *testing.T) {
 		{
 			pluginType:       uiv1alpha1.TypeMonitoring,
 			clusterVersion:   "v4.15",
-			expectedKey:      "ui-monitoring",
+			expectedKey:      "ui-monitoring-pf5",
 			expectedFeatures: []string{},
 			expectedErr:      nil,
 		},
 		{
 			pluginType:       uiv1alpha1.TypeMonitoring,
 			clusterVersion:   "v4.15.0-0.nightly-2024-06-06-064349",
+			expectedKey:      "ui-monitoring-pf5",
+			expectedFeatures: []string{},
+			expectedErr:      nil,
+		},
+		{
+			pluginType:       uiv1alpha1.TypeMonitoring,
+			clusterVersion:   "v4.19",
+			expectedKey:      "ui-monitoring",
+			expectedFeatures: []string{},
+			expectedErr:      nil,
+		},
+		{
+			pluginType:       uiv1alpha1.TypeMonitoring,
+			clusterVersion:   "v4.19.0-0.nightly-2024-06-06-064349",
 			expectedKey:      "ui-monitoring",
 			expectedFeatures: []string{},
 			expectedErr:      nil,


### PR DESCRIPTION
### Description 
[monitoring-console-plugin-0.4](https://github.com/openshift/monitoring-plugin/tree/release-coo-0.4) patternfly v5, Bug fixes
[monitoring-console-plugin-0.5](https://github.com/openshift/monitoring-plugin/tree/release-coo-0.5) patternfly v6, react-router v5, incident bug fixes

### JIRA 
https://issues.redhat.com/browse/OU-585

### Related PRs: 
konflux-release-data (VPN required): https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/6422
konflux-coo: https://github.com/rhobs/konflux-coo/pull/1135

### Process 
1. Update main.go to include the two monitoring-console-plugin stream (v0.4.0 and v0.5.0) 
2. Update compatibility-matrix.go to assign the  image name `monitoring-plugin-pf5` when OCP version 4.15 - 4.18, and image `monitoring-plugin` when OCP version 4.19+ is detected (this image contains patternfly 6). 
3. Update compatibility_matrix_test.go to reflect these changes. 