### PR TITLE
chore: update troubleshooting plugin image tag

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -40,7 +40,7 @@ var defaultImages = map[string]string{
 	"alertmanager":               "",
 	"thanos":                     obopo.DefaultThanosImage,
 	"ui-dashboards":              "quay.io/openshift-observability-ui/console-dashboards-plugin:v0.4.0",
-	"ui-troubleshooting-panel":   "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v0.4.0",
+	"ui-troubleshooting-panel":   "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v0.4.1",
 	"ui-distributed-tracing-pf4": "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.3.0",
 	"ui-distributed-tracing-pf5": "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.4.0",
 	"ui-distributed-tracing":     "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v1.0.0",


### PR DESCRIPTION
In preparation for COO 1.2 release, update the troubleshooting plugin to reference a new image which contains the lastest commits from https://github.com/openshift/troubleshooting-panel-console-plugin/tree/release-0.4

Quay (tag v0.4.1)
https://quay.io/repository/openshift-observability-ui/troubleshooting-panel-console-plugin?tab=tags

JIRA
https://issues.redhat.com/browse/OU-585