### PR TITLE
test: fix NoOwnerRefInvalidNamespaceReasonEvent test

### DIFF
--- a/test/e2e/framework/assertions.go
+++ b/test/e2e/framework/assertions.go
@@ -21,9 +21,11 @@ import (
 	monv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -694,9 +696,23 @@ func (f *Framework) AssertNoEventWithReason(t *testing.T, reason string) {
 		t.Fatalf("unexpected error: %s", err)
 	}
 
-	if len(evts.Items) > 0 {
-		t.Logf("expected 0 event with reason=%q, got %d", reason, len(evts.Items))
-		for i, e := range evts.Items {
+	// Filter events about COO resources only otherwise the test might trip
+	// over events unrelated to the operator.
+	var events []eventsv1.Event
+	for _, evt := range evts.Items {
+		gv, err := schema.ParseGroupVersion(evt.Regarding.APIVersion)
+		if err != nil {
+			t.Logf("failed to parse groupVersion for %q: %v", evt.Regarding.APIVersion, err)
+			continue
+		}
+		if gv.Group == v1alpha1.GroupVersion.Group {
+			events = append(events, evt)
+		}
+	}
+
+	if len(events) > 0 {
+		t.Logf("expected 0 event with reason=%q, got %d", reason, len(events))
+		for i, e := range events {
 			t.Logf("event[%d]: %s", i, e.String())
 		}
 		t.FailNow()


### PR DESCRIPTION
This commit filters events which are related to COO resources only because unexpected events sometimes happen in test environments due to unrelated operators.

https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-rhobs-observability-operator-main-amd64-ocp-4.21-azure-coo-stage/2062092334132105216 as an example of such failures.