### PR TITLE
[COO-1304] Fix misspelled labels of accelerator metrics

### DIFF
--- a/pkg/controllers/uiplugin/accelerators.go
+++ b/pkg/controllers/uiplugin/accelerators.go
@@ -106,10 +106,10 @@ func newAcceleratorsDashboard(namespace string) *persesv1alpha1.PersesDashboard 
 					"0_0": getPanel("GPU Utilization", "accelerator_gpu_utilization"),
 					"0_1": getPanel("Memory Used Bytes", "accelerator_memory_used_bytes"),
 					"0_2": getPanel("Memory Total Bytes", "accelerator_memory_total_bytes"),
-					"0_3": getPanel("Power Usage (watts)", "accelerator_power_usage_watts"),
-					"0_4": getPanel("Temperature (celcius)", "accelerator_temperature_celcius"),
-					"0_5": getPanel("SM Clock(hertz)", "accelerator_sm_clock_hertz"),
-					"0_6": getPanel("Memory Clock(hertz)", "accelerator_memory_clock_hertz"),
+					"0_3": getPanel("Power Usage (Watts)", "accelerator_power_usage_watts"),
+					"0_4": getPanel("Temperature (Celsius)", "accelerator_temperature_celcius"),
+					"0_5": getPanel("SM Clock (Hertz)", "accelerator_sm_clock_hertz"),
+					"0_6": getPanel("Memory Clock (Hertz)", "accelerator_memory_clock_hertz"),
 				},
 				Layouts: []dashboard.Layout{
 					{


### PR DESCRIPTION
Fix misspelled labels in the common accelerator metrics dashboard.