### PR TITLE
test: fix env var name in run-e2e.sh

### DIFF
--- a/test/run-e2e.sh
+++ b/test/run-e2e.sh
@@ -57,7 +57,7 @@ build_bundle() {
 	}
 
 	make operator-image bundle bundle-image \
-		IMAGE_BASE="$OBO_IMG_REPO" VERSION="$OBO_VERSION"
+		IMG_BASE="$OBO_IMG_REPO" VERSION="$OBO_VERSION"
 }
 
 push_bundle() {
@@ -68,7 +68,7 @@ push_bundle() {
 	}
 
 	make operator-push bundle-push \
-		IMAGE_BASE="$OBO_IMG_REPO" VERSION="$OBO_VERSION" \
+		IMG_BASE="$OBO_IMG_REPO" VERSION="$OBO_VERSION" \
 		PUSH_OPTIONS=--tls-verify=false
 
 }


### PR DESCRIPTION
After the change in f0d520add0a6886860fbd63db943e2f243684959