### PR TITLE
fix: fix & rename health-analyzer and korrel8r clusterrolebindings

### DIFF
--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -35,6 +35,7 @@ const (
 	OpenshiftLoggingNs     = "openshift-logging"
 	OpenshiftNetobservNs   = "netobserv"
 	OpenshiftTracingNs     = "openshift-tracing"
+	monitorClusterroleName = "cluster-monitoring-view"
 
 	annotationPrefix = "observability.openshift.io/ui-plugin-"
 )
@@ -121,7 +122,7 @@ func pluginComponentReconcilers(plugin *uiv1alpha1.UIPlugin, pluginInfo UIPlugin
 			monitoringConfig.Incidents.Enabled &&
 			pluginInfo.HealthAnalyzerImage != ""
 		components = append(components,
-			reconciler.NewOptionalUpdater(newClusterRoleBinding(namespace, serviceAccountName, "cluster-monitoring-view", plugin.Name+"cluster-monitoring-view"), plugin, incidentsEnabled),
+			reconciler.NewOptionalUpdater(newClusterRoleBinding(namespace, serviceAccountName, monitorClusterroleName, plugin.Name+"-"+monitorClusterroleName), plugin, incidentsEnabled),
 			reconciler.NewOptionalUpdater(newClusterRoleBinding(namespace, serviceAccountName, "system:auth-delegator", serviceAccountName+"-system-auth-delegator"), plugin, incidentsEnabled),
 			reconciler.NewOptionalUpdater(newAlertManagerViewRoleBinding(serviceAccountName, namespace), plugin, incidentsEnabled),
 			reconciler.NewOptionalUpdater(newHealthAnalyzerPrometheusRole(namespace), plugin, incidentsEnabled),


### PR DESCRIPTION
There was an issue with two `cluster-monitoring-view` clusterrolebindings (one for korrel8r and second one for health analyzer) during the release. 

We quickly fixed this during the release by renaming the crb for the health analyzer. This is an attempt to improve the hotfix:
- have only one function for crb creation
- crb names are prefixed with the plugin name 