### PR TITLE
build: drop default image parameters

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:1.2.0
-    createdAt: "2025-09-03T19:00:46Z"
+    createdAt: "2025-09-11T17:19:09Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operatorframework.io/cluster-monitoring: "true"
@@ -926,9 +926,6 @@ spec:
               containers:
               - args:
                 - --namespace=$(NAMESPACE)
-                - --images=alertmanager=quay.io/prometheus/alertmanager:v0.26.0
-                - --images=prometheus=quay.io/prometheus/prometheus:v2.49.1
-                - --images=thanos=quay.io/thanos/thanos:v0.33.0
                 - --images=perses=quay.io/openshift-observability-ui/perses:v0.51.1-go-1.23
                 env:
                 - name: NAMESPACE

--- a/deploy/operator/kustomization.yaml
+++ b/deploy/operator/kustomization.yaml
@@ -17,30 +17,6 @@ patches:
 - patch: |-
     - op: add
       path: /spec/template/spec/containers/0/args/-
-      value: --images=alertmanager=quay.io/prometheus/alertmanager:v0.26.0
-  target:
-    group: apps
-    kind: Deployment
-    version: v1
-- patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: --images=prometheus=quay.io/prometheus/prometheus:v2.49.1
-  target:
-    group: apps
-    kind: Deployment
-    version: v1
-- patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: --images=thanos=quay.io/thanos/thanos:v0.33.0
-  target:
-    group: apps
-    kind: Deployment
-    version: v1
-- patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
       value: --images=perses=quay.io/openshift-observability-ui/perses:v0.51.1-go-1.23
   target:
     group: apps

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -951,7 +951,6 @@ const oboManagedFieldsJson = `
   "f:externalLabels": {
     "f:key": {}
   },
-  "f:image": {},
   "f:logLevel": {},
   "f:podMetadata": {
     "f:labels": {


### PR DESCRIPTION
The operator has built-in defaults that are specified by the respective prometheus-operator version. This way we don't need to update the default versions.