### PR TITLE
COO-1248: fix: use apiReader for correct ui plugin registration

### DIFF
--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -113,7 +113,7 @@ func pluginComponentReconcilers(plugin *uiv1alpha1.UIPlugin, pluginInfo UIPlugin
 	if pluginInfo.HealthAnalyzerImage != "" {
 		serviceAccountName := plugin.Name + serviceAccountSuffix
 		components = append(components, reconciler.NewUpdater(newClusterRoleBinding(namespace, serviceAccountName, "cluster-monitoring-view", "cluster-monitoring-view"), plugin))
-		components = append(components, reconciler.NewUpdater(newClusterRoleBinding(namespace, serviceAccountName, "system:auth-delegator", serviceAccountName+":system:auth-delegator"), plugin))
+		components = append(components, reconciler.NewUpdater(newClusterRoleBinding(namespace, serviceAccountName, "system:auth-delegator", serviceAccountName+"-system-auth-delegator"), plugin))
 		components = append(components, reconciler.NewUpdater(newHealthAnalyzerPrometheusRole(namespace), plugin))
 		components = append(components, reconciler.NewUpdater(newHealthAnalyzerPrometheusRoleBinding(namespace), plugin))
 		components = append(components, reconciler.NewUpdater(newHealthAnalyzerService(namespace), plugin))
@@ -124,9 +124,9 @@ func pluginComponentReconcilers(plugin *uiv1alpha1.UIPlugin, pluginInfo UIPlugin
 	if pluginInfo.PersesImage != "" {
 		persesServiceAccountName := "perses" + serviceAccountSuffix
 		components = append(components, reconciler.NewUpdater(newServiceAccount("perses", namespace), plugin))
-		components = append(components, reconciler.NewUpdater(newClusterRoleBinding(namespace, persesServiceAccountName, "system:auth-delegator", persesServiceAccountName+":system:auth-delegator"), plugin))
+		components = append(components, reconciler.NewUpdater(newClusterRoleBinding(namespace, persesServiceAccountName, "system:auth-delegator", persesServiceAccountName+"-system-auth-delegator"), plugin))
 		components = append(components, reconciler.NewUpdater(newPersesClusterRole(), plugin))
-		components = append(components, reconciler.NewUpdater(newClusterRoleBinding(namespace, persesServiceAccountName, "perses-cr", persesServiceAccountName+":perses-cr"), plugin))
+		components = append(components, reconciler.NewUpdater(newClusterRoleBinding(namespace, persesServiceAccountName, "perses-cr", persesServiceAccountName+"-perses-cr"), plugin))
 		components = append(components, reconciler.NewUpdater(newPerses(namespace, pluginInfo.PersesImage), plugin))
 		components = append(components, reconciler.NewUpdater(newAcceleratorsDatasource(namespace), plugin))
 		components = append(components, reconciler.NewUpdater(newAcceleratorsDashboard(namespace), plugin))

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -38,6 +38,7 @@ type resourceManager struct {
 	controller       controller.Controller
 	pluginConf       UIPluginsConfiguration
 	clusterVersion   string
+	apiReader        client.Reader
 }
 
 type UIPluginsConfiguration struct {
@@ -129,6 +130,7 @@ func RegisterWithManager(mgr ctrl.Manager, opts Options) error {
 		logger:           logger,
 		pluginConf:       opts.PluginsConf,
 		clusterVersion:   clusterVersion.Status.Desired.Version,
+		apiReader:        mgr.GetAPIReader(),
 	}
 
 	generationChanged := builder.WithPredicates(predicate.GenerationChangedPredicate{})
@@ -337,7 +339,7 @@ func (rm resourceManager) updateStatus(ctx context.Context, req ctrl.Request, pl
 
 func (rm resourceManager) registerPluginWithConsole(ctx context.Context, pluginInfo *UIPluginInfo) error {
 	cluster := &operatorv1.Console{}
-	if err := rm.k8sClient.Get(ctx, client.ObjectKey{Name: "cluster"}, cluster); err != nil {
+	if err := rm.apiReader.Get(ctx, client.ObjectKey{Name: "cluster"}, cluster); err != nil {
 		return err
 	}
 
@@ -359,7 +361,7 @@ func (rm resourceManager) registerPluginWithConsole(ctx context.Context, pluginI
 
 func (rm resourceManager) deregisterPluginFromConsole(ctx context.Context, pluginConsoleName string) error {
 	cluster := &operatorv1.Console{}
-	if err := rm.k8sClient.Get(ctx, client.ObjectKey{Name: "cluster"}, cluster); err != nil {
+	if err := rm.apiReader.Get(ctx, client.ObjectKey{Name: "cluster"}, cluster); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR:

- fixes the empty response when reading the cluster.console.operator.openshift.io, this is caused from reading from the cache when using the k8sClient. As the cluster plugins is read occasionally we can use the apiReader to get latest results.
- Fixes the names of some role bindings so labels are valid