### PR TITLE
ci: don't run commitlint on dependabot PRs

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   commit-lint:
+    if: (github.actor != 'dependabot[bot]') && ! startsWith(github.head_ref, 'dependabot/')
     name: Lint the commit messages
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The `commitlint.config.mjs` seems to have stopped working, so just skip the step on dependabot PRs.