### PR TITLE
COO-1687: feat: migrate to EndpointSlice service discovery

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ metadata:
     certified: "false"
     console.openshift.io/operator-monitoring-default: "true"
     containerImage: observability-operator:1.3.0
-    createdAt: "2026-03-03T14:08:32Z"
+    createdAt: "2026-03-09T07:53:46Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operatorframework.io/cluster-monitoring: "true"
@@ -435,6 +435,14 @@ spec:
           - list
           - patch
           - update
+          - watch
+        - apiGroups:
+          - discovery.k8s.io
+          resources:
+          - endpointslices
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - extensions

--- a/deploy/operator/observability-operator-cluster-role.yaml
+++ b/deploy/operator/observability-operator-cluster-role.yaml
@@ -120,6 +120,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - extensions
   - networking.k8s.io
   resources:

--- a/pkg/controllers/monitoring/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components.go
@@ -101,6 +101,10 @@ func newPrometheusClusterRole(rbacResourceName string, rbacVerbs []string) *rbac
 			Resources: []string{"services", "endpoints", "pods"},
 			Verbs:     rbacVerbs,
 		}, {
+			APIGroups: []string{"discovery.k8s.io"},
+			Resources: []string{"endpointslices"},
+			Verbs:     rbacVerbs,
+		}, {
 			APIGroups: []string{"extensions", "networking.k8s.io"},
 			Resources: []string{"ingresses"},
 			Verbs:     rbacVerbs,

--- a/pkg/controllers/monitoring/monitoring-stack/controller.go
+++ b/pkg/controllers/monitoring/monitoring-stack/controller.go
@@ -80,6 +80,7 @@ const finalizerName = "monitoring.observability.openshift.io/finalizer"
 
 // RBAC for delegating permissions to Prometheus
 //+kubebuilder:rbac:groups="",resources=pods;services;endpoints,verbs=get;list;watch
+//+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 //+kubebuilder:rbac:groups=extensions;networking.k8s.io,resources=ingresses,verbs=get;list;watch
 
 // RBAC for delegating the use of SCC nonroot-v2 (for OpenShift >= 4.11) and nonroot (for OpenShift < 4.11)

--- a/pkg/controllers/monitoring/thanos-querier/components.go
+++ b/pkg/controllers/monitoring/thanos-querier/components.go
@@ -249,6 +249,7 @@ func newServiceMonitor(name string, namespace string, thanos *msoapi.ThanosQueri
 			Labels:    componentLabels(name),
 		},
 		Spec: monv1.ServiceMonitorSpec{
+			ServiceDiscoveryRole: ptr.To(monv1.EndpointSliceRole),
 			Endpoints: []monv1.Endpoint{
 				{
 					Port:   "http",

--- a/pkg/controllers/operator/components.go
+++ b/pkg/controllers/operator/components.go
@@ -42,6 +42,7 @@ func newServiceMonitor(namespace string) *monv1.ServiceMonitor {
 		},
 
 		Spec: monv1.ServiceMonitorSpec{
+			ServiceDiscoveryRole: ptr.To(monv1.EndpointSliceRole),
 			Endpoints: []monv1.Endpoint{
 				{
 					Port:   "metrics",
@@ -85,6 +86,10 @@ func newPrometheusRole(namespace string) *rbacv1.Role {
 		Rules: []rbacv1.PolicyRule{{
 			APIGroups: []string{""},
 			Resources: []string{"services", "endpoints", "pods"},
+			Verbs:     []string{"get", "list", "watch"},
+		}, {
+			APIGroups: []string{"discovery.k8s.io"},
+			Resources: []string{"endpointslices"},
 			Verbs:     []string{"get", "list", "watch"},
 		}},
 	}

--- a/pkg/controllers/operator/components.go
+++ b/pkg/controllers/operator/components.go
@@ -42,7 +42,6 @@ func newServiceMonitor(namespace string) *monv1.ServiceMonitor {
 		},
 
 		Spec: monv1.ServiceMonitorSpec{
-			ServiceDiscoveryRole: ptr.To(monv1.EndpointSliceRole),
 			Endpoints: []monv1.Endpoint{
 				{
 					Port:   "metrics",

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -95,6 +95,7 @@ const (
 //+kubebuilder:rbac:groups=apps,resources=daemonsets;deployments;replicasets;statefulsets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=configmaps;endpoints;events;namespaces;nodes;persistentvolumeclaims;persistentvolumes;pods;replicationcontrollers;secrets;serviceaccounts;services,verbs=get;list;watch
+//+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 //+kubebuilder:rbac:groups=batch,resources=cronjobs;jobs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch
 //+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch

--- a/pkg/controllers/uiplugin/health_analyzer.go
+++ b/pkg/controllers/uiplugin/health_analyzer.go
@@ -39,6 +39,11 @@ func newHealthAnalyzerPrometheusRole(namespace string) *rbacv1.Role {
 				Resources: []string{"services", "endpoints", "pods"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
+			{
+				APIGroups: []string{"discovery.k8s.io"},
+				Resources: []string{"endpointslices"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
 		},
 	}
 	return role
@@ -219,6 +224,7 @@ func newHealthAnalyzerServiceMonitor(namespace string) *monv1.ServiceMonitor {
 			Namespace: namespace,
 		},
 		Spec: monv1.ServiceMonitorSpec{
+			ServiceDiscoveryRole: ptr.To(monv1.EndpointSliceRole),
 			Endpoints: []monv1.Endpoint{
 				{
 					Interval: "30s",

--- a/pkg/controllers/uiplugin/health_analyzer.go
+++ b/pkg/controllers/uiplugin/health_analyzer.go
@@ -224,7 +224,6 @@ func newHealthAnalyzerServiceMonitor(namespace string) *monv1.ServiceMonitor {
 			Namespace: namespace,
 		},
 		Spec: monv1.ServiceMonitorSpec{
-			ServiceDiscoveryRole: ptr.To(monv1.EndpointSliceRole),
 			Endpoints: []monv1.Endpoint{
 				{
 					Interval: "30s",

--- a/pkg/controllers/uiplugin/troubleshooting_panel.go
+++ b/pkg/controllers/uiplugin/troubleshooting_panel.go
@@ -195,6 +195,11 @@ func korrel8rClusterRole(name string) *rbacv1.ClusterRole {
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
+				APIGroups: []string{"discovery.k8s.io"},
+				Resources: []string{"endpointslices"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
 				APIGroups: []string{"rbac.authorization.k8s.io"},
 				Resources: []string{"roles", "rolebindings", "clusterroles", "clusterrolebindings"},
 				Verbs:     []string{"list", "watch"},


### PR DESCRIPTION
Prometheus Operator defaults to watching the deprecated Endpoints API for service discovery. Switch the operator's own ServiceMonitors to use EndpointSlice explicitly, which eliminates the deprecation log noise from the operator's internal components.

Changes:
- Set serviceDiscoveryRole: EndpointSlice on the ServiceMonitors we own (observability-operator, health-analyzer, thanos-querier) so that prometheus-operator uses the EndpointSlice role for these jobs.
- Add discovery.k8s.io/endpointslices to all Prometheus RBAC roles and ClusterRoles (alongside the existing endpoints permission) so that Prometheus can serve both kinds of ServiceMonitors simultaneously.
- Add discovery.k8s.io/endpointslices to the korrel8r ClusterRole so the correlation tool can read both endpoint representations.
- Add the corresponding kubebuilder markers and update the generated cluster role YAML and CSV.

The Prometheus CR's global serviceDiscoveryRole is intentionally left unset (defaulting to Endpoints) so that user-created ServiceMonitors continue to work without modification. Users can opt individual ServiceMonitors into EndpointSlice by setting serviceDiscoveryRole: EndpointSlice on them.