### PR TITLE
fix: Add 'create tokenreview' to korrel8r RBAC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ CATALOG_TEMP := $(shell mktemp -d)
 
 ## Development
 
+.PHONY: all
+all: lint test-unit operator-image bundle-image
+
 .PHONY: test-unit
 test-unit:
 	go test -cover ./cmd/... ./pkg/...

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -109,8 +109,10 @@ const (
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,resourceNames=k8s,verbs=get;create;update
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers/api,resourceNames=main,verbs=get;list
 
-// RBAC for Health Analyzer
+// RBAC for Korrel8r and Health Analyzer
 //+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+
+// RBAC for Health Analyzer
 //+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create;update;patch;delete
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;list

--- a/pkg/controllers/uiplugin/troubleshooting_panel.go
+++ b/pkg/controllers/uiplugin/troubleshooting_panel.go
@@ -239,6 +239,11 @@ func korrel8rClusterRole(name string) *rbacv1.ClusterRole {
 				Resources: []string{"application", "audit", "infrastructure", "network"},
 				Verbs:     []string{"get"},
 			},
+			{
+				APIGroups: []string{"authentication.k8s.io"},
+				Resources: []string{"tokenreviews"},
+				Verbs:     []string{"create"},
+			},
 		},
 	}
 }

--- a/pkg/controllers/uiplugin/troubleshooting_panel_test.go
+++ b/pkg/controllers/uiplugin/troubleshooting_panel_test.go
@@ -1,0 +1,71 @@
+package uiplugin
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func findPolicyRule(rules []rbacv1.PolicyRule, apiGroup, resource string) *rbacv1.PolicyRule {
+	for i := range rules {
+		for _, g := range rules[i].APIGroups {
+			if g != apiGroup {
+				continue
+			}
+			for _, r := range rules[i].Resources {
+				if r == resource {
+					return &rules[i]
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func TestKorrel8rClusterRole(t *testing.T) {
+	cr := korrel8rClusterRole("korrel8r")
+
+	assert.Equal(t, cr.Name, "korrel8r-view")
+	assert.Equal(t, cr.Kind, "ClusterRole")
+
+	tests := []struct {
+		name     string
+		apiGroup string
+		resource string
+		verbs    []string
+	}{
+		{
+			name:     "core resources",
+			apiGroup: "",
+			resource: "pods",
+			verbs:    []string{"get", "list", "watch"},
+		},
+		{
+			name:     "apps resources",
+			apiGroup: "apps",
+			resource: "deployments",
+			verbs:    []string{"get", "list", "watch"},
+		},
+		{
+			name:     "loki resources",
+			apiGroup: "loki.grafana.com",
+			resource: "application",
+			verbs:    []string{"get"},
+		},
+		{
+			name:     "tokenreviews for session authentication",
+			apiGroup: "authentication.k8s.io",
+			resource: "tokenreviews",
+			verbs:    []string{"create"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rule := findPolicyRule(cr.Rules, tc.apiGroup, tc.resource)
+			assert.Assert(t, rule != nil, "expected rule for %s/%s", tc.apiGroup, tc.resource)
+			assert.DeepEqual(t, rule.Verbs, tc.verbs)
+		})
+	}
+}


### PR DESCRIPTION
Allow Korrel8r to create tokenreviews to associate user names with sessions.
In order to handle multiple users concurrently, korrel8r now has independent sessions per user.
To identify users (username, userID) from bearer tokens, it needs to use the tokenreview process.

The same user logged in multiple times can have different tokens, so comparing tokens is not sufficient.