### PR TITLE
COO-1063: fix: set default resource requests and limits on Alertmanager and Thanos sidecar

### DIFF
--- a/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
+++ b/bundle/manifests/monitoring.rhobs_monitoringstacks.yaml
@@ -79,6 +79,73 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  resources:
+                    default:
+                      limits:
+                        cpu: 250m
+                        memory: 256Mi
+                      requests:
+                        cpu: 50m
+                        memory: 128Mi
+                    description: Define resources requests and limits for the Alertmanager
+                      container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
                   webTLSConfig:
                     description: Configure TLS options for the Alertmanager web server.
                     properties:
@@ -1555,6 +1622,73 @@ spec:
                     description: Default interval between scrapes.
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
+                  thanosResources:
+                    default:
+                      limits:
+                        cpu: 250m
+                        memory: 256Mi
+                      requests:
+                        cpu: 50m
+                        memory: 128Mi
+                    description: Define resources requests and limits for the Thanos
+                      sidecar container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
                   webTLSConfig:
                     description: Configure TLS options for the Prometheus web server.
                     properties:
@@ -1676,8 +1810,8 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 256Mi
-                description: Define resources requests and limits for Monitoring Stack
-                  Pods.
+                description: Define resources requests and limits for the Prometheus
+                  container.
                 properties:
                   claims:
                     description: |-

--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ metadata:
     certified: "false"
     console.openshift.io/operator-monitoring-default: "true"
     containerImage: observability-operator:1.3.0
-    createdAt: "2026-05-25T12:42:53Z"
+    createdAt: "2026-05-27T09:13:56Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operatorframework.io/cluster-monitoring: "true"

--- a/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
+++ b/deploy/crds/common/monitoring.rhobs_monitoringstacks.yaml
@@ -79,6 +79,73 @@ spec:
                     format: int32
                     minimum: 0
                     type: integer
+                  resources:
+                    default:
+                      limits:
+                        cpu: 250m
+                        memory: 256Mi
+                      requests:
+                        cpu: 50m
+                        memory: 128Mi
+                    description: Define resources requests and limits for the Alertmanager
+                      container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
                   webTLSConfig:
                     description: Configure TLS options for the Alertmanager web server.
                     properties:
@@ -1555,6 +1622,73 @@ spec:
                     description: Default interval between scrapes.
                     pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                     type: string
+                  thanosResources:
+                    default:
+                      limits:
+                        cpu: 250m
+                        memory: 256Mi
+                      requests:
+                        cpu: 50m
+                        memory: 128Mi
+                    description: Define resources requests and limits for the Thanos
+                      sidecar container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
                   webTLSConfig:
                     description: Configure TLS options for the Prometheus web server.
                     properties:
@@ -1676,8 +1810,8 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 256Mi
-                description: Define resources requests and limits for Monitoring Stack
-                  Pods.
+                description: Define resources requests and limits for the Prometheus
+                  container.
                 properties:
                   claims:
                     description: |-

--- a/docs/api.md
+++ b/docs/api.md
@@ -164,7 +164,7 @@ To disable service discovery, set to null. E.g. resourceSelector:.<br/>
         <td><b><a href="#monitoringstackspecresources">resources</a></b></td>
         <td>object</td>
         <td>
-          Define resources requests and limits for Monitoring Stack Pods.<br/>
+          Define resources requests and limits for the Prometheus container.<br/>
           <br/>
             <i>Default</i>: map[limits:map[cpu:500m memory:512Mi] requests:map[cpu:100m memory:256Mi]]<br/>
         </td>
@@ -251,6 +251,15 @@ Define Alertmanager config
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b><a href="#monitoringstackspecalertmanagerconfigresources">resources</a></b></td>
+        <td>object</td>
+        <td>
+          Define resources requests and limits for the Alertmanager container.<br/>
+          <br/>
+            <i>Default</i>: map[limits:map[cpu:250m memory:256Mi] requests:map[cpu:50m memory:128Mi]]<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#monitoringstackspecalertmanagerconfigwebtlsconfig">webTLSConfig</a></b></td>
         <td>object</td>
         <td>
@@ -292,6 +301,95 @@ With None, routes match all incoming alerts regardless of namespace.<br/>
           <br/>
             <i>Enum</i>: OnNamespace, OnNamespaceExceptForAlertmanagerNamespace, None<br/>
             <i>Default</i>: None<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### MonitoringStack.spec.alertmanagerConfig.resources
+<sup><sup>[↩ Parent](#monitoringstackspecalertmanagerconfig)</sup></sup>
+
+
+
+Define resources requests and limits for the Alertmanager container.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#monitoringstackspecalertmanagerconfigresourcesclaimsindex">claims</a></b></td>
+        <td>[]object</td>
+        <td>
+          Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>limits</b></td>
+        <td>map[string]int or string</td>
+        <td>
+          Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>requests</b></td>
+        <td>map[string]int or string</td>
+        <td>
+          Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### MonitoringStack.spec.alertmanagerConfig.resources.claims[index]
+<sup><sup>[↩ Parent](#monitoringstackspecalertmanagerconfigresources)</sup></sup>
+
+
+
+ResourceClaim references one entry in PodSpec.ResourceClaims.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>
+          Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>request</b></td>
+        <td>string</td>
+        <td>
+          Request is the name chosen for a request in the referenced claim.
+If empty, everything from the claim is made available, otherwise
+only the result of this request.<br/>
         </td>
         <td>false</td>
       </tr></tbody>
@@ -594,6 +692,15 @@ The resulting endpoint is /api/v1/otlp/v1/metrics.<br/>
         <td>string</td>
         <td>
           Default interval between scrapes.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b><a href="#monitoringstackspecprometheusconfigthanosresources">thanosResources</a></b></td>
+        <td>object</td>
+        <td>
+          Define resources requests and limits for the Thanos sidecar container.<br/>
+          <br/>
+            <i>Default</i>: map[limits:map[cpu:250m memory:256Mi] requests:map[cpu:50m memory:128Mi]]<br/>
         </td>
         <td>false</td>
       </tr><tr>
@@ -3246,6 +3353,95 @@ Regex capture groups are available.<br/>
 </table>
 
 
+### MonitoringStack.spec.prometheusConfig.thanosResources
+<sup><sup>[↩ Parent](#monitoringstackspecprometheusconfig)</sup></sup>
+
+
+
+Define resources requests and limits for the Thanos sidecar container.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b><a href="#monitoringstackspecprometheusconfigthanosresourcesclaimsindex">claims</a></b></td>
+        <td>[]object</td>
+        <td>
+          Claims lists the names of resources, defined in spec.resourceClaims,
+that are used by this container.
+
+This is an alpha field and requires enabling the
+DynamicResourceAllocation feature gate.
+
+This field is immutable. It can only be set for containers.<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>limits</b></td>
+        <td>map[string]int or string</td>
+        <td>
+          Limits describes the maximum amount of compute resources allowed.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
+        <td><b>requests</b></td>
+        <td>map[string]int or string</td>
+        <td>
+          Requests describes the minimum amount of compute resources required.
+If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+otherwise to an implementation-defined value. Requests cannot exceed Limits.
+More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
+### MonitoringStack.spec.prometheusConfig.thanosResources.claims[index]
+<sup><sup>[↩ Parent](#monitoringstackspecprometheusconfigthanosresources)</sup></sup>
+
+
+
+ResourceClaim references one entry in PodSpec.ResourceClaims.
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Required</th>
+        </tr>
+    </thead>
+    <tbody><tr>
+        <td><b>name</b></td>
+        <td>string</td>
+        <td>
+          Name must match the name of one entry in pod.spec.resourceClaims of
+the Pod where this field is used. It makes that resource available
+inside a container.<br/>
+        </td>
+        <td>true</td>
+      </tr><tr>
+        <td><b>request</b></td>
+        <td>string</td>
+        <td>
+          Request is the name chosen for a request in the referenced claim.
+If empty, everything from the claim is made available, otherwise
+only the result of this request.<br/>
+        </td>
+        <td>false</td>
+      </tr></tbody>
+</table>
+
+
 ### MonitoringStack.spec.prometheusConfig.webTLSConfig
 <sup><sup>[↩ Parent](#monitoringstackspecprometheusconfig)</sup></sup>
 
@@ -3478,7 +3674,7 @@ merge patch.<br/>
 
 
 
-Define resources requests and limits for Monitoring Stack Pods.
+Define resources requests and limits for the Prometheus container.
 
 <table>
     <thead>

--- a/pkg/apis/monitoring/v1alpha1/types.go
+++ b/pkg/apis/monitoring/v1alpha1/types.go
@@ -155,7 +155,7 @@ type MonitoringStackSpec struct {
 	// +optional
 	RetentionSize monv1.ByteSize `json:"retentionSize,omitempty"`
 
-	// Define resources requests and limits for Monitoring Stack Pods.
+	// Define resources requests and limits for the Prometheus container.
 	// +optional
 	// +kubebuilder:default={requests:{cpu: "100m", memory: "256Mi"}, limits:{memory: "512Mi", cpu: "500m"}}
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
@@ -280,6 +280,11 @@ type PrometheusConfig struct {
 	// Default interval between scrapes.
 	// +optional
 	ScrapeInterval *monv1.Duration `json:"scrapeInterval,omitempty"`
+	// Define resources requests and limits for the Thanos sidecar container.
+	// +optional
+	// +kubebuilder:default={requests:{cpu: "50m", memory: "128Mi"}, limits:{memory: "256Mi", cpu: "250m"}}
+	ThanosResources corev1.ResourceRequirements `json:"thanosResources,omitempty"`
+
 	// Configure TLS options for the Prometheus web server.
 	// +optional
 	WebTLSConfig *WebTLSConfig `json:"webTLSConfig,omitempty"`
@@ -296,6 +301,11 @@ type AlertmanagerConfig struct {
 	// +kubebuilder:default=2
 	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas,omitempty"`
+
+	// Define resources requests and limits for the Alertmanager container.
+	// +optional
+	// +kubebuilder:default={requests:{cpu: "50m", memory: "128Mi"}, limits:{memory: "256Mi", cpu: "250m"}}
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
 
 	// Define how AlertmanagerConfig objects process incoming alerts.
 	// +optional

--- a/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/monitoring/v1alpha1/zz_generated.deepcopy.go
@@ -35,6 +35,7 @@ func (in *AlertmanagerConfig) DeepCopyInto(out *AlertmanagerConfig) {
 		*out = new(int32)
 		**out = **in
 	}
+	in.Resources.DeepCopyInto(&out.Resources)
 	out.MatcherStrategy = in.MatcherStrategy
 	if in.WebTLSConfig != nil {
 		in, out := &in.WebTLSConfig, &out.WebTLSConfig
@@ -268,6 +269,7 @@ func (in *PrometheusConfig) DeepCopyInto(out *PrometheusConfig) {
 		*out = new(monitoringv1.Duration)
 		**out = **in
 	}
+	in.ThanosResources.DeepCopyInto(&out.ThanosResources)
 	if in.WebTLSConfig != nil {
 		in, out := &in.WebTLSConfig, &out.WebTLSConfig
 		*out = new(WebTLSConfig)

--- a/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
+++ b/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
@@ -36,6 +36,7 @@ func newAlertmanager(
 				Labels: podLabels("alertmanager", ms.Name),
 			},
 			Replicas:                   ms.Spec.AlertmanagerConfig.Replicas,
+			Resources:                  ms.Spec.AlertmanagerConfig.Resources,
 			ServiceAccountName:         rbacResourceName,
 			AlertmanagerConfigSelector: resourceSelector,
 			AlertmanagerConfigMatcherStrategy: monv1.AlertmanagerConfigMatcherStrategy{

--- a/pkg/controllers/monitoring/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components.go
@@ -214,7 +214,8 @@ func newPrometheus(
 			RuleSelector:          prometheusSelector,
 			RuleNamespaceSelector: ms.Spec.NamespaceSelector,
 			Thanos: &monv1.ThanosSpec{
-				Image: ptr.To(thanosCfg.Image),
+				Image:     ptr.To(thanosCfg.Image),
+				Resources: ms.Spec.PrometheusConfig.ThanosResources,
 			},
 		},
 	}

--- a/pkg/controllers/monitoring/monitoring-stack/components_test.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components_test.go
@@ -46,6 +46,76 @@ func TestStorageSpec(t *testing.T) {
 	}
 }
 
+func TestNewAlertmanagerSetsResources(t *testing.T) {
+	amResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+	ms := &stack.MonitoringStack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns",
+		},
+		Spec: stack.MonitoringStackSpec{
+			AlertmanagerConfig: stack.AlertmanagerConfig{
+				Resources: amResources,
+			},
+		},
+	}
+
+	am := newAlertmanager(ms, "test-alertmanager", AlertmanagerConfiguration{})
+	assert.DeepEqual(t, amResources, am.Spec.Resources)
+}
+
+func TestNewPrometheusSetsThanosSidecarResources(t *testing.T) {
+	promResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+	thanosResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+	}
+	ms := &stack.MonitoringStack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns",
+		},
+		Spec: stack.MonitoringStackSpec{
+			Resources: promResources,
+			PrometheusConfig: &stack.PrometheusConfig{
+				ThanosResources: thanosResources,
+			},
+			AlertmanagerConfig: stack.AlertmanagerConfig{Disabled: true},
+		},
+	}
+
+	prom := newPrometheus(ms, "test-prometheus", "test-scrape",
+		ThanosConfiguration{Image: "thanos:latest"},
+		PrometheusConfiguration{})
+
+	assert.DeepEqual(t, thanosResources, prom.Spec.Thanos.Resources)
+	assert.DeepEqual(t, promResources, prom.Spec.Resources)
+}
+
 func TestNewAdditionalScrapeConfigsSecret(t *testing.T) {
 	for _, tc := range []struct {
 		name       string


### PR DESCRIPTION
When a ResourceQuota is set on the namespace, Alertmanager and Prometheus pods fail to start because the Alertmanager container and Thanos sidecar container don't have resource requests/limits. Propagate the MonitoringStack's resource requirements to both components, matching what is already done for the Prometheus container.