### PR TITLE
fix: reconcile incident related resources only in 4.19+

### DIFF
--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -116,7 +116,10 @@ func pluginComponentReconcilers(plugin *uiv1alpha1.UIPlugin, pluginInfo UIPlugin
 	if plugin.Spec.Type == uiv1alpha1.TypeMonitoring {
 		monitoringConfig := plugin.Spec.Monitoring
 		serviceAccountName := plugin.Name + serviceAccountSuffix
-		incidentsEnabled := monitoringConfig != nil && monitoringConfig.Incidents != nil && monitoringConfig.Incidents.Enabled
+		incidentsEnabled := monitoringConfig != nil &&
+			monitoringConfig.Incidents != nil &&
+			monitoringConfig.Incidents.Enabled &&
+			pluginInfo.HealthAnalyzerImage != ""
 		components = append(components,
 			reconciler.NewOptionalUpdater(newClusterRoleBinding(namespace, serviceAccountName, "cluster-monitoring-view", "cluster-monitoring-view"), plugin, incidentsEnabled),
 			reconciler.NewOptionalUpdater(newClusterRoleBinding(namespace, serviceAccountName, "system:auth-delegator", serviceAccountName+"-system-auth-delegator"), plugin, incidentsEnabled),


### PR DESCRIPTION
this is to address https://issues.redhat.com/browse/COO-1285