### PR TITLE
fix: remove replace command after introducing API module

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,8 +5,6 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# remove this line once the replace command is removed from go.mod
-COPY pkg/apis/go.mod pkg/apis/go.mod
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -29,10 +29,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 
-replace github.com/rhobs/observability-operator/pkg/apis v0.0.0-unpublished => ./pkg/apis
-
 require (
-	github.com/rhobs/observability-operator/pkg/apis v0.0.0-unpublished
+	github.com/rhobs/observability-operator/pkg/apis v0.0.0-20250709130004-32736be06093
 	github.com/rhobs/perses v0.0.0-20250612171017-5d7686af9ae4
 	github.com/rhobs/perses-operator v0.1.10-0.20250612173146-78eb619430df
 )

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,8 @@ github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.83.0-rhobs1 h1:t
 github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.83.0-rhobs1/go.mod h1:cVp/Ggq8Y2v3WUDhwbDAF4b07C8P75lozrsJg6eIYxw=
 github.com/rhobs/obo-prometheus-operator/pkg/client v0.83.0-rhobs1 h1:2AuX/2mC2tiTQaemoMk2SAutmzubHmqtyid9jlYs6Xc=
 github.com/rhobs/obo-prometheus-operator/pkg/client v0.83.0-rhobs1/go.mod h1:1FBCRmzRgKgGhJA/gMuxdsBxxUu6VrgAtJZ8yi5ExHw=
+github.com/rhobs/observability-operator/pkg/apis v0.0.0-20250709130004-32736be06093 h1:kQsJbRSjPpKC4awzwm8TD2XPtjGYZD7TnxEpDkW/mKc=
+github.com/rhobs/observability-operator/pkg/apis v0.0.0-20250709130004-32736be06093/go.mod h1:bNP815/mCv8ydNQ2Q3a9gqlx9b2XouWa6hws9vthq78=
 github.com/rhobs/perses v0.0.0-20250612171017-5d7686af9ae4 h1:IxpxGJ/fbnRkZZYFm17NMedFyEuOKuf4TS23g+6jMvU=
 github.com/rhobs/perses v0.0.0-20250612171017-5d7686af9ae4/go.mod h1:Mxs4sXawWiV50qokKG1UZCV9NJEdJWsALY71/z38NKA=
 github.com/rhobs/perses-operator v0.1.10-0.20250612173146-78eb619430df h1:rwtqpvrowEF6EjSiO3PPcqC6s2jo7NU3VsGU6yrpxTg=

--- a/pkg/apis/monitoring/v1alpha1/register.go
+++ b/pkg/apis/monitoring/v1alpha1/register.go
@@ -15,6 +15,11 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the rhobs v1alpha1 API group
+//
+// The observability-operator API module uses semantic versioning for version tags,
+// but does not guarantee backward compatibility, even for versions v1.0.0 and above.
+// Breaking changes may occur without major version bumps.
+//
 // +kubebuilder:object:generate=true
 // +groupName=monitoring.rhobs
 package v1alpha1

--- a/pkg/apis/observability/v1alpha1/register.go
+++ b/pkg/apis/observability/v1alpha1/register.go
@@ -1,3 +1,9 @@
+// Package v1alpha1 contains API Schema definitions for the rhobs v1alpha1 API group
+//
+// The observability-operator API module uses semantic versioning for version tags,
+// but does not guarantee backward compatibility, even for versions v1.0.0 and above.
+// Breaking changes may occur without major version bumps.
+//
 // +kubebuilder:object:generate=true
 // +groupName=observability.openshift.io
 package v1alpha1

--- a/pkg/apis/uiplugin/v1alpha1/register.go
+++ b/pkg/apis/uiplugin/v1alpha1/register.go
@@ -15,6 +15,11 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the rhobs v1alpha1 API group
+//
+// The observability-operator API module uses semantic versioning for version tags,
+// but does not guarantee backward compatibility, even for versions v1.0.0 and above.
+// Breaking changes may occur without major version bumps.
+//
 // +kubebuilder:object:generate=true
 // +groupName=observability.openshift.io
 package v1alpha1

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -6,8 +6,7 @@ WORKDIR ${PKG}
 
 COPY go.mod go.mod
 COPY go.sum go.sum
-# remove this line once the replace command is removed from go.mod
-COPY pkg/apis/go.mod pkg/apis/go.mod
+
 #
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer


### PR DESCRIPTION
This removes the `replace` command and the temporary workarounds for the new API module dependency. Maybe it would be good to add something like:
```
go mod edit -require "github.com/rhobs/observability-operator/pkg/apis@v$(VERSION)"
```
but not sure where (perhaps the `make initiate-release` target?) and maybe it's too early (since there's no tag for the API module)