### PR TITLE
COO-1553: feat: bind the tls profile with the ui plugin deployments

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -23,9 +23,9 @@ import (
 	"os"
 	"slices"
 
-	obopo "github.com/rhobs/obo-prometheus-operator/pkg/operator"
 	configv1 "github.com/openshift/api/config/v1"
 	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
+	obopo "github.com/rhobs/obo-prometheus-operator/pkg/operator"
 	"go.uber.org/zap/zapcore"
 	k8sflag "k8s.io/component-base/cli/flag"
 	"k8s.io/utils/ptr"

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -24,10 +24,13 @@ import (
 	"slices"
 
 	obopo "github.com/rhobs/obo-prometheus-operator/pkg/operator"
+	configv1 "github.com/openshift/api/config/v1"
+	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
 	"go.uber.org/zap/zapcore"
 	k8sflag "k8s.io/component-base/cli/flag"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/rhobs/observability-operator/pkg/operator"
@@ -134,6 +137,23 @@ func main() {
 	ctx, cancel := context.WithCancel(signalCtx)
 	defer cancel()
 
+	var initialTLSProfileSpec configv1.TLSProfileSpec
+	if openShiftEnabled {
+		scheme := operator.NewOpenShiftScheme()
+		directClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+		if err != nil {
+			setupLog.Error(err, "failed to create client for TLS profile fetch")
+			os.Exit(1)
+		}
+
+		initialTLSProfileSpec, err = openshifttls.FetchAPIServerTLSProfile(ctx, directClient)
+		if err != nil {
+			setupLog.Error(err, "failed to fetch TLS profile from cluster")
+			os.Exit(1)
+		}
+		setupLog.Info("fetched initial TLS profile", "minVersion", initialTLSProfileSpec.MinTLSVersion, "ciphers_len", len(initialTLSProfileSpec.Ciphers), "ciphers", initialTLSProfileSpec.Ciphers)
+	}
+
 	op, err := operator.New(
 		ctx,
 		operator.NewOperatorConfiguration(
@@ -156,6 +176,13 @@ func main() {
 				},
 			}),
 			operator.WithCancelFunc(cancel),
+
+			func() func(*operator.OperatorConfiguration) {
+				if openShiftEnabled {
+					return operator.WithTLSProfile(initialTLSProfileSpec)
+				}
+				return func(*operator.OperatorConfiguration) {}
+			}(),
 		))
 	if err != nil {
 		setupLog.Error(err, "cannot create a new operator")

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/open-telemetry/opentelemetry-operator v0.135.0
 	github.com/openshift/api v3.9.0+incompatible // PINNED: newer versions remove console/v1alpha1 API needed for OpenShift <4.17 compatibility
 	github.com/openshift/controller-runtime-common v0.0.0-20260210092218-8eef974290cd
+	github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5
 	github.com/operator-framework/api v0.38.0
 	github.com/perses/perses v0.53.0
 	github.com/perses/plugins/prometheus v0.57.0
@@ -122,7 +123,6 @@ require (
 	github.com/novln/docker-parser v1.0.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/openshift/library-go v0.0.0-20260213153706-03f1709971c5 // indirect
 	github.com/perses/common v0.30.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus-community/prom-label-proxy v0.12.1 // indirect

--- a/pkg/controllers/uiplugin/compatibility_matrix.go
+++ b/pkg/controllers/uiplugin/compatibility_matrix.go
@@ -29,6 +29,9 @@ type CompatibilityEntry struct {
 	ImageKey          string
 	SupportLevel      SupportLevel
 	Features          []string
+	// SupportsTLSProfile indicates whether this plugin image supports
+	// -tls-min-version and -tls-cipher-suites command flags.
+	SupportsTLSProfile bool
 }
 
 type ListFunction func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
@@ -157,7 +160,8 @@ var compatibilityMatrix = []CompatibilityEntry{
 		SupportLevel:      GeneralAvailability,
 		// feature flags for montioring are dynamically injected
 		// based on the cluster version and and UIPlugin CR configurations
-		Features: []string{},
+		Features:           []string{},
+		SupportsTLSProfile: true,
 	},
 }
 

--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -282,6 +282,13 @@ func newDeployment(info UIPluginInfo, namespace string, config *uiv1alpha1.Deplo
 		pluginArgs = append(pluginArgs, info.ExtraArgs...)
 	}
 
+	if info.TLSMinVersion != "" {
+		pluginArgs = append(pluginArgs, fmt.Sprintf("-tls-min-version=%s", info.TLSMinVersion))
+	}
+	if len(info.TLSCiphers) > 0 {
+		pluginArgs = append(pluginArgs, fmt.Sprintf("-tls-cipher-suites=%s", strings.Join(info.TLSCiphers, ",")))
+	}
+
 	volumes := []corev1.Volume{
 		{
 			Name: servingCertVolumeName,

--- a/pkg/controllers/uiplugin/components_test.go
+++ b/pkg/controllers/uiplugin/components_test.go
@@ -54,3 +54,180 @@ func TestIsVersionAheadOrEqual(t *testing.T) {
 		assert.Equal(t, tc.expected, actual)
 	}
 }
+
+func TestNewDeploymentTLSArgs(t *testing.T) {
+	testCases := []struct {
+		name           string
+		tlsMinVersion  string
+		tlsCiphers     []string
+		extraArgs      []string
+		expectArgs     []string
+		notExpectArgs  []string
+	}{
+		{
+			name:          "TLS profile with min version and ciphers",
+			tlsMinVersion: "VersionTLS12",
+			tlsCiphers:    []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+			expectArgs: []string{
+				"-tls-min-version=VersionTLS12",
+				"-tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384",
+			},
+		},
+		{
+			name:          "no TLS profile",
+			tlsMinVersion: "",
+			tlsCiphers:    nil,
+			notExpectArgs: []string{
+				"-tls-min-version=",
+				"-tls-cipher-suites=",
+			},
+		},
+		{
+			name:          "TLS min version only",
+			tlsMinVersion: "VersionTLS13",
+			tlsCiphers:    nil,
+			expectArgs: []string{
+				"-tls-min-version=VersionTLS13",
+			},
+			notExpectArgs: []string{
+				"-tls-cipher-suites=",
+			},
+		},
+		{
+			name:          "TLS args appear after extra args",
+			tlsMinVersion: "VersionTLS12",
+			tlsCiphers:    []string{"TLS_AES_128_GCM_SHA256"},
+			extraArgs:     []string{"-plugin-config-path=/etc/plugin/config/config.yaml"},
+			expectArgs: []string{
+				"-plugin-config-path=/etc/plugin/config/config.yaml",
+				"-tls-min-version=VersionTLS12",
+				"-tls-cipher-suites=TLS_AES_128_GCM_SHA256",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := UIPluginInfo{
+				Name:          "test-plugin",
+				Image:         "test-image:latest",
+				ExtraArgs:     tc.extraArgs,
+				TLSMinVersion: tc.tlsMinVersion,
+				TLSCiphers:    tc.tlsCiphers,
+			}
+
+			deploy := newDeployment(info, "test-ns", nil)
+			args := deploy.Spec.Template.Spec.Containers[0].Args
+
+			// Always expect base args
+			assert.Assert(t, containsArg(args, "-port=9443"))
+			assert.Assert(t, containsArg(args, "-cert=/var/serving-cert/tls.crt"))
+			assert.Assert(t, containsArg(args, "-key=/var/serving-cert/tls.key"))
+
+			for _, expected := range tc.expectArgs {
+				assert.Assert(t, containsArg(args, expected), "expected arg %q not found in %v", expected, args)
+			}
+
+			for _, notExpected := range tc.notExpectArgs {
+				assert.Assert(t, !containsArgPrefix(args, notExpected), "unexpected arg prefix %q found in %v", notExpected, args)
+			}
+
+			// Verify ordering: TLS args should come after extra args
+			if len(tc.extraArgs) > 0 && tc.tlsMinVersion != "" {
+				extraArgIdx := indexOfArg(args, tc.extraArgs[0])
+				tlsArgIdx := indexOfArg(args, "-tls-min-version="+tc.tlsMinVersion)
+				assert.Assert(t, extraArgIdx < tlsArgIdx, "extra args should appear before TLS args")
+			}
+		})
+	}
+}
+
+func containsArg(args []string, target string) bool {
+	for _, arg := range args {
+		if arg == target {
+			return true
+		}
+	}
+	return false
+}
+
+func containsArgPrefix(args []string, prefix string) bool {
+	for _, arg := range args {
+		if len(arg) >= len(prefix) && arg[:len(prefix)] == prefix {
+			return true
+		}
+	}
+	return false
+}
+
+func indexOfArg(args []string, target string) int {
+	for i, arg := range args {
+		if arg == target {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestPluginComponentReconcilersTLSProfile(t *testing.T) {
+	testCases := []struct {
+		name          string
+		tlsMinVersion string
+		tlsCiphers    []string
+		expectTLS     bool
+	}{
+		{
+			name:          "TLS profile applied when SupportsTLSProfile populates fields",
+			tlsMinVersion: "VersionTLS12",
+			tlsCiphers:    []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+			expectTLS:     true,
+		},
+		{
+			name:          "no TLS args when plugin does not support TLS profile",
+			tlsMinVersion: "",
+			tlsCiphers:    nil,
+			expectTLS:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := UIPluginInfo{
+				Name:              "test-plugin",
+				ConsoleName:       "test-console-plugin",
+				Image:             "test-image:latest",
+				ResourceNamespace: "test-ns",
+				ExtraArgs:         []string{"-config-path=/opt/app-root/config"},
+				TLSMinVersion:     tc.tlsMinVersion,
+				TLSCiphers:        tc.tlsCiphers,
+			}
+
+			deploy := newDeployment(info, "test-ns", nil)
+			args := deploy.Spec.Template.Spec.Containers[0].Args
+
+			if tc.expectTLS {
+				assert.Assert(t, containsArg(args, "-tls-min-version="+tc.tlsMinVersion),
+					"expected -tls-min-version arg in %v", args)
+				assert.Assert(t, containsArgPrefix(args, "-tls-cipher-suites="),
+					"expected -tls-cipher-suites arg in %v", args)
+
+				// TLS args must come after plugin-specific extra args
+				extraIdx := indexOfArg(args, "-config-path=/opt/app-root/config")
+				tlsIdx := indexOfArg(args, "-tls-min-version="+tc.tlsMinVersion)
+				assert.Assert(t, extraIdx < tlsIdx,
+					"TLS args (idx %d) should appear after extra args (idx %d)", tlsIdx, extraIdx)
+			} else {
+				assert.Assert(t, !containsArgPrefix(args, "-tls-min-version="),
+					"unexpected -tls-min-version arg in %v", args)
+				assert.Assert(t, !containsArgPrefix(args, "-tls-cipher-suites="),
+					"unexpected -tls-cipher-suites arg in %v", args)
+			}
+
+			// Base args must always be present regardless of TLS
+			assert.Assert(t, containsArg(args, "-port=9443"))
+			assert.Assert(t, containsArg(args, "-cert=/var/serving-cert/tls.crt"))
+			assert.Assert(t, containsArg(args, "-key=/var/serving-cert/tls.key"))
+			assert.Assert(t, containsArg(args, "-config-path=/opt/app-root/config"))
+		})
+	}
+}

--- a/pkg/controllers/uiplugin/components_test.go
+++ b/pkg/controllers/uiplugin/components_test.go
@@ -57,12 +57,12 @@ func TestIsVersionAheadOrEqual(t *testing.T) {
 
 func TestNewDeploymentTLSArgs(t *testing.T) {
 	testCases := []struct {
-		name           string
-		tlsMinVersion  string
-		tlsCiphers     []string
-		extraArgs      []string
-		expectArgs     []string
-		notExpectArgs  []string
+		name          string
+		tlsMinVersion string
+		tlsCiphers    []string
+		extraArgs     []string
+		expectArgs    []string
+		notExpectArgs []string
 	}{
 		{
 			name:          "TLS profile with min version and ciphers",

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -46,6 +46,7 @@ type resourceManager struct {
 type UIPluginsConfiguration struct {
 	Images             map[string]string
 	ResourcesNamespace string
+	TLSProfile         configv1.TLSProfileSpec
 }
 
 type Options struct {

--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -3,11 +3,11 @@ package uiplugin
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/go-logr/logr"
 	osv1 "github.com/openshift/api/console/v1"
 	osv1alpha1 "github.com/openshift/api/console/v1alpha1"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/dynamic"
@@ -46,46 +46,6 @@ var pluginTypeToConsoleName = map[uiv1alpha1.UIPluginType]string{
 	uiv1alpha1.TypeDistributedTracing:   "distributed-tracing-console-plugin",
 	uiv1alpha1.TypeLogging:              "logging-view-plugin",
 	uiv1alpha1.TypeMonitoring:           "monitoring-console-plugin",
-}
-
-// translateOpenSSLToGoNameMap maps OpenSSL cipher names (used by OpenShift TLS profiles)
-// to Go TLS package cipher names (expected by UI plugins)
-func translateOpenSSLToGoNameMap() map[string]string {
-	return map[string]string{
-		// TLS 1.3 Mozilla Modern compatibility
-		"TLS_AES_128_GCM_SHA256":          "TLS_AES_128_GCM_SHA256",          
-		"TLS_AES_256_GCM_SHA384":          "TLS_AES_256_GCM_SHA384",          
-		"TLS_CHACHA20_POLY1305_SHA256":    "TLS_CHACHA20_POLY1305_SHA256",    
-
-		// TLS 1.2 Mozilla Intermediate compatibility  
-		"ECDHE-ECDSA-AES128-GCM-SHA256":   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",   
-		"ECDHE-RSA-AES128-GCM-SHA256":     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",     
-		"ECDHE-ECDSA-AES256-GCM-SHA384":   "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",  
-		"ECDHE-RSA-AES256-GCM-SHA384":     "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",     
-		"ECDHE-ECDSA-CHACHA20-POLY1305":   "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", 
-		"ECDHE-RSA-CHACHA20-POLY1305":     "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",   
-	}
-}
-
-func translateCiphers(opensslCiphers []string, logger logr.Logger) []string {
-	translationMap := translateOpenSSLToGoNameMap()
-	var goFormatCiphers []string
-
-	for _, cipher := range opensslCiphers {
-		if translatedName, ok := translationMap[cipher]; ok {
-			goFormatCiphers = append(goFormatCiphers, translatedName)
-		} else {
-			// Check for unsupported DHE-RSA ciphers
-			if strings.HasPrefix(cipher, "DHE-RSA-") {
-				logger.Info("Skipping DHE-RSA cipher: not supported by Go",
-					"cipher", cipher)
-				continue
-			}
-			goFormatCiphers = append(goFormatCiphers, cipher)
-		}
-	}
-
-	return goFormatCiphers
 }
 
 func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interface, plugin *uiv1alpha1.UIPlugin, pluginConf UIPluginsConfiguration, compatibilityInfo CompatibilityEntry, clusterVersion string, logger logr.Logger) (*UIPluginInfo, error) {
@@ -152,7 +112,7 @@ func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interfac
 
 	if compatibilityInfo.SupportsTLSProfile {
 		pluginInfo.TLSMinVersion = string(pluginConf.TLSProfile.MinTLSVersion)
-		pluginInfo.TLSCiphers = translateCiphers(pluginConf.TLSProfile.Ciphers, logger)
+		pluginInfo.TLSCiphers = libgocrypto.OpenSSLToIANACipherSuites(pluginConf.TLSProfile.Ciphers)
 	} else {
 		logger.Info("TLS profile not applied: plugin image does not support TLS profile flags",
 			"plugin", plugin.Name,

--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -3,6 +3,7 @@ package uiplugin
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	osv1 "github.com/openshift/api/console/v1"
@@ -47,6 +48,46 @@ var pluginTypeToConsoleName = map[uiv1alpha1.UIPluginType]string{
 	uiv1alpha1.TypeMonitoring:           "monitoring-console-plugin",
 }
 
+// translateOpenSSLToGoNameMap maps OpenSSL cipher names (used by OpenShift TLS profiles)
+// to Go TLS package cipher names (expected by UI plugins)
+func translateOpenSSLToGoNameMap() map[string]string {
+	return map[string]string{
+		// TLS 1.3 Mozilla Modern compatibility
+		"TLS_AES_128_GCM_SHA256":          "TLS_AES_128_GCM_SHA256",          
+		"TLS_AES_256_GCM_SHA384":          "TLS_AES_256_GCM_SHA384",          
+		"TLS_CHACHA20_POLY1305_SHA256":    "TLS_CHACHA20_POLY1305_SHA256",    
+
+		// TLS 1.2 Mozilla Intermediate compatibility  
+		"ECDHE-ECDSA-AES128-GCM-SHA256":   "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",   
+		"ECDHE-RSA-AES128-GCM-SHA256":     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",     
+		"ECDHE-ECDSA-AES256-GCM-SHA384":   "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",  
+		"ECDHE-RSA-AES256-GCM-SHA384":     "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",     
+		"ECDHE-ECDSA-CHACHA20-POLY1305":   "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", 
+		"ECDHE-RSA-CHACHA20-POLY1305":     "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",   
+	}
+}
+
+func translateCiphers(opensslCiphers []string, logger logr.Logger) []string {
+	translationMap := translateOpenSSLToGoNameMap()
+	var goFormatCiphers []string
+
+	for _, cipher := range opensslCiphers {
+		if translatedName, ok := translationMap[cipher]; ok {
+			goFormatCiphers = append(goFormatCiphers, translatedName)
+		} else {
+			// Check for unsupported DHE-RSA ciphers
+			if strings.HasPrefix(cipher, "DHE-RSA-") {
+				logger.Info("Skipping DHE-RSA cipher: not supported by Go",
+					"cipher", cipher)
+				continue
+			}
+			goFormatCiphers = append(goFormatCiphers, cipher)
+		}
+	}
+
+	return goFormatCiphers
+}
+
 func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interface, plugin *uiv1alpha1.UIPlugin, pluginConf UIPluginsConfiguration, compatibilityInfo CompatibilityEntry, clusterVersion string, logger logr.Logger) (*UIPluginInfo, error) {
 	image := pluginConf.Images[compatibilityInfo.ImageKey]
 	if image == "" {
@@ -61,6 +102,9 @@ func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interfac
 	switch plugin.Spec.Type {
 	case uiv1alpha1.TypeDashboards:
 		pluginInfo, err = createDashboardsPluginInfo(plugin, namespace, plugin.Name, image)
+		if err != nil {
+			return nil, err
+		}
 
 	case uiv1alpha1.TypeTroubleshootingPanel:
 		pluginInfo, err = createTroubleshootingPanelPluginInfo(plugin, namespace, plugin.Name, image, []string{})
@@ -86,27 +130,34 @@ func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interfac
 
 	case uiv1alpha1.TypeDistributedTracing:
 		pluginInfo, err = createDistributedTracingPluginInfo(plugin, namespace, plugin.Name, image, []string{})
+		if err != nil {
+			return nil, err
+		}
 
 	case uiv1alpha1.TypeLogging:
 		pluginInfo, err = createLoggingPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, ctx, dk, logger, pluginConf.Images["korrel8r"])
+		if err != nil {
+			return nil, err
+		}
 
 	case uiv1alpha1.TypeMonitoring:
 		pluginInfo, err = createMonitoringPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, clusterVersion, pluginConf.Images["health-analyzer"], pluginConf.Images["perses"])
+		if err != nil {
+			return nil, err
+		}
 
 	default:
 		return nil, fmt.Errorf("plugin type not supported: %s", plugin.Spec.Type)
 	}
 
-	if pluginInfo != nil {
-		if compatibilityInfo.SupportsTLSProfile {
-			pluginInfo.TLSMinVersion = string(pluginConf.TLSProfile.MinTLSVersion)
-			pluginInfo.TLSCiphers = pluginConf.TLSProfile.Ciphers
-		} else {
-			logger.Info("TLS profile not applied: plugin image does not support TLS profile flags",
-				"plugin", plugin.Name,
-				"pluginType", plugin.Spec.Type,
-				"imageKey", compatibilityInfo.ImageKey)
-		}
+	if compatibilityInfo.SupportsTLSProfile {
+		pluginInfo.TLSMinVersion = string(pluginConf.TLSProfile.MinTLSVersion)
+		pluginInfo.TLSCiphers = translateCiphers(pluginConf.TLSProfile.Ciphers, logger)
+	} else {
+		logger.Info("TLS profile not applied: plugin image does not support TLS profile flags",
+			"plugin", plugin.Name,
+			"pluginType", plugin.Spec.Type,
+			"imageKey", compatibilityInfo.ImageKey)
 	}
 
 	return pluginInfo, err

--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -35,6 +35,8 @@ type UIPluginInfo struct {
 	ResourceNamespace          string
 	PersesImage                string
 	AreMonitoringFeatsDisabled bool
+	TLSMinVersion              string
+	TLSCiphers                 []string
 }
 
 var pluginTypeToConsoleName = map[uiv1alpha1.UIPluginType]string{
@@ -52,12 +54,16 @@ func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interfac
 	}
 
 	namespace := pluginConf.ResourcesNamespace
+
+	var pluginInfo *UIPluginInfo
+	var err error
+
 	switch plugin.Spec.Type {
 	case uiv1alpha1.TypeDashboards:
-		return createDashboardsPluginInfo(plugin, namespace, plugin.Name, image)
+		pluginInfo, err = createDashboardsPluginInfo(plugin, namespace, plugin.Name, image)
 
 	case uiv1alpha1.TypeTroubleshootingPanel:
-		pluginInfo, err := createTroubleshootingPanelPluginInfo(plugin, namespace, plugin.Name, image, []string{})
+		pluginInfo, err = createTroubleshootingPanelPluginInfo(plugin, namespace, plugin.Name, image, []string{})
 		if err != nil {
 			return nil, err
 		}
@@ -78,17 +84,30 @@ func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interfac
 			return nil, err
 		}
 
-		return pluginInfo, nil
-
 	case uiv1alpha1.TypeDistributedTracing:
-		return createDistributedTracingPluginInfo(plugin, namespace, plugin.Name, image, []string{})
+		pluginInfo, err = createDistributedTracingPluginInfo(plugin, namespace, plugin.Name, image, []string{})
 
 	case uiv1alpha1.TypeLogging:
-		return createLoggingPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, ctx, dk, logger, pluginConf.Images["korrel8r"])
+		pluginInfo, err = createLoggingPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, ctx, dk, logger, pluginConf.Images["korrel8r"])
 
 	case uiv1alpha1.TypeMonitoring:
-		return createMonitoringPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, clusterVersion, pluginConf.Images["health-analyzer"], pluginConf.Images["perses"])
+		pluginInfo, err = createMonitoringPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, clusterVersion, pluginConf.Images["health-analyzer"], pluginConf.Images["perses"])
+
+	default:
+		return nil, fmt.Errorf("plugin type not supported: %s", plugin.Spec.Type)
 	}
 
-	return nil, fmt.Errorf("plugin type not supported: %s", plugin.Spec.Type)
+	if pluginInfo != nil {
+		if compatibilityInfo.SupportsTLSProfile {
+			pluginInfo.TLSMinVersion = string(pluginConf.TLSProfile.MinTLSVersion)
+			pluginInfo.TLSCiphers = pluginConf.TLSProfile.Ciphers
+		} else {
+			logger.Info("TLS profile not applied: plugin image does not support TLS profile flags",
+				"plugin", plugin.Name,
+				"pluginType", plugin.Spec.Type,
+				"imageKey", compatibilityInfo.ImageKey)
+		}
+	}
+
+	return pluginInfo, err
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -329,6 +329,8 @@ func New(ctx context.Context, cfg *OperatorConfiguration) (*Operator, error) {
 			return nil, fmt.Errorf("failed to fetch TLS profile from cluster: %w", err)
 		}
 
+		cfg.UIPlugins.TLSProfile = initialTLSProfileSpec
+
 		watcher := &openshifttls.SecurityProfileWatcher{
 			Client:                mgr.GetClient(),
 			InitialTLSProfileSpec: initialTLSProfileSpec,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -153,6 +153,12 @@ func WithCancelFunc(cancel context.CancelFunc) func(*OperatorConfiguration) {
 	}
 }
 
+func WithTLSProfile(tlsProfile configv1.TLSProfileSpec) func(*OperatorConfiguration) {
+	return func(oc *OperatorConfiguration) {
+		oc.UIPlugins.TLSProfile = tlsProfile
+	}
+}
+
 func New(ctx context.Context, cfg *OperatorConfiguration) (*Operator, error) {
 	restConfig := ctrl.GetConfigOrDie()
 	scheme := NewScheme(cfg)
@@ -318,22 +324,9 @@ func New(ctx context.Context, cfg *OperatorConfiguration) (*Operator, error) {
 	if cfg.FeatureGates.OpenShift.Enabled {
 		setupLog := ctrl.Log.WithName("setup")
 
-		// Use a direct (non-cached) client for the initial fetch because the
-		// manager's cache hasn't started yet at this point.
-		directClient, err := client.New(restConfig, client.Options{Scheme: scheme})
-		if err != nil {
-			return nil, fmt.Errorf("failed to create client for TLS profile fetch: %w", err)
-		}
-		initialTLSProfileSpec, err := openshifttls.FetchAPIServerTLSProfile(ctx, directClient)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch TLS profile from cluster: %w", err)
-		}
-
-		cfg.UIPlugins.TLSProfile = initialTLSProfileSpec
-
 		watcher := &openshifttls.SecurityProfileWatcher{
 			Client:                mgr.GetClient(),
-			InitialTLSProfileSpec: initialTLSProfileSpec,
+			InitialTLSProfileSpec: cfg.UIPlugins.TLSProfile,
 			OnProfileChange: func(_ context.Context, _, _ configv1.TLSProfileSpec) {
 				setupLog.Info("TLS security profile changed, triggering graceful restart")
 				if cfg.CancelFunc != nil {

--- a/pkg/operator/scheme.go
+++ b/pkg/operator/scheme.go
@@ -47,3 +47,10 @@ func NewScheme(cfg *OperatorConfiguration) *runtime.Scheme {
 
 	return scheme
 }
+
+func NewOpenShiftScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(configv1.Install(scheme))
+	return scheme
+}


### PR DESCRIPTION
Fixes: [COO-1553](https://redhat.atlassian.net/browse/COO-1553)

This PR binds the cluster TLS profile to the plugins, we added a flag in the compatibility matrix as not all the plugins support the command line args yet. We will be setting the value when the upstream plugin images are ready. Then we can completely remove the check when all the plugins support the TLS configuration.