### PR TITLE
feat: support size-based retention for MonitoringStack

### DIFF
--- a/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
+++ b/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
@@ -1715,9 +1715,22 @@ spec:
               retention:
                 default: 120h
                 description: |-
-                  Time duration to retain data for. Default is '120h',
-                  and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes hours days weeks years).
+                  Time duration to retain data for. Default is '120h', and the value must
+                  match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds
+                  seconds minutes hours days weeks years).
+
+                  When both retention and retentionSize are defined, whichever triggers
+                  first will be applied.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                type: string
+              retentionSize:
+                description: |-
+                  retentionSize defines the maximum number of bytes used by the Prometheus
+                  data. By default the size is unlimited.
+
+                  When both retention and retentionSize are defined, whichever triggers
+                  first will be applied.
+                pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
                 type: string
               tolerations:
                 description: Define tolerations for Monitoring Stack Pods.

--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -42,7 +42,7 @@ metadata:
     categories: Monitoring
     certified: "false"
     containerImage: observability-operator:1.3.0
-    createdAt: "2025-11-27T18:47:09Z"
+    createdAt: "2025-11-28T13:17:19Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operatorframework.io/cluster-monitoring: "true"

--- a/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
+++ b/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
@@ -1715,9 +1715,22 @@ spec:
               retention:
                 default: 120h
                 description: |-
-                  Time duration to retain data for. Default is '120h',
-                  and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes hours days weeks years).
+                  Time duration to retain data for. Default is '120h', and the value must
+                  match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds
+                  seconds minutes hours days weeks years).
+
+                  When both retention and retentionSize are defined, whichever triggers
+                  first will be applied.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                type: string
+              retentionSize:
+                description: |-
+                  retentionSize defines the maximum number of bytes used by the Prometheus
+                  data. By default the size is unlimited.
+
+                  When both retention and retentionSize are defined, whichever triggers
+                  first will be applied.
+                pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
                 type: string
               tolerations:
                 description: Define tolerations for Monitoring Stack Pods.

--- a/docs/api.md
+++ b/docs/api.md
@@ -173,10 +173,25 @@ To disable service discovery, set to null. E.g. resourceSelector:.<br/>
         <td><b>retention</b></td>
         <td>string</td>
         <td>
-          Time duration to retain data for. Default is '120h',
-and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes hours days weeks years).<br/>
+          Time duration to retain data for. Default is '120h', and the value must
+match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds
+seconds minutes hours days weeks years).
+
+When both retention and retentionSize are defined, whichever triggers
+first will be applied.<br/>
           <br/>
             <i>Default</i>: 120h<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>retentionSize</b></td>
+        <td>string</td>
+        <td>
+          retentionSize defines the maximum number of bytes used by the Prometheus
+data. By default the size is unlimited.
+
+When both retention and retentionSize are defined, whichever triggers
+first will be applied.<br/>
         </td>
         <td>false</td>
       </tr><tr>

--- a/pkg/apis/monitoring/v1alpha1/types.go
+++ b/pkg/apis/monitoring/v1alpha1/types.go
@@ -103,10 +103,24 @@ type MonitoringStackSpec struct {
 	// +optional
 	CreateClusterRoleBindings ClusterRoleBindingPolicy `json:"createClusterRoleBindings,omitempty"`
 
-	// Time duration to retain data for. Default is '120h',
-	// and must match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds seconds minutes hours days weeks years).
+	// Time duration to retain data for. Default is '120h', and the value must
+	// match the regular expression `[0-9]+(ms|s|m|h|d|w|y)` (milliseconds
+	// seconds minutes hours days weeks years).
+	//
+	// When both retention and retentionSize are defined, whichever triggers
+	// first will be applied.
+	//
 	// +kubebuilder:default="120h"
 	Retention monv1.Duration `json:"retention,omitempty"`
+
+	// retentionSize defines the maximum number of bytes used by the Prometheus
+	// data. By default the size is unlimited.
+	//
+	// When both retention and retentionSize are defined, whichever triggers
+	// first will be applied.
+	//
+	// +optional
+	RetentionSize monv1.ByteSize `json:"retentionSize,omitempty"`
 
 	// Define resources requests and limits for Monitoring Stack Pods.
 	// +optional

--- a/pkg/controllers/monitoring/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components.go
@@ -210,6 +210,7 @@ func newPrometheus(
 				}(),
 			},
 			Retention:             ms.Spec.Retention,
+			RetentionSize:         ms.Spec.RetentionSize,
 			RuleSelector:          prometheusSelector,
 			RuleNamespaceSelector: ms.Spec.NamespaceSelector,
 			Thanos: &monv1.ThanosSpec{


### PR DESCRIPTION
This commit exposes a new `retentionSize` field in the MonitoringStack CRD which mimics the API already present in the Prometheus CRD.

Closes #890