### PR TITLE
fix: fix linter issues and add CI check for linter changes

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -43,6 +43,9 @@ jobs:
       - name: Lint Shell scripts
         run: make lint-shell
 
+      - name: Check for linter changes
+        run: git diff --exit-code
+
   generate:
     name: Verify generated code
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,6 @@ lint: lint-golang lint-shell
 lint-golang: $(GOLANGCI_LINT)
 	$(GOLANGCI_LINT) run ./... --fix
 
-# TODO(simonpasquier): remove this after #629 merges.
-.PHONY: lint-jsonnet fmt-jsonnet
-lint-jsonnet fmt-jsonnet:
-
 .PHONY: lint-shell
 lint-shell: $(SHELLCHECK)
 	find -name "*.sh" -print0 | xargs --null $(SHELLCHECK)

--- a/pkg/controllers/observability/observability_controller.go
+++ b/pkg/controllers/observability/observability_controller.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	tempov1alpha1 "github.com/grafana/tempo-operator/api/tempo/v1alpha1"
+	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -24,8 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	tempov1alpha1 "github.com/grafana/tempo-operator/api/tempo/v1alpha1"
-	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
 	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
 )

--- a/pkg/controllers/observability/otel_components.go
+++ b/pkg/controllers/observability/otel_components.go
@@ -9,10 +9,10 @@ import (
 	"text/template"
 
 	go_yaml "github.com/goccy/go-yaml"
+	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
 )
 
@@ -69,7 +69,7 @@ func otelCollector(instance *obsv1alpha1.ClusterObservability) (*otelv1beta1.Ope
 }
 
 func otelCollectorName(instance string) string {
-	return fmt.Sprintf("%s", instance)
+	return instance
 }
 
 func otelCollectorComponentsRBAC(instance *obsv1alpha1.ClusterObservability) (*rbacv1.ClusterRole, *rbacv1.ClusterRoleBinding) {

--- a/pkg/controllers/observability/tempo_components.go
+++ b/pkg/controllers/observability/tempo_components.go
@@ -66,7 +66,7 @@ func tempoStack(instance *obsv1alpha1.ClusterObservability) *tempov1alpha1.Tempo
 }
 
 func tempoName(instance string) string {
-	return fmt.Sprintf("%s", instance)
+	return instance
 }
 
 func tempoStorageCAConfigMapName(name string) string {

--- a/pkg/operator/scheme.go
+++ b/pkg/operator/scheme.go
@@ -9,7 +9,6 @@ import (
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
-	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
 	persesv1alpha1 "github.com/rhobs/perses-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -18,6 +17,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	rhobsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/monitoring/v1alpha1"
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
 	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
 )
 


### PR DESCRIPTION
Since we call `golang-lint --fix` we should check if the linter has fixed anything.