### PR TITLE
fix: [COO-1313] Add missing description for ObservabilityInstaller in OpenShift console

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:1.3.0
-    createdAt: "2025-11-03T09:23:49Z"
+    createdAt: "2025-11-07T04:13:59Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operatorframework.io/cluster-monitoring: "true"
@@ -80,7 +80,10 @@ spec:
       kind: MonitoringStack
       name: monitoringstacks.monitoring.rhobs
       version: v1alpha1
-    - kind: ObservabilityInstaller
+    - description: Provides end-to-end observability capabilities with minimal configuration.
+        Simplifies deployment and management of observability components such as tracing.
+      displayName: Observability Installer
+      kind: ObservabilityInstaller
       name: observabilityinstallers.observability.openshift.io
       version: v1alpha1
     - description: Perses is the Schema for the perses API

--- a/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
+++ b/deploy/olm/bases/observability-operator.clusterserviceversion.yaml
@@ -2,7 +2,37 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: "[]"
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "observability.openshift.io/v1alpha1",
+          "kind": "ObservabilityInstaller",
+          "metadata": {
+            "name": "sample-observability",
+            "namespace": "observability"
+          },
+          "spec": {
+            "capabilities": {
+              "tracing": {
+                "enabled": true,
+                "storage": {
+                  "objectStorage": {
+                    "s3": {
+                      "bucket": "tempo",
+                      "endpoint": "http://minio.minio.svc:9000",
+                      "accessKeyID": "tempo",
+                      "accessKeySecret": {
+                        "name": "minio-secret",
+                        "key": "access_key_secret"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
     capabilities: Basic Install
     categories: Monitoring
     certified: "false"
@@ -44,6 +74,11 @@ spec:
         displayName: MonitoringStack
         kind: MonitoringStack
         name: monitoringstacks.monitoring.rhobs
+        version: v1alpha1
+      - description: Provides end-to-end observability capabilities with minimal configuration. Simplifies deployment and management of observability components such as tracing.
+        displayName: Observability Installer
+        kind: ObservabilityInstaller
+        name: observabilityinstallers.observability.openshift.io
         version: v1alpha1
       - description: PodMonitor defines monitoring for a set of pods
         displayName: PodMonitor

--- a/deploy/samples/observability-installer.yaml
+++ b/deploy/samples/observability-installer.yaml
@@ -1,0 +1,18 @@
+apiVersion: observability.openshift.io/v1alpha1
+kind: ObservabilityInstaller
+metadata:
+  name: sample-observability
+  namespace: observability
+spec:
+  capabilities:
+    tracing:
+      enabled: true
+      storage:
+        objectStorage:
+          s3:
+            bucket: tempo
+            endpoint: http://minio.minio.svc:9000
+            accessKeyID: tempo
+            accessKeySecret:
+              name: minio-secret
+              key: access_key_secret

--- a/pkg/apis/observability/v1alpha1/types.go
+++ b/pkg/apis/observability/v1alpha1/types.go
@@ -16,6 +16,7 @@ import (
 // +kubebuilder:printcolumn:name="OpenTelemetry",type="string",JSONPath=".status.opentelemetry"
 // +kubebuilder:printcolumn:name="Tempo",type="string",JSONPath=".status.tempo"
 // +operator-sdk:csv:customresourcedefinitions:displayName="Observability Installer"
+// +operator-sdk:csv:customresourcedefinitions:description="Provides end-to-end observability capabilities with minimal configuration. Simplifies deployment and management of observability components such as tracing."
 // +kubebuilder:metadata:annotations="observability.openshift.io/api-support=TechPreview"
 type ObservabilityInstaller struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
The PR fixes issue https://issues.redhat.com/browse/COO-1313
- Add ObservabilityInstaller CRD entry to base ClusterServiceVersion with proper description and displayName
- Add operator-sdk description annotation to ObservabilityInstaller Go type
- Create sample ObservabilityInstaller YAML for tracing with S3 storage