### PR TITLE
fix: disable unmanaged Prometheus configuration

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:1.3.0
-    createdAt: "2025-11-28T13:17:19Z"
+    createdAt: "2025-12-02T10:45:37Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operatorframework.io/cluster-monitoring: "true"
@@ -865,6 +865,7 @@ spec:
                 - --alertmanager-instance-selector=app.kubernetes.io/managed-by=observability-operator
                 - --thanos-ruler-instance-selector=app.kubernetes.io/managed-by=observability-operator
                 - --watch-referenced-objects-in-all-namespaces=true
+                - --disable-unmanaged-prometheus-configuration=true
                 env:
                 - name: GOGC
                   value: "30"

--- a/deploy/dependencies/kustomization.yaml
+++ b/deploy/dependencies/kustomization.yaml
@@ -77,6 +77,7 @@ patches:
                 - --alertmanager-instance-selector=app.kubernetes.io/managed-by=observability-operator
                 - --thanos-ruler-instance-selector=app.kubernetes.io/managed-by=observability-operator
                 - --watch-referenced-objects-in-all-namespaces=true
+                - --disable-unmanaged-prometheus-configuration=true
               resources:
                 requests:
                   cpu: 5m


### PR DESCRIPTION
This commit adds the `--disable-unmanaged-prometheus-configuration=true` argument to the Prometheus operator deployment. Without this change and in case of a null resource selector, the Prometheus pods fail to become ready because the Prometheus configuration is left empty while the Thanos sidecar expects to find external labels. The "unmanaged configuration" mode is an old upstream "hack" which allowed users to provide their own custom Prometheus configuration for cases where it couldn't be implemented with `ServiceMonitor`. The new approach is to use the `ScrapeConfig` CRD.

When a `MonitoringStack` resource is created with a null resource selector, the Prometheus configuration will contain no scrape configuration and no rules. One possible use case is to deploy a Prometheus which only ingests metrics via remote-write and/or OTLP.

Closes #932