### PR TITLE
fix: Use rhobs/openshift-api for console/v1 for 4.17-4.18

### DIFF
--- a/DEPENDENCY_CONSTRAINTS.md
+++ b/DEPENDENCY_CONSTRAINTS.md
@@ -30,8 +30,11 @@ Dependabot takes care of dependency updates, the configuration is located at `.g
 
 ## Future Considerations
 
-When OpenShift &lt; 4.18 support is no longer needed, we can:
+When OpenShift &lt; 4.17 support is no longer needed, we can:
 1. Remove `console/v1alpha1` API usage.
-2. Remove dual API support code.
-3. Remove dependency on `github.com/rhobs/openshift-api` 
 4. Update this document
+
+When OpenShift &lt; 4.19 support is no longer needed, we can:
+1. Remove dual API support code.
+2. Remove dependency on `github.com/rhobs/openshift-api` 
+3. Update this document

--- a/DEPENDENCY_CONSTRAINTS.md
+++ b/DEPENDENCY_CONSTRAINTS.md
@@ -9,17 +9,18 @@ This project depends on 2 versions of `github.com/openshift/api`:
 * A [forked version](https://github.com/rhobs/openshift-api).
 
 **Why Forked:** The observability-operator needs to support both OpenShift console API `v1` and `v1alpha1` for backward compatibility:
-- OpenShift >= 4.17 uses `console/v1` API
-- OpenShift < 4.17 uses `console/v1alpha1` API
+- OpenShift >= 4.19 uses `console/v1` API (openshift/api)
+- OpenShift 4.17 - 4.18 uses `console/v1` API (rhobs/openshift-api)
+- OpenShift < 4.17 uses `console/v1alpha1` API (rhobs/openshift-api)
 
-Newer versions of `github.com/openshift/api` (after April 2024) have removed the `console/v1alpha1` API, breaking compatibility with older OpenShift versions. To continue supporting older versions, we forked the library under (https://github.com/rhobs/openshift-api) using the last commit including the `v1alpha1` API and renaming the Go module in `go.mod` to `github.com/rhobs/openshift-api`.
+Newer versions of `github.com/openshift/api` (after April 2024) have removed the `console/v1alpha1` API, breaking compatibility with older OpenShift versions. To continue supporting older versions, we forked the library under (https://github.com/rhobs/openshift-api) using the last commit including the `v1alpha1` API and renaming the Go module in `go.mod` to `github.com/rhobs/openshift-api`. The openshift/api `console/v1` adds the `ConsolePlugin.spec.ContentSecurityPolicy` field when marshalling, which is not supported in 4.17 and 4.18, so we utilize rhobs/openshift-api `console/v1` for those versions. 
 
 **Impact:** The codebase maintains dual API support with runtime version detection to create the appropriate Console Plugin resources.
 
 **Files Affected:**
 - `pkg/controllers/uiplugin/controller.go` - Version detection logic
-- `pkg/controllers/uiplugin/components.go` - Dual Console Plugin creation
-- `pkg/controllers/uiplugin/plugin_info_builder.go` - Plugin info structure with LegacyProxies
+- `pkg/controllers/uiplugin/components.go` - Console Plugin version determination and creation
+- `pkg/controllers/uiplugin/proxy.go` - Plugin info structure for proxies which are different between v1 and v1alpha1 version
 - `pkg/operator/scheme.go` - API scheme registration
 - All uiplugin package files using `osv1alpha1` imports
 
@@ -29,8 +30,8 @@ Dependabot takes care of dependency updates, the configuration is located at `.g
 
 ## Future Considerations
 
-When OpenShift &lt; 4.17 support is no longer needed, we can:
+When OpenShift &lt; 4.18 support is no longer needed, we can:
 1. Remove `console/v1alpha1` API usage.
 2. Remove dual API support code.
 3. Remove dependency on `github.com/rhobs/openshift-api` 
-4. Update this document 
+4. Update this document

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -141,6 +141,7 @@ func main() {
 	defer cancel()
 
 	var initialTLSProfileSpec configv1.TLSProfileSpec
+	var openshiftVersion string
 	if openShiftEnabled {
 		scheme := operator.NewOpenShiftScheme()
 		directClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
@@ -155,6 +156,14 @@ func main() {
 			os.Exit(1)
 		}
 		setupLog.Info("fetched initial TLS profile", "minVersion", initialTLSProfileSpec.MinTLSVersion, "ciphers", initialTLSProfileSpec.Ciphers)
+
+		clusterVersion := &configv1.ClusterVersion{}
+		key := client.ObjectKey{Name: "version"}
+		if err := directClient.Get(ctx, key, clusterVersion); err != nil {
+			setupLog.Error(err, "failed to fetch cluster version")
+			os.Exit(1)
+		}
+		openshiftVersion = clusterVersion.Status.Desired.Version
 	}
 
 	op, err := operator.New(
@@ -176,6 +185,7 @@ func main() {
 			operator.WithFeatureGates(operator.FeatureGates{
 				OpenShift: operator.OpenShiftFeatureGates{
 					Enabled: openShiftEnabled,
+					Version: openshiftVersion,
 				},
 			}),
 			operator.WithCancelFunc(cancel),

--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	osv1 "github.com/openshift/api/console/v1"
+	osRhobsv1 "github.com/rhobs/openshift-api/console/v1"
 	osv1alpha1 "github.com/rhobs/openshift-api/console/v1alpha1"
 	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"
@@ -51,7 +52,7 @@ var (
 	korrel8rConfigYAMLTmplFile embed.FS
 )
 
-func isVersionAheadOrEqual(currentVersion, version string) bool {
+func IsVersionAheadOrEqual(currentVersion, version string) bool {
 	if !strings.HasPrefix(currentVersion, "v") {
 		currentVersion = "v" + currentVersion
 	}
@@ -73,8 +74,10 @@ func pluginComponentReconcilers(plugin *uiv1alpha1.UIPlugin, pluginInfo UIPlugin
 		reconciler.NewUpdater(newService(pluginInfo, namespace), plugin),
 	}
 
-	if isVersionAheadOrEqual(clusterVersion, "v4.17") {
+	if IsVersionAheadOrEqual(clusterVersion, "v4.19") {
 		components = append(components, reconciler.NewUpdater(newConsolePlugin(pluginInfo, namespace), plugin))
+	} else if IsVersionAheadOrEqual(clusterVersion, "v4.17") {
+		components = append(components, reconciler.NewUpdater(newRhobsConsolePlugin(pluginInfo, namespace), plugin))
 	} else {
 		components = append(components, reconciler.NewUpdater(newLegacyConsolePlugin(pluginInfo, namespace), plugin))
 	}
@@ -224,6 +227,11 @@ func newRoleBinding(info UIPluginInfo) *rbacv1.RoleBinding {
 }
 
 func newLegacyConsolePlugin(info UIPluginInfo, namespace string) *osv1alpha1.ConsolePlugin {
+	proxies := make([]osv1alpha1.ConsolePluginProxy, len(info.Proxies))
+	for i, p := range info.Proxies {
+		proxies[i] = p.ToV1Alpha1()
+	}
+
 	return &osv1alpha1.ConsolePlugin{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: osv1alpha1.SchemeGroupVersion.String(),
@@ -240,12 +248,48 @@ func newLegacyConsolePlugin(info UIPluginInfo, namespace string) *osv1alpha1.Con
 				Port:      port,
 				BasePath:  "/",
 			},
-			Proxy: info.LegacyProxies,
+			Proxy: proxies,
+		},
+	}
+}
+
+func newRhobsConsolePlugin(info UIPluginInfo, namespace string) *osRhobsv1.ConsolePlugin {
+	proxies := make([]osRhobsv1.ConsolePluginProxy, len(info.Proxies))
+	for i, p := range info.Proxies {
+		proxies[i] = p.ToRhobsV1()
+	}
+
+	return &osRhobsv1.ConsolePlugin{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: osRhobsv1.SchemeGroupVersion.String(),
+			Kind:       "ConsolePlugin",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: info.ConsoleName,
+		},
+		Spec: osRhobsv1.ConsolePluginSpec{
+			DisplayName: info.DisplayName,
+			Backend: osRhobsv1.ConsolePluginBackend{
+				Type: osRhobsv1.Service,
+				Service: &osRhobsv1.ConsolePluginService{
+					Name:      info.Name,
+					Namespace: namespace,
+					Port:      port,
+					BasePath:  "/",
+				},
+			},
+			Proxy: proxies,
+			I18n:  osRhobsv1.ConsolePluginI18n{LoadType: osRhobsv1.Preload},
 		},
 	}
 }
 
 func newConsolePlugin(info UIPluginInfo, namespace string) *osv1.ConsolePlugin {
+	proxies := make([]osv1.ConsolePluginProxy, len(info.Proxies))
+	for i, p := range info.Proxies {
+		proxies[i] = p.ToUpstreamV1()
+	}
+
 	return &osv1.ConsolePlugin{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: osv1.SchemeGroupVersion.String(),
@@ -265,7 +309,7 @@ func newConsolePlugin(info UIPluginInfo, namespace string) *osv1.ConsolePlugin {
 					BasePath:  "/",
 				},
 			},
-			Proxy:                 info.Proxies,
+			Proxy:                 proxies,
 			I18n:                  osv1.ConsolePluginI18n{LoadType: osv1.Preload},
 			ContentSecurityPolicy: []osv1.ConsolePluginCSP{},
 		},

--- a/pkg/controllers/uiplugin/components_test.go
+++ b/pkg/controllers/uiplugin/components_test.go
@@ -50,7 +50,7 @@ func TestIsVersionAheadOrEqual(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		actual := isVersionAheadOrEqual(tc.clusterVersion, tc.nextClusterVersion)
+		actual := IsVersionAheadOrEqual(tc.clusterVersion, tc.nextClusterVersion)
 		assert.Equal(t, tc.expected, actual)
 	}
 }

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -51,7 +51,8 @@ type UIPluginsConfiguration struct {
 }
 
 type Options struct {
-	PluginsConf UIPluginsConfiguration
+	PluginsConf    UIPluginsConfiguration
+	ClusterVersion string
 }
 
 const (
@@ -126,13 +127,6 @@ const finalizerName = "uiplugin.observability.openshift.io/finalizer"
 func RegisterWithManager(mgr ctrl.Manager, opts Options) error {
 	logger := ctrl.Log.WithName("observability-ui")
 
-	clusterVersion, err := getClusterVersion(mgr.GetAPIReader())
-
-	if err != nil {
-		logger.Error(err, "failed to get cluster version")
-		return err
-	}
-
 	dynamicClient, err := dynamic.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		logger.Error(err, "failed to create dynamic client")
@@ -145,7 +139,7 @@ func RegisterWithManager(mgr ctrl.Manager, opts Options) error {
 		scheme:           mgr.GetScheme(),
 		logger:           logger,
 		pluginConf:       opts.PluginsConf,
-		clusterVersion:   clusterVersion.Status.Desired.Version,
+		clusterVersion:   opts.ClusterVersion,
 		apiReader:        mgr.GetAPIReader(),
 	}
 
@@ -179,15 +173,6 @@ func RegisterWithManager(mgr ctrl.Manager, opts Options) error {
 	rm.controller = ctrl
 
 	return nil
-}
-
-func getClusterVersion(k8client client.Reader) (*configv1.ClusterVersion, error) {
-	clusterVersion := &configv1.ClusterVersion{}
-	key := client.ObjectKey{Name: "version"}
-	if err := k8client.Get(context.TODO(), key, clusterVersion); err != nil {
-		return nil, err
-	}
-	return clusterVersion, nil
 }
 
 func (rm resourceManager) consolePluginCapabilityEnabled(ctx context.Context, name types.NamespacedName, clusterVersion string) bool {

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -9,6 +9,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	osv1 "github.com/openshift/api/console/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	osRhobsv1 "github.com/rhobs/openshift-api/console/v1"
 	osv1alpha1 "github.com/rhobs/openshift-api/console/v1alpha1"
 	persesv1alpha2 "github.com/rhobs/perses-operator/api/v1alpha2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -162,8 +163,10 @@ func RegisterWithManager(mgr ctrl.Manager, opts Options) error {
 		Owns(&persesv1alpha2.PersesDatasource{}, generationChanged).
 		Owns(&persesv1alpha2.PersesGlobalDatasource{}, generationChanged)
 
-	if isVersionAheadOrEqual(rm.clusterVersion, "v4.17") {
+	if IsVersionAheadOrEqual(rm.clusterVersion, "v4.19") {
 		ctrlBuilder.Owns(&osv1.ConsolePlugin{}, generationChanged)
+	} else if IsVersionAheadOrEqual(rm.clusterVersion, "v4.17") {
+		ctrlBuilder.Owns(&osRhobsv1.ConsolePlugin{}, generationChanged)
 	} else {
 		ctrlBuilder.Owns(&osv1alpha1.ConsolePlugin{}, generationChanged)
 	}
@@ -190,7 +193,7 @@ func getClusterVersion(k8client client.Reader) (*configv1.ClusterVersion, error)
 func (rm resourceManager) consolePluginCapabilityEnabled(ctx context.Context, name types.NamespacedName, clusterVersion string) bool {
 	var err error
 
-	if isVersionAheadOrEqual(clusterVersion, "v4.17") {
+	if IsVersionAheadOrEqual(clusterVersion, "v4.17") {
 		consolePlugin := &osv1.ConsolePlugin{}
 		err = rm.k8sClient.Get(ctx, name, consolePlugin)
 	} else {

--- a/pkg/controllers/uiplugin/dashboards.go
+++ b/pkg/controllers/uiplugin/dashboards.go
@@ -1,8 +1,6 @@
 package uiplugin
 
 import (
-	osv1 "github.com/openshift/api/console/v1"
-	osv1alpha1 "github.com/rhobs/openshift-api/console/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,30 +19,13 @@ func createDashboardsPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, im
 		ConsoleName:       pluginTypeToConsoleName[plugin.Spec.Type],
 		DisplayName:       "Console Enhanced Dashboards",
 		ResourceNamespace: namespace,
-		LegacyProxies: []osv1alpha1.ConsolePluginProxy{
+		Proxies: []PluginProxy{
 			{
-				Type:      osv1alpha1.ProxyTypeService,
-				Alias:     "backend",
-				Authorize: true,
-				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
-					Name:      pluginName,
-					Namespace: namespace,
-					Port:      port,
-				},
-			},
-		},
-		Proxies: []osv1.ConsolePluginProxy{
-			{
-				Alias:         "backend",
-				Authorization: "UserToken",
-				Endpoint: osv1.ConsolePluginProxyEndpoint{
-					Type: osv1.ProxyTypeService,
-					Service: &osv1.ConsolePluginProxyServiceConfig{
-						Name:      pluginName,
-						Namespace: namespace,
-						Port:      port,
-					},
-				},
+				Alias:            "backend",
+				ServiceName:      pluginName,
+				ServiceNamespace: namespace,
+				ServicePort:      port,
+				Authorize:        true,
 			},
 		},
 		Role: &rbacv1.Role{

--- a/pkg/controllers/uiplugin/distributed_tracing.go
+++ b/pkg/controllers/uiplugin/distributed_tracing.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	osv1 "github.com/openshift/api/console/v1"
-	osv1alpha1 "github.com/rhobs/openshift-api/console/v1alpha1"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -38,30 +36,13 @@ func createDistributedTracingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, 
 		DisplayName:       "Distributed Tracing Console Plugin",
 		ResourceNamespace: namespace,
 		ExtraArgs:         extraArgs,
-		LegacyProxies: []osv1alpha1.ConsolePluginProxy{
+		Proxies: []PluginProxy{
 			{
-				Type:      osv1alpha1.ProxyTypeService,
-				Alias:     "backend",
-				Authorize: true,
-				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
-					Name:      name,
-					Namespace: namespace,
-					Port:      port,
-				},
-			},
-		},
-		Proxies: []osv1.ConsolePluginProxy{
-			{
-				Alias:         "backend",
-				Authorization: "UserToken",
-				Endpoint: osv1.ConsolePluginProxyEndpoint{
-					Type: osv1.ProxyTypeService,
-					Service: &osv1.ConsolePluginProxyServiceConfig{
-						Name:      name,
-						Namespace: namespace,
-						Port:      port,
-					},
-				},
+				Alias:            "backend",
+				ServiceName:      name,
+				ServiceNamespace: namespace,
+				ServicePort:      port,
+				Authorize:        true,
 			},
 		},
 		ConfigMap: &corev1.ConfigMap{

--- a/pkg/controllers/uiplugin/logging.go
+++ b/pkg/controllers/uiplugin/logging.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	osv1 "github.com/openshift/api/console/v1"
-	osv1alpha1 "github.com/rhobs/openshift-api/console/v1alpha1"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -53,59 +51,23 @@ func createLoggingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, image
 		extraArgs = append(extraArgs, fmt.Sprintf("-features=%s", strings.Join(features, ",")))
 	}
 
-	legacyProxies := []osv1alpha1.ConsolePluginProxy{
+	proxies := []PluginProxy{
 		{
-			Type:      "Service",
-			Alias:     "backend",
-			Authorize: true,
-			Service: osv1alpha1.ConsolePluginProxyServiceConfig{
-				Name:      fmt.Sprintf("%s-gateway-http", lokiStackName),
-				Namespace: lokiStackNamespace,
-				Port:      8080,
-			},
+			Alias:            "backend",
+			ServiceName:      fmt.Sprintf("%s-gateway-http", lokiStackName),
+			ServiceNamespace: lokiStackNamespace,
+			ServicePort:      8080,
+			Authorize:        true,
 		},
 	}
 
 	if korrel8rImage != "" {
-		legacyProxies = append(legacyProxies, osv1alpha1.ConsolePluginProxy{
-			Type:      "Service",
-			Alias:     "korrel8r",
-			Authorize: true,
-			Service: osv1alpha1.ConsolePluginProxyServiceConfig{
-				Name:      korrel8rName,
-				Namespace: namespace,
-				Port:      port,
-			},
-		})
-	}
-
-	proxies := []osv1.ConsolePluginProxy{
-		{
-			Alias:         "backend",
-			Authorization: "UserToken",
-			Endpoint: osv1.ConsolePluginProxyEndpoint{
-				Type: osv1.ProxyTypeService,
-				Service: &osv1.ConsolePluginProxyServiceConfig{
-					Name:      fmt.Sprintf("%s-gateway-http", lokiStackName),
-					Namespace: lokiStackNamespace,
-					Port:      8080,
-				},
-			},
-		},
-	}
-
-	if korrel8rImage != "" {
-		proxies = append(proxies, osv1.ConsolePluginProxy{
-			Alias:         "korrel8r",
-			Authorization: "UserToken",
-			Endpoint: osv1.ConsolePluginProxyEndpoint{
-				Type: osv1.ProxyTypeService,
-				Service: &osv1.ConsolePluginProxyServiceConfig{
-					Name:      korrel8rName,
-					Namespace: namespace,
-					Port:      port,
-				},
-			},
+		proxies = append(proxies, PluginProxy{
+			Alias:            "korrel8r",
+			ServiceName:      korrel8rName,
+			ServiceNamespace: namespace,
+			ServicePort:      port,
+			Authorize:        true,
 		})
 	}
 
@@ -116,7 +78,6 @@ func createLoggingPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, image
 		DisplayName:       "Logging View",
 		ExtraArgs:         extraArgs,
 		ResourceNamespace: namespace,
-		LegacyProxies:     legacyProxies,
 		Proxies:           proxies,
 		Korrel8rImage:     korrel8rImage,
 		ConfigMap: &corev1.ConfigMap{

--- a/pkg/controllers/uiplugin/monitoring.go
+++ b/pkg/controllers/uiplugin/monitoring.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	osv1 "github.com/openshift/api/console/v1"
-	osv1alpha1 "github.com/rhobs/openshift-api/console/v1alpha1"
 	persesv1alpha2 "github.com/rhobs/perses-operator/api/v1alpha2"
 	persesconfig "github.com/rhobs/perses/pkg/model/api/config"
 	"golang.org/x/mod/semver"
@@ -88,57 +86,25 @@ func getBasePluginInfo(namespace, name, image string) *UIPluginInfo {
 			"-static-path=/opt/app-root/web/dist",
 		},
 		ResourceNamespace: namespace,
-		Proxies: []osv1.ConsolePluginProxy{
+		Proxies: []PluginProxy{
 			{
-				Alias:         "backend",
-				Authorization: "UserToken",
-				Endpoint: osv1.ConsolePluginProxyEndpoint{
-					Type: osv1.ProxyTypeService,
-					Service: &osv1.ConsolePluginProxyServiceConfig{
-						Name:      name,
-						Namespace: namespace,
-						Port:      port,
-					},
-				},
-			},
-		},
-		LegacyProxies: []osv1alpha1.ConsolePluginProxy{
-			{
-				Type:      "Service",
-				Alias:     "backend",
-				Authorize: true,
-				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
-					Name:      name,
-					Namespace: namespace,
-					Port:      9443,
-				},
+				Alias:            "backend",
+				ServiceName:      name,
+				ServiceNamespace: namespace,
+				ServicePort:      port,
+				Authorize:        true,
 			},
 		},
 	}
 }
 
 func addPersesProxy(pluginInfo *UIPluginInfo, namespace string) {
-	pluginInfo.Proxies = append(pluginInfo.Proxies, osv1.ConsolePluginProxy{
-		Alias:         "perses",
-		Authorization: "UserToken",
-		Endpoint: osv1.ConsolePluginProxyEndpoint{
-			Type: osv1.ProxyTypeService,
-			Service: &osv1.ConsolePluginProxyServiceConfig{
-				Name:      persesServiceName,
-				Namespace: namespace,
-				Port:      8080,
-			},
-		},
-	})
-	pluginInfo.LegacyProxies = append(pluginInfo.LegacyProxies, osv1alpha1.ConsolePluginProxy{
-		Type:      "Service",
-		Alias:     "perses",
-		Authorize: true,
-		Service: osv1alpha1.ConsolePluginProxyServiceConfig{
-			Name:      persesServiceName,
-			Namespace: namespace,
-			Port:      8080,
-		},
+	pluginInfo.Proxies = append(pluginInfo.Proxies, PluginProxy{
+		Alias:            "perses",
+		ServiceName:      persesServiceName,
+		ServiceNamespace: namespace,
+		ServicePort:      8080,
+		Authorize:        true,
 	})
 }
 
@@ -148,51 +114,19 @@ func addAcmAlertingProxy(pluginInfo *UIPluginInfo, name string, namespace string
 		fmt.Sprintf("-thanos-querier=%s", config.ACM.ThanosQuerier.Url),
 	)
 	pluginInfo.Proxies = append(pluginInfo.Proxies,
-		osv1.ConsolePluginProxy{
-			Alias:         "alertmanager-proxy",
-			Authorization: "UserToken",
-			Endpoint: osv1.ConsolePluginProxyEndpoint{
-				Type: osv1.ProxyTypeService,
-				Service: &osv1.ConsolePluginProxyServiceConfig{
-					Name:      name,
-					Namespace: namespace,
-					Port:      9444,
-				},
-			},
+		PluginProxy{
+			Alias:            "alertmanager-proxy",
+			ServiceName:      name,
+			ServiceNamespace: namespace,
+			ServicePort:      9444,
+			Authorize:        true,
 		},
-		osv1.ConsolePluginProxy{
-			Alias:         "thanos-proxy",
-			Authorization: "UserToken",
-			Endpoint: osv1.ConsolePluginProxyEndpoint{
-				Type: osv1.ProxyTypeService,
-				Service: &osv1.ConsolePluginProxyServiceConfig{
-					Name:      name,
-					Namespace: namespace,
-					Port:      9445,
-				},
-			},
-		},
-	)
-	pluginInfo.LegacyProxies = append(pluginInfo.LegacyProxies,
-		osv1alpha1.ConsolePluginProxy{
-			Type:      "Service",
-			Alias:     "alertmanager-proxy",
-			Authorize: true,
-			Service: osv1alpha1.ConsolePluginProxyServiceConfig{
-				Name:      name,
-				Namespace: namespace,
-				Port:      9444,
-			},
-		},
-		osv1alpha1.ConsolePluginProxy{
-			Type:      "Service",
-			Alias:     "thanos-proxy",
-			Authorize: true,
-			Service: osv1alpha1.ConsolePluginProxyServiceConfig{
-				Name:      name,
-				Namespace: namespace,
-				Port:      9445,
-			},
+		PluginProxy{
+			Alias:            "thanos-proxy",
+			ServiceName:      name,
+			ServiceNamespace: namespace,
+			ServicePort:      9445,
+			Authorize:        true,
 		},
 	)
 }

--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	osv1 "github.com/openshift/api/console/v1"
 	libgocrypto "github.com/openshift/library-go/pkg/crypto"
-	osv1alpha1 "github.com/rhobs/openshift-api/console/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/dynamic"
@@ -26,8 +24,7 @@ type UIPluginInfo struct {
 	ConsoleName                string
 	DisplayName                string
 	ExtraArgs                  []string
-	LegacyProxies              []osv1alpha1.ConsolePluginProxy
-	Proxies                    []osv1.ConsolePluginProxy
+	Proxies                    []PluginProxy
 	Role                       *rbacv1.Role
 	RoleBinding                *rbacv1.RoleBinding
 	ClusterRoles               []*rbacv1.ClusterRole

--- a/pkg/controllers/uiplugin/proxy.go
+++ b/pkg/controllers/uiplugin/proxy.go
@@ -1,0 +1,71 @@
+package uiplugin
+
+import (
+	osv1 "github.com/openshift/api/console/v1"
+	osRhobsv1 "github.com/rhobs/openshift-api/console/v1"
+	osv1alpha1 "github.com/rhobs/openshift-api/console/v1alpha1"
+)
+
+type PluginProxy struct {
+	Alias            string
+	ServiceName      string
+	ServiceNamespace string
+	ServicePort      int32
+	Authorize        bool
+}
+
+// Used for OCP 4.16 and earlier.
+func (p PluginProxy) ToV1Alpha1() osv1alpha1.ConsolePluginProxy {
+	return osv1alpha1.ConsolePluginProxy{
+		Type:      "Service",
+		Alias:     p.Alias,
+		Authorize: p.Authorize,
+		Service: osv1alpha1.ConsolePluginProxyServiceConfig{
+			Name:      p.ServiceName,
+			Namespace: p.ServiceNamespace,
+			Port:      p.ServicePort,
+		},
+	}
+}
+
+// Used for OCP 4.17-18 (No CSP Field)
+func (p PluginProxy) ToRhobsV1() osRhobsv1.ConsolePluginProxy {
+	authorization := osRhobsv1.None
+	if p.Authorize {
+		authorization = osRhobsv1.UserToken
+	}
+
+	return osRhobsv1.ConsolePluginProxy{
+		Alias:         p.Alias,
+		Authorization: authorization,
+		Endpoint: osRhobsv1.ConsolePluginProxyEndpoint{
+			Type: osRhobsv1.ProxyTypeService,
+			Service: &osRhobsv1.ConsolePluginProxyServiceConfig{
+				Name:      p.ServiceName,
+				Namespace: p.ServiceNamespace,
+				Port:      p.ServicePort,
+			},
+		},
+	}
+}
+
+// Used for OCP 4.19+
+func (p PluginProxy) ToUpstreamV1() osv1.ConsolePluginProxy {
+	authorization := osv1.None
+	if p.Authorize {
+		authorization = osv1.UserToken
+	}
+
+	return osv1.ConsolePluginProxy{
+		Alias:         p.Alias,
+		Authorization: authorization,
+		Endpoint: osv1.ConsolePluginProxyEndpoint{
+			Type: osv1.ProxyTypeService,
+			Service: &osv1.ConsolePluginProxyServiceConfig{
+				Name:      p.ServiceName,
+				Namespace: p.ServiceNamespace,
+				Port:      p.ServicePort,
+			},
+		},
+	}
+}

--- a/pkg/controllers/uiplugin/troubleshooting_panel.go
+++ b/pkg/controllers/uiplugin/troubleshooting_panel.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	osv1 "github.com/openshift/api/console/v1"
-	osv1alpha1 "github.com/rhobs/openshift-api/console/v1alpha1"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -49,30 +47,13 @@ func createTroubleshootingPanelPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace
 		LokiServiceNames:  make(map[string]string),
 		TempoServiceNames: make(map[string]string),
 		ExtraArgs:         extraArgs,
-		LegacyProxies: []osv1alpha1.ConsolePluginProxy{
+		Proxies: []PluginProxy{
 			{
-				Type:      osv1alpha1.ProxyTypeService,
-				Alias:     "korrel8r",
-				Authorize: true,
-				Service: osv1alpha1.ConsolePluginProxyServiceConfig{
-					Name:      korrel8rSvcName,
-					Namespace: namespace,
-					Port:      port,
-				},
-			},
-		},
-		Proxies: []osv1.ConsolePluginProxy{
-			{
-				Alias:         "korrel8r",
-				Authorization: "UserToken",
-				Endpoint: osv1.ConsolePluginProxyEndpoint{
-					Type: osv1.ProxyTypeService,
-					Service: &osv1.ConsolePluginProxyServiceConfig{
-						Name:      korrel8rSvcName,
-						Namespace: namespace,
-						Port:      port,
-					},
-				},
+				Alias:            "korrel8r",
+				ServiceName:      korrel8rSvcName,
+				ServiceNamespace: namespace,
+				ServicePort:      port,
+				Authorize:        true,
 			},
 		},
 		ConfigMap: &corev1.ConfigMap{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -351,7 +351,10 @@ func New(ctx context.Context, cfg *OperatorConfiguration) (*Operator, error) {
 			return nil, fmt.Errorf("unable to setup TLS profile watcher: %w", err)
 		}
 
-		if err := uictrl.RegisterWithManager(mgr, uictrl.Options{PluginsConf: cfg.UIPlugins}); err != nil {
+		if err := uictrl.RegisterWithManager(mgr, uictrl.Options{
+			PluginsConf:    cfg.UIPlugins,
+			ClusterVersion: cfg.FeatureGates.OpenShift.Version,
+		}); err != nil {
 			return nil, fmt.Errorf("unable to register observability-ui-plugin controller: %w", err)
 		}
 	} else {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -54,7 +54,8 @@ type Operator struct {
 }
 
 type OpenShiftFeatureGates struct {
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 type FeatureGates struct {

--- a/pkg/operator/scheme.go
+++ b/pkg/operator/scheme.go
@@ -9,6 +9,7 @@ import (
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
+	osRhobsv1 "github.com/rhobs/openshift-api/console/v1"
 	osv1alpha1 "github.com/rhobs/openshift-api/console/v1alpha1"
 	persesv1alpha2 "github.com/rhobs/perses-operator/api/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
@@ -20,6 +21,7 @@ import (
 	rhobsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/monitoring/v1alpha1"
 	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
 	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
+	"github.com/rhobs/observability-operator/pkg/controllers/uiplugin"
 )
 
 func NewScheme(cfg *OperatorConfiguration) *runtime.Scheme {
@@ -36,13 +38,18 @@ func NewScheme(cfg *OperatorConfiguration) *runtime.Scheme {
 
 	if cfg.FeatureGates.OpenShift.Enabled {
 		utilruntime.Must(configv1.Install(scheme))
-		utilruntime.Must(osv1.Install(scheme))
 		utilruntime.Must(osv1alpha1.Install(scheme))
 		utilruntime.Must(operatorv1.Install(scheme))
 		utilruntime.Must(corev1.AddToScheme(scheme))
 		utilruntime.Must(monv1.AddToScheme(scheme))
 		utilruntime.Must(persesv1alpha2.AddToScheme(scheme))
 		utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
+
+		if uiplugin.IsVersionAheadOrEqual(cfg.FeatureGates.OpenShift.Version, "v4.19") {
+			utilruntime.Must(osv1.Install(scheme))
+		} else {
+			utilruntime.Must(osRhobsv1.Install(scheme))
+		}
 	}
 
 	return scheme


### PR DESCRIPTION
The content security policy field was added to the ConsolePlugin CRD in OCP 4.19, however the field is not supported in OCP 4.17 and 4.18. A recent update to the `openshift/api` console/v1 version makes the field be marshalled by default, leading to a reconciliation error.  

This PR changes OCP 4.17 and 4.18 to use the `rhobs/openshift-api` console/v1 for OCP 4.17 and 4.18. It checks the OCP version on startup when `openshift.enabled` is true, registers the correct scheme (`rhobs/openshift-api/console/v1` or `openshift/api/console/v1`), then creates the appropriate CR version