### PR TITLE
fix: rename clusterrolebinding used for monitoring plugin to avoid clash

### DIFF
--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -121,7 +121,7 @@ func pluginComponentReconcilers(plugin *uiv1alpha1.UIPlugin, pluginInfo UIPlugin
 			monitoringConfig.Incidents.Enabled &&
 			pluginInfo.HealthAnalyzerImage != ""
 		components = append(components,
-			reconciler.NewOptionalUpdater(newClusterRoleBinding(namespace, serviceAccountName, "cluster-monitoring-view", "cluster-monitoring-view"), plugin, incidentsEnabled),
+			reconciler.NewOptionalUpdater(newClusterRoleBinding(namespace, serviceAccountName, "cluster-monitoring-view", plugin.Name+"cluster-monitoring-view"), plugin, incidentsEnabled),
 			reconciler.NewOptionalUpdater(newClusterRoleBinding(namespace, serviceAccountName, "system:auth-delegator", serviceAccountName+"-system-auth-delegator"), plugin, incidentsEnabled),
 			reconciler.NewOptionalUpdater(newAlertManagerViewRoleBinding(serviceAccountName, namespace), plugin, incidentsEnabled),
 			reconciler.NewOptionalUpdater(newHealthAnalyzerPrometheusRole(namespace), plugin, incidentsEnabled),


### PR DESCRIPTION
This is a suggestion of quick fix for https://issues.redhat.com/browse/COO-1314. The `clusterrolebinding` with name `cluster-monitoring-view` is created twice:

- https://github.com/rhobs/observability-operator/blob/main/pkg/controllers/uiplugin/troubleshooting_panel.go#L241 - for the korrel8r & troubleshooting. This adds bunch of policy rules which are not needed in the `health-analyzer` 
- https://github.com/rhobs/observability-operator/blob/main/pkg/controllers/uiplugin/components.go#L121 - for the incident detection