### PR TITLE
Add parameter enableAdminAPI to prometheus configuration

### DIFF
--- a/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
+++ b/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
@@ -199,6 +199,15 @@ spec:
                   replicas: 2
                 description: Define prometheus config
                 properties:
+                  enableAdminAPI:
+                    description: |-
+                      Enable Prometheus Admin API.
+                      Defaults to the value of `false`.
+                      WARNING: Enabling the admin APIs enables mutating endpoints, to delete data,
+                      shutdown Prometheus, and more. Enabling this should be done with care and the
+                      user is advised to add additional authentication authorization via a proxy to
+                      ensure only clients authorized to perform these actions can do so.
+                    type: boolean
                   enableOtlpHttpReceiver:
                     description: |-
                       Enable Prometheus to accept OpenTelemetry Metrics via the otlp/http protocol.

--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:1.2.0
-    createdAt: "2025-10-16T07:15:08Z"
+    createdAt: "2025-10-27T09:42:32Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operatorframework.io/cluster-monitoring: "true"

--- a/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
+++ b/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
@@ -199,6 +199,15 @@ spec:
                   replicas: 2
                 description: Define prometheus config
                 properties:
+                  enableAdminAPI:
+                    description: |-
+                      Enable Prometheus Admin API.
+                      Defaults to the value of `false`.
+                      WARNING: Enabling the admin APIs enables mutating endpoints, to delete data,
+                      shutdown Prometheus, and more. Enabling this should be done with care and the
+                      user is advised to add additional authentication authorization via a proxy to
+                      ensure only clients authorized to perform these actions can do so.
+                    type: boolean
                   enableOtlpHttpReceiver:
                     description: |-
                       Enable Prometheus to accept OpenTelemetry Metrics via the otlp/http protocol.

--- a/docs/api.md
+++ b/docs/api.md
@@ -470,6 +470,18 @@ Define prometheus config
         </tr>
     </thead>
     <tbody><tr>
+        <td><b>enableAdminAPI</b></td>
+        <td>boolean</td>
+        <td>
+          Enable Prometheus Admin API.
+Defaults to the value of `false`.
+WARNING: Enabling the admin APIs enables mutating endpoints, to delete data,
+shutdown Prometheus, and more. Enabling this should be done with care and the
+user is advised to add additional authentication authorization via a proxy to
+ensure only clients authorized to perform these actions can do so.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b>enableOtlpHttpReceiver</b></td>
         <td>boolean</td>
         <td>

--- a/pkg/apis/monitoring/v1alpha1/types.go
+++ b/pkg/apis/monitoring/v1alpha1/types.go
@@ -236,6 +236,14 @@ type PrometheusConfig struct {
 	// Configure TLS options for the Prometheus web server.
 	// +optional
 	WebTLSConfig *WebTLSConfig `json:"webTLSConfig,omitempty"`
+	// Enable Prometheus Admin API.
+	// Defaults to the value of `false`.
+	// WARNING: Enabling the admin APIs enables mutating endpoints, to delete data,
+	// shutdown Prometheus, and more. Enabling this should be done with care and the
+	// user is advised to add additional authentication authorization via a proxy to
+	// ensure only clients authorized to perform these actions can do so.
+	// +optional
+	EnableAdminAPI bool `json:"enableAdminAPI,omitempty"`
 }
 
 type AlertmanagerConfig struct {


### PR DESCRIPTION
As part of the openstack `[watcher](https://opendev.org/openstack/watcher)` [tests](https://opendev.org/openstack/watcher-tempest-plugin/commit/380572db57798530b64dcac14c6b01b0382c5d8e)  we are injecting metrics on prometheus to simulate CPU and memory load on openstack instances. 

we need to delete old metrics to avoid errors calculating node resource utilizations.

To inject metrics, only remotewritter is needed, but to delete them, we need the adminAPI.

We are enabling it by patching prometheus on post_scripting, after controlplane is created, using:

`oc patch prometheuses.monitoring.rhobs metric-storage --namespace=openstack --type=merge -p '{"spec":{"enableAdminAPI":true}}'` [here](https://github.com/openstack-k8s-operators/watcher-operator/blob/9c9ab71408802f8b5a792bcba160111ecd2c1247/ci/playbooks/prometheus_admin_api.yaml)

Having the possibility of adding this parameter to the control-plane kustomize variables at the installation time would avoid to need the post scripting, making edpm jobs easier to maintain (no need to patch, undeploy prometheus, waiting for it to be available...)

I have followed the same logic than used to add `enableRemoteWriteReceiver` parameter, which is also used by our tests to inject metrics.

I'm also creating a similar [PR](https://github.com/openstack-k8s-operators/telemetry-operator/pull/773) on telemetry-operator project, not sure which will require the other to be first merged