### PR TITLE
COO-1493: fix: create RoleBinding when NoClusterRoleBindings policy is set (COO…

### DIFF
--- a/pkg/controllers/monitoring/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components.go
@@ -63,12 +63,12 @@ func stackComponentReconcilers(
 		reconciler.NewUpdater(newPrometheusClusterRole(prometheusName, rbacVerbs), ms),
 		// create clusterrolebinding if nsSelector's present otherwise a rolebinding
 		reconciler.NewOptionalUpdater(newClusterRoleBinding(ms, prometheusName), ms, createCRB),
-		reconciler.NewOptionalUpdater(newRoleBindingForClusterRole(ms, prometheusName), ms, !hasNsSelector),
+		reconciler.NewOptionalUpdater(newRoleBindingForClusterRole(ms, prometheusName), ms, !createCRB),
 
 		reconciler.NewOptionalUpdater(newAlertManagerClusterRole(alertmanagerName, rbacVerbs), ms, deployAlertmanager),
 		// create clusterrolebinding if alertmanager is enabled and namespace selector is also present in MonitoringStack
 		reconciler.NewOptionalUpdater(newClusterRoleBinding(ms, alertmanagerName), ms, deployAlertmanager && createCRB),
-		reconciler.NewOptionalUpdater(newRoleBindingForClusterRole(ms, alertmanagerName), ms, deployAlertmanager && !hasNsSelector),
+		reconciler.NewOptionalUpdater(newRoleBindingForClusterRole(ms, alertmanagerName), ms, deployAlertmanager && !createCRB),
 
 		// Prometheus Deployment
 		reconciler.NewUpdater(newPrometheus(ms, prometheusName,


### PR DESCRIPTION
…-1493)

When a MonitoringStack has createClusterRoleBindings: NoClusterRoleBindings with a namespaceSelector, neither a ClusterRoleBinding nor a RoleBinding was created, leaving ServiceAccounts with no permissions and preventing StatefulSet creation.