### PR TITLE
fix: server conflict error when enable OCP in test script

### DIFF
--- a/test/run-e2e-ocp.sh
+++ b/test/run-e2e-ocp.sh
@@ -66,7 +66,29 @@ enable_ocp() {
     ' "$CSV_JSON_FILE" > /tmp/tmp.$$.json && mv /tmp/tmp.$$.json "$CSV_JSON_FILE"
   ok "Added arguments to container operator in '$CSV_JSON_FILE'."
 
-	oc replace -f "$CSV_JSON_FILE"
+  # Retry logic
+  max_retries=3
+  retry_count=0
+
+  while [ $retry_count -lt $max_retries ]; do
+    if oc -n "$OPERATORS_NS" apply -f "$CSV_JSON_FILE"; then
+      ok "Successfully updated CSV ${CSV_NAME}"
+      break
+    fi
+
+    ((retry_count++))
+    if [ $retry_count -eq $max_retries ]; then
+      err "Failed to update CSV ${CSV_NAME} after $max_retries attempts"
+      exit 1
+    fi
+
+    # Get fresh version and reapply changes
+    oc -n "$OPERATORS_NS" get csv "${CSV_NAME}" -o json > "$CSV_JSON_FILE"
+    jq --arg container_name operator --argjson args "$ARGS_JSON" '
+      (.spec.install.spec.deployments[].spec.template.spec.containers[] | select(.name == $container_name) | .args) += $args
+    ' "$CSV_JSON_FILE" > /tmp/tmp.$$.json && mv /tmp/tmp.$$.json "$CSV_JSON_FILE"
+  done
+
 	rm -f "$CSV_JSON_FILE"
 
 	# enable platform monitoring


### PR DESCRIPTION
[COO-1147](https://issues.redhat.com/browse/COO-1147)
Fix the following error in [prow job](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-rhobs-observability-operator-main-upstream-ocp-4.19-aws-coo-compat/1950328998986780672/artifacts/coo-compat/obo-e2e/build-log.txt )
Error from server (Conflict): error when replacing "/tmp/observability-operator.v1.3.0-250724084111U6mvt0.json": Operation cannot be fulfilled on clusterserviceversions.operators.coreos.com "observability-operator.v1.3.0-250724084111": the object has been modified; please apply your changes to the latest version and try again