### PR TITLE
SREP-995: Deploying COO in place of OBO on MC clusters

### DIFF
--- a/deploy/olm/syncselector-template.yaml
+++ b/deploy/olm/syncselector-template.yaml
@@ -40,62 +40,6 @@ objects:
   - apiVersion: hive.openshift.io/v1
     kind: SelectorSyncSet
     metadata:
-      name: observability-operator-hypershift
-    spec:
-      clusterDeploymentSelector:
-        matchLabels:
-          api.openshift.com/managed: 'true'
-        matchExpressions:
-          - key: ext-hypershift.openshift.io/cluster-type
-            operator: In
-            values:
-              - management-cluster
-      resourceApplyMode: Sync
-      resources:
-        - apiVersion: operators.coreos.com/v1alpha1
-          kind: CatalogSource
-          metadata:
-            name: observability-operator-catalog
-            namespace: openshift-observability-operator
-          spec:
-            displayName: Red Hat Observability Operator
-            image: quay.io/rhobs/observability-operator-catalog@sha256:e648be80d3ec35fc128c7396d9c052bd1f615d5b4465e07497779398f2eab845
-            publisher: OSD Red Hat Addons
-            sourceType: grpc
-            grpcPodConfig:
-              securityContextConfig: restricted
-              nodeSelector:
-                node-role.kubernetes.io: infra
-              tolerations:
-                - effect: NoSchedule
-                  key: node-role.kubernetes.io/infra
-                  operator: Exists
-        - apiVersion: operators.coreos.com/v1alpha2
-          kind: OperatorGroup
-          metadata:
-            name: observability-operator-og
-            namespace: openshift-observability-operator
-        - apiVersion: operators.coreos.com/v1alpha1
-          kind: Subscription
-          metadata:
-            name: observability-operator
-            namespace: openshift-observability-operator
-          spec:
-            channel: ${CHANNEL}
-            name: observability-operator
-            source: observability-operator-catalog
-            sourceNamespace: openshift-observability-operator
-            config:
-              resources:
-                limits:
-                  cpu: ${RESOURCE_LIMIT_CPU}
-                  memory: ${RESOURCE_LIMIT_MEMORY}
-                requests:
-                  cpu: ${RESOURCE_REQUEST_CPU}
-                  memory: ${RESOURCE_REQUEST_MEMORY}
-  - apiVersion: hive.openshift.io/v1
-    kind: SelectorSyncSet
-    metadata:
       name: cluster-observability-operator-hypershift
     spec:
       clusterDeploymentSelector:
@@ -106,6 +50,7 @@ objects:
             operator: In
             values:
               - service-cluster
+              - management-cluster
       resourceApplyMode: Sync
       resources:
         - apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
This PR:
1. Removes OBO subscription from Hypershift management clusters (MCs)
2. Deploy COO on those clusters.

Note that a similar change has been done on SC cluster via the following PRs: https://github.com/rhobs/observability-operator/pull/667, https://github.com/rhobs/observability-operator/pull/716

PR definitely uninstalling OBO by removing the CSV:
https://github.com/openshift/managed-cluster-config/pull/2460