### PR TITLE
fix: sync Perses CRD with perses-operator

### DIFF
--- a/bundle/manifests/perses.dev_perses.yaml
+++ b/bundle/manifests/perses.dev_perses.yaml
@@ -1697,7 +1697,6 @@ spec:
                             type: array
                         required:
                         - disable_custom
-                        - disable_zoom
                         type: object
                     required:
                     - disable
@@ -2072,7 +2071,6 @@ spec:
                                 type: array
                             required:
                             - enable_native
-                            - kubernetes
                             type: object
                           refresh_token_ttl:
                             description: |-

--- a/deploy/perses/crds/perses.dev_perses.yaml
+++ b/deploy/perses/crds/perses.dev_perses.yaml
@@ -1696,7 +1696,6 @@ spec:
                             type: array
                         required:
                         - disable_custom
-                        - disable_zoom
                         type: object
                     required:
                     - disable
@@ -2071,7 +2070,6 @@ spec:
                                 type: array
                             required:
                             - enable_native
-                            - kubernetes
                             type: object
                           refresh_token_ttl:
                             description: |-


### PR DESCRIPTION
There was a misalignment between the Perses CRD in this repository with the Perses CRD from the operator at `quay.io/openshift-observability-ui/perses-operator:v0.2-go-1.23`.

I ran `make bundle` in `github.com/rhobs/perses-operator`, `v0.2.0-golang_1_23` branch and copy&pasted the updated CRD.

cc @PeterYurkovich @jgbernalp 

Resolves: https://issues.redhat.com/browse/COO-1197