### PR TITLE
feat: update perses operator to v0.1.12

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -658,6 +658,7 @@ spec:
           resources:
           - services
           - configmaps
+          - secrets
           verbs:
           - get
           - patch
@@ -999,7 +1000,7 @@ spec:
                         operator: Exists
                     weight: 1
               containers:
-              - image: quay.io/persesdev/perses-operator:v0.1.10
+              - image: quay.io/persesdev/perses-operator:v0.1.12
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/deploy/perses/perses-operator-cluster-role.yaml
+++ b/deploy/perses/perses-operator-cluster-role.yaml
@@ -29,6 +29,7 @@ rules:
     resources:
       - services
       - configmaps
+      - secrets
     verbs:
       - get
       - patch

--- a/deploy/perses/perses-operator-deployment.yaml
+++ b/deploy/perses/perses-operator-deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: perses-operator
-        image: quay.io/persesdev/perses-operator:v0.1.10
+        image: quay.io/persesdev/perses-operator:v0.1.12
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/pkg/controllers/uiplugin/monitoring.go
+++ b/pkg/controllers/uiplugin/monitoring.go
@@ -319,8 +319,10 @@ func newPerses(namespace string, persesImage string) *persesv1alpha1.Perses {
 				TLS: &persesv1alpha1.TLS{
 					Enable: true,
 					CaCert: &persesv1alpha1.Certificate{
-						Type:     persesv1alpha1.CertificateTypeSecret,
-						CertPath: "ca.crt",
+						Type:           persesv1alpha1.CertificateTypeSecret,
+						CertPath:       "tls.crt",
+						PrivateKeyPath: "tls.key",
+						Name:           name,
 					},
 				},
 			},


### PR DESCRIPTION
Update the perses operator to the newest version, add secret retrieval to permission set of perses operator, and pass in the secret name and paths to retrieve the cert