### PR TITLE
COO-1597: Raise memory limit of observability-operator deploy

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -953,9 +953,7 @@ spec:
                 - containerPort: 8080
                   name: http
                 resources:
-                  limits:
-                    cpu: 100m
-                    memory: 500Mi
+                  limits: {}
                   requests:
                     cpu: 5m
                     memory: 150Mi
@@ -1026,9 +1024,7 @@ spec:
                 - containerPort: 8443
                   name: https
                 resources:
-                  limits:
-                    cpu: 200m
-                    memory: 200Mi
+                  limits: {}
                   requests:
                     cpu: 50m
                     memory: 50Mi
@@ -1095,9 +1091,7 @@ spec:
                     path: /healthz
                     port: 8081
                 resources:
-                  limits:
-                    cpu: 400m
-                    memory: 512Mi
+                  limits: {}
                   requests:
                     cpu: 100m
                     memory: 256Mi
@@ -1169,9 +1163,7 @@ spec:
                   initialDelaySeconds: 5
                   periodSeconds: 10
                 resources:
-                  limits:
-                    cpu: 500m
-                    memory: 512Mi
+                  limits: {}
                   requests:
                     cpu: 100m
                     memory: 128Mi

--- a/deploy/dependencies/kustomization.yaml
+++ b/deploy/dependencies/kustomization.yaml
@@ -88,9 +88,7 @@ patches:
                 requests:
                   cpu: 5m
                   memory: 150Mi
-                limits:
-                  cpu: 100m
-                  memory: 500Mi
+                limits: {}
               terminationMessagePolicy: FallbackToLogsOnError
           securityContext:
             runAsNonRoot: true

--- a/deploy/olm/syncselector-template.yaml
+++ b/deploy/olm/syncselector-template.yaml
@@ -7,15 +7,9 @@ parameters:
   - name: CHANNEL
     value: development
     required: true
-  - name: RESOURCE_LIMIT_CPU
-    required: true
-    value: 200m
   - name: RESOURCE_REQUEST_CPU
     required: true
     value: 100m
-  - name: RESOURCE_LIMIT_MEMORY
-    required: true
-    value: 300Mi
   - name: RESOURCE_REQUEST_MEMORY
     required: true
     value: 150m
@@ -67,9 +61,7 @@ objects:
             sourceNamespace: openshift-marketplace
             config:
               resources:
-                limits:
-                  cpu: ${RESOURCE_LIMIT_CPU}
-                  memory: ${RESOURCE_LIMIT_MEMORY}
+                limits: {}
                 requests:
                   cpu: ${RESOURCE_REQUEST_CPU}
                   memory: ${RESOURCE_REQUEST_MEMORY}
@@ -118,9 +110,7 @@ objects:
             sourceNamespace: openshift-observability-operator
             config:
               resources:
-                limits:
-                  cpu: ${RESOURCE_LIMIT_CPU}
-                  memory: ${RESOURCE_LIMIT_MEMORY}
+                limits: {}
                 requests:
                   cpu: ${RESOURCE_REQUEST_CPU}
                   memory: ${RESOURCE_REQUEST_MEMORY}
@@ -169,9 +159,7 @@ objects:
             sourceNamespace: openshift-observability-operator
             config:
               resources:
-                limits:
-                  cpu: ${RESOURCE_LIMIT_CPU}
-                  memory: ${RESOURCE_LIMIT_MEMORY}
+                limits: {}
                 requests:
                   cpu: ${RESOURCE_REQUEST_CPU}
                   memory: ${RESOURCE_REQUEST_MEMORY}

--- a/deploy/operator/observability-operator-deployment.yaml
+++ b/deploy/operator/observability-operator-deployment.yaml
@@ -41,7 +41,7 @@ spec:
           resources:
             limits:
               cpu: 400m
-              memory: 512Mi
+              memory: 550Mi
             requests:
               cpu: 100m
               memory: 256Mi

--- a/deploy/operator/observability-operator-deployment.yaml
+++ b/deploy/operator/observability-operator-deployment.yaml
@@ -39,9 +39,7 @@ spec:
               drop:
               - ALL
           resources:
-            limits:
-              cpu: 400m
-              memory: 512Mi
+            limits: {}
             requests:
               cpu: 100m
               memory: 256Mi

--- a/deploy/perses/perses-operator-deployment.yaml
+++ b/deploy/perses/perses-operator-deployment.yaml
@@ -47,9 +47,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
+          limits: {}
           requests:
             cpu: 100m
             memory: 128Mi


### PR DESCRIPTION
On a larger OCP 4.18 cluster with 66 nodes observability-operator 1.3.0 gets OOMKilled right after start.

Issue is reported in https://access.redhat.com/support/cases/#/case/04368491
Issue is tracked in https://issues.redhat.com/browse/COO-1597

**Update** due to missing information about the actual issue:
We are aware of the fact that it is possible to set resource requests and limits in the subscription. We use the following as a workaround:
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: cluster-observability-operator
  namespace: openshift-operators-redhat
spec:
  channel: stable
  config:
    resources:
      limits:
        memory: 3Gi
     requests:
       memory: 500Mi
```

The problem is that the given config is set on all COO components equally:
- obo-prometheus-operator
- obo-prometheus-operator-admission-webhook
- observability-operator
- perses-operator

Because of the elevated memory usage of perses in contrast to the other components, we were forced to set the memory limit to 3Gi.
Now all the components have a needlessly too high memory limit:
```bash
$ oc get deploy -o custom-columns=NAME:.metadata.name,RESOURCES:.spec.template.spec.containers[0].resources
NAME                                        RESOURCES
logging                                     map[]
loki-operator-controller-manager            map[]
obo-prometheus-operator                     map[limits:map[memory:3Gi] requests:map[memory:500Mi]]
obo-prometheus-operator-admission-webhook   map[limits:map[memory:3Gi] requests:map[memory:500Mi]]
observability-operator                      map[limits:map[memory:3Gi] requests:map[memory:500Mi]]
perses-operator                             map[limits:map[memory:3Gi] requests:map[memory:500Mi]]


$ oc adm top po
NAME                                                        CPU(cores)   MEMORY(bytes)   
logging-7c8b5bfdf4-v5p67                                    1m           23Mi            
loki-operator-controller-manager-7c5b4ffbfb-wvt9b           49m          5622Mi          
obo-prometheus-operator-545cdc864f-wxmzh                    61m          317Mi           
obo-prometheus-operator-admission-webhook-57d54bf6d-4p6j6   1m           11Mi            
obo-prometheus-operator-admission-webhook-57d54bf6d-x5pfh   1m           12Mi            
observability-operator-595c984dfb-24lsc                     3m           536Mi           
perses-operator-5fc9687477-8g9jc                            11m          1701Mi          
```