### PR TITLE
chore: Fix SetLogger warning and image ref to use multiarch images with fully qualified names. 

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -10,10 +10,13 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"go.uber.org/zap/zapcore"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/rhobs/observability-operator/pkg/operator"
 	"github.com/rhobs/observability-operator/test/e2e/framework"
@@ -32,6 +35,13 @@ var (
 
 func TestMain(m *testing.M) {
 	flag.Parse()
+
+	// Setup controller-runtime logger to avoid warning messages
+	opts := zap.Options{
+		Development: true,
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
+	}
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	// Deferred calls are not executed on os.Exit from TestMain.
 	// As a workaround, we call another function in which we can add deferred calls.

--- a/test/e2e/traces_minio.yaml
+++ b/test/e2e/traces_minio.yaml
@@ -45,7 +45,7 @@ spec:
               value: tempo
             - name: MINIO_SECRET_KEY
               value: supersecret
-          image: minio/minio
+          image: quay.io/minio/minio:RELEASE.2024-10-02T17-50-41Z
           name: minio
           ports:
             - containerPort: 9000

--- a/test/e2e/traces_tempo_readiness.yaml
+++ b/test/e2e/traces_tempo_readiness.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: readiness-checker
-          image: curlimages/curl:latest
+          image: ghcr.io/grafana/tempo-operator/test-utils:main
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
The PR fixes the SetLogger warning we get during test execution.
```
    observability_installer_test.go:240: job verify-traces-traceql-grpc didn't succeed yet
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 115 [running]:
	>  runtime/debug.Stack()
	>  	/opt/homebrew/Cellar/go/1.24.6/libexec/src/runtime/debug/stack.go:26 +0x64
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
	>  	/Users/ikanse/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.3/pkg/log/log.go:60 +0xf4
	>  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).WithValues(0x14000426ec0, {0x0, 0x0, 0x0})
	>  	/Users/ikanse/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.3/pkg/log/deleg.go:168 +0x38
	>  github.com/go-logr/logr.Logger.WithValues(...)
	>  	/Users/ikanse/go/pkg/mod/github.com/go-logr/logr@v1.4.3/logr.go:332
	>  sigs.k8s.io/controller-runtime/pkg/log.FromContext({0x102d9ee68?, 0x1043b9940?}, {0x0?, 0x0?, 0x0?})
	>  	/Users/ikanse/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.3/pkg/log/log.go:98 +0xac
	>  sigs.k8s.io/controller-runtime/pkg/log.(*KubeAPIWarningLogger).HandleWarningHeaderWithContext(0x140005554e8, {0x102d9ee68?, 0x1043b9940?}, 0x12b, {0xb?, 0x102225136?}, {0x1400058c300, 0xa3})
	>  	/Users/ikanse/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.3/pkg/log/warning_handler.go:49 +0x54
	>  k8s.io/client-go/rest.handleWarnings({0x102d9ee68, 0x1043b9940}, 0x10?, {0x102d73680?, 0x140005554e8?})
	>  	/Users/ikanse/go/pkg/mod/k8s.io/client-go@v0.34.1/rest/warnings.go:187 +0xe0
	>  k8s.io/client-go/rest.(*Request).transformResponse(0x14000c7bc80, {0x102d9ee68, 0x1043b9940}, 0x14000013e60, 0x140003cb7c0)
	>  	/Users/ikanse/go/pkg/mod/k8s.io/client-go@v0.34.1/rest/request.go:1263 +0x320
	>  k8s.io/client-go/rest.(*Request).Do.func1(0x1400095e800?, 0xa?)
	>  	/Users/ikanse/go/pkg/mod/k8s.io/client-go@v0.34.1/rest/request.go:1137 +0x44
	>  k8s.io/client-go/rest.(*Request).request.func3.1(...)
	>  	/Users/ikanse/go/pkg/mod/k8s.io/client-go@v0.34.1/rest/request.go:1107
	>  k8s.io/client-go/rest.(*Request).request.func3(0x14000013e60, 0x14000747b78, {0x102d9f458?, 0x1400095e800?}, 0x14000013e60?, 0x0?, 0x140003cb7c0, {0x0?, 0x0?}, 0x0?)
	>  	/Users/ikanse/go/pkg/mod/k8s.io/client-go@v0.34.1/rest/request.go:1114 +0xb8
	>  k8s.io/client-go/rest.(*Request).request(0x14000c7bc80, {0x102d9ee68, 0x1043b9940}, 0x14000747b78)
	>  	/Users/ikanse/go/pkg/mod/k8s.io/client-go@v0.34.1/rest/request.go:1116 +0x400
	>  k8s.io/client-go/rest.(*Request).Do(0x14000c7bc80, {0x102d9ee68, 0x1043b9940})
	>  	/Users/ikanse/go/pkg/mod/k8s.io/client-go@v0.34.1/rest/request.go:1136 +0xd8
	>  sigs.k8s.io/controller-runtime/pkg/client.(*unstructuredClient).Delete(0x1400049eb58?, {0x102d9ee68, 0x1043b9940}, {0x102dd0a18?, 0x1400008f6e8?}, {0x0, 0x0, 0x102e36d1a?})
	>  	/Users/ikanse/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.3/pkg/client/unstructured_client.go:114 +0x328
	>  sigs.k8s.io/controller-runtime/pkg/client.(*client).Delete(0x1400049eb40?, {0x102d9ee68?, 0x1043b9940?}, {0x102dd0a18?, 0x1400008f6e8?}, {0x0?, 0x0?, 0x0?})
	>  	/Users/ikanse/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.3/pkg/client/client.go:298 +0x124
	>  github.com/rhobs/observability-operator/test/e2e.testObservabilityInstallerTracing.func10()
	>  	/Users/ikanse/observability-operator/test/e2e/observability_installer_test.go:189 +0x4c
	>  github.com/rhobs/observability-operator/test/e2e.testObservabilityInstallerTracing.(*Framework).CleanUp.func19()
	>  	/Users/ikanse/observability-operator/test/e2e/framework/framework.go:256 +0x50
	>  testing.(*common).Cleanup.func1()
	>  	/opt/homebrew/Cellar/go/1.24.6/libexec/src/testing/testing.go:1211 +0xf4
	>  testing.(*common).runCleanup(0x140000eac40, 0x140007de6e0?)
	>  	/opt/homebrew/Cellar/go/1.24.6/libexec/src/testing/testing.go:1445 +0xe4
	>  testing.tRunner.func2()
	>  	/opt/homebrew/Cellar/go/1.24.6/libexec/src/testing/testing.go:1786 +0x2c
	>  testing.tRunner(0x140000eac40, 0x102d68290)
	>  	/opt/homebrew/Cellar/go/1.24.6/libexec/src/testing/testing.go:1798 +0x110
	>  created by testing.(*T).Run in goroutine 107
	>  	/opt/homebrew/Cellar/go/1.24.6/libexec/src/testing/testing.go:1851 +0x374
```
And images not being pulled with short name restrictions. 
```
Warning Failed  47m (x41 over 3h52m)   kubelet Failed to pull image "minio/minio": short name mode is enforcing, but image name minio/minio:latest returns ambiguous list
Warning Failed     16s (x2 over 33s) kubelet      Failed to pull image "curlimages/curl:latest": short name mode is enforcing, but image name curlimages/curl:latest returns ambiguous list
```