### PR TITLE
test: add DumpOnFailure debug infrastructure for all e2e tests

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -260,6 +260,41 @@ func (f *Framework) CleanUp(t *testing.T, cleanupFunc func()) {
 	})
 }
 
+// DebugFunc is a diagnostic function invoked when a test fails.
+// Implementations should use t.Logf to emit relevant state.
+type DebugFunc func(t *testing.T)
+
+// DumpOnFailure registers a t.Cleanup that runs the given debug functions
+// when the test fails. It can be called multiple times to add more debug
+// functions as resources become available during the test.
+//
+// Cleanups run in LIFO order, so call DumpOnFailure before registering
+// resource deletions via CleanUp to ensure debug info is captured while
+// the resources still exist.
+func (f *Framework) DumpOnFailure(t *testing.T, fns ...DebugFunc) {
+	t.Helper()
+	t.Cleanup(func() {
+		if !t.Failed() {
+			return
+		}
+		for _, fn := range fns {
+			fn(t)
+		}
+	})
+}
+
+// DebugNamespace returns a DebugFunc that dumps deployments, pods, and events
+// for the given namespaces.
+func (f *Framework) DebugNamespace(namespaces ...string) DebugFunc {
+	return func(t *testing.T) {
+		t.Helper()
+		for _, ns := range namespaces {
+			t.Logf("--- Dumping debug info for namespace %s ---", ns)
+			f.DumpNamespaceDebug(t, ns)
+		}
+	}
+}
+
 // SkipIfClusterVersionBelow skips the test if the cluster version is below
 // minVersion. The minVersion string should be a semver-compatible version
 // (e.g. "4.19" or "v4.19").

--- a/test/e2e/monitoring_stack_controller_test.go
+++ b/test/e2e/monitoring_stack_controller_test.go
@@ -48,6 +48,7 @@ func assertCRDExists(t *testing.T, crds ...string) {
 }
 
 func TestMonitoringStackController(t *testing.T) {
+	f.DumpOnFailure(t, f.DebugNamespace(e2eTestNamespace))
 	err := stack.AddToScheme(scheme.Scheme)
 	assert.NilError(t, err, "adding stack to scheme failed")
 	assertCRDExists(t,

--- a/test/e2e/observability_installer_test.go
+++ b/test/e2e/observability_installer_test.go
@@ -45,6 +45,7 @@ func TestObservabilityInstallerController(t *testing.T) {
 }
 
 func testObservabilityInstallerTracing(t *testing.T) {
+	f.DumpOnFailure(t, f.DebugNamespace(f.OperatorNamespace, "tracing-observability"))
 	ctx := context.Background()
 
 	// The ObservabilityInstaller installs operators via subscriptions,

--- a/test/e2e/operator_metrics_test.go
+++ b/test/e2e/operator_metrics_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestOperatorMetrics(t *testing.T) {
+	f.DumpOnFailure(t, f.DebugNamespace(f.OperatorNamespace))
 	t.Run("operator exposes metrics", func(t *testing.T) {
 		pod := f.GetOperatorPod(t)
 

--- a/test/e2e/po_admission_webhook_test.go
+++ b/test/e2e/po_admission_webhook_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestPrometheusRuleWebhook(t *testing.T) {
+	f.DumpOnFailure(t, f.DebugNamespace(e2eTestNamespace))
 	assertCRDExists(t,
 		"prometheusrules.monitoring.rhobs",
 	)

--- a/test/e2e/prometheus_operator_test.go
+++ b/test/e2e/prometheus_operator_test.go
@@ -29,6 +29,7 @@ type testCase struct {
 }
 
 func TestPrometheusOperatorForNonOwnedResources(t *testing.T) {
+	f.DumpOnFailure(t, f.DebugNamespace(e2eTestNamespace))
 	resources := []client.Object{
 		newPrometheus(nil),
 		newAlertmanager(nil),
@@ -74,6 +75,7 @@ func TestPrometheusOperatorForNonOwnedResources(t *testing.T) {
 }
 
 func TestPrometheusOperatorForOwnedResources(t *testing.T) {
+	f.DumpOnFailure(t, f.DebugNamespace(e2eTestNamespace))
 	resources := []client.Object{
 		newPrometheus(ownedResourceLabels),
 		newAlertmanager(ownedResourceLabels),

--- a/test/e2e/thanos_querier_controller_test.go
+++ b/test/e2e/thanos_querier_controller_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestThanosQuerierController(t *testing.T) {
+	f.DumpOnFailure(t, f.DebugNamespace(e2eTestNamespace))
 	assertCRDExists(t, "thanosqueriers.monitoring.rhobs")
 
 	ts := []testCase{

--- a/test/e2e/uiplugin_cluster_health_analyzer_test.go
+++ b/test/e2e/uiplugin_cluster_health_analyzer_test.go
@@ -32,16 +32,13 @@ func clusterHealthAnalyzer(t *testing.T) {
 	err := monv1.AddToScheme(f.K8sClient.Scheme())
 	assert.NilError(t, err, "failed to add monv1 to scheme")
 
+	f.DumpOnFailure(t, f.DebugNamespace(uiPluginInstallNS))
+
 	plugin := resetMonitoringUIPlugin(t)
 	err = f.K8sClient.Create(t.Context(), plugin)
 	assert.NilError(t, err, "failed to create monitoring UIPlugin")
 
-	t.Cleanup(func() {
-		if t.Failed() {
-			dumpClusterHealthAnalyzerDebug(t, plugin.Name)
-		}
-	})
-
+	f.DumpOnFailure(t, dumpUIPluginDebug(plugin.Name))
 	t.Log("Waiting for health-analyzer deployment to become ready...")
 	haDeployment := appsv1.Deployment{}
 	f.GetResourceWithRetry(t, healthAnalyzerDeploymentName, uiPluginInstallNS, &haDeployment)
@@ -179,15 +176,16 @@ func newAlwaysFiringRule(t *testing.T, ruleName, alertName string) *monv1.Promet
 	return rule
 }
 
-func dumpClusterHealthAnalyzerDebug(t *testing.T, pluginName string) {
-	t.Helper()
-	ctx := context.WithoutCancel(t.Context())
+func dumpUIPluginDebug(pluginName string) framework.DebugFunc {
+	return func(t *testing.T) {
+		t.Helper()
+		ctx := context.WithoutCancel(t.Context())
 
-	// UIPlugin-specific diagnostics
-	var plugin uiv1.UIPlugin
-	if err := f.K8sClient.Get(ctx, client.ObjectKey{Name: pluginName}, &plugin); err != nil {
-		t.Logf("Failed to get UIPlugin %q: %v", pluginName, err)
-	} else {
+		var plugin uiv1.UIPlugin
+		if err := f.K8sClient.Get(ctx, client.ObjectKey{Name: pluginName}, &plugin); err != nil {
+			t.Logf("Failed to get UIPlugin %q: %v", pluginName, err)
+			return
+		}
 		t.Logf("UIPlugin %q generation=%d, resourceVersion=%s", pluginName, plugin.Generation, plugin.ResourceVersion)
 		t.Logf("UIPlugin spec.type=%s", plugin.Spec.Type)
 		if plugin.Spec.Monitoring != nil {
@@ -204,18 +202,15 @@ func dumpClusterHealthAnalyzerDebug(t *testing.T, pluginName string) {
 		for _, c := range plugin.Status.Conditions {
 			t.Logf("UIPlugin condition: type=%s status=%s reason=%s message=%s", c.Type, c.Status, c.Reason, c.Message)
 		}
-	}
 
-	var plugins uiv1.UIPluginList
-	if err := f.K8sClient.List(ctx, &plugins); err != nil {
-		t.Logf("Failed to list UIPlugins: %v", err)
-	} else {
-		t.Logf("Total UIPlugins in cluster: %d", len(plugins.Items))
-		for _, p := range plugins.Items {
-			t.Logf("  UIPlugin: name=%s type=%s conditions=%d", p.Name, p.Spec.Type, len(p.Status.Conditions))
+		var plugins uiv1.UIPluginList
+		if err := f.K8sClient.List(ctx, &plugins); err != nil {
+			t.Logf("Failed to list UIPlugins: %v", err)
+		} else {
+			t.Logf("Total UIPlugins in cluster: %d", len(plugins.Items))
+			for _, p := range plugins.Items {
+				t.Logf("  UIPlugin: name=%s type=%s conditions=%d", p.Name, p.Spec.Type, len(p.Status.Conditions))
+			}
 		}
 	}
-
-	// Generic namespace diagnostics (deployments, pods, events)
-	f.DumpNamespaceDebug(t, uiPluginInstallNS)
 }

--- a/test/e2e/uiplugin_test.go
+++ b/test/e2e/uiplugin_test.go
@@ -46,6 +46,7 @@ func TestUIPlugin(t *testing.T) {
 }
 
 func dashboardsUIPlugin(t *testing.T) {
+	f.DumpOnFailure(t, f.DebugNamespace(uiPluginInstallNS))
 	db := newDashboardsUIPlugin(t)
 	err := f.K8sClient.Create(context.Background(), db)
 	assert.NilError(t, err, "failed to create a dashboards UIPlugin")


### PR DESCRIPTION
## Summary

- Introduces a composable `DebugFunc` type and `DumpOnFailure` helper in the e2e framework — tests register diagnostic functions that only fire when the test fails
- Adds `DebugNamespace(ns...)` which dumps deployments (with conditions), pods (with container statuses), and events for the given namespaces
- Refactors `dumpClusterHealthAnalyzerDebug` into a reusable `dumpUIPluginDebug` returning a `DebugFunc`
- Wires `DumpOnFailure` into all e2e test suites for consistent post-failure diagnostics

## How it works

```go
// Register namespace-level debug (runs only on failure, LIFO before CleanUp)
f.DumpOnFailure(t, f.DebugNamespace("my-namespace"))

// Register CR-specific debug
f.DumpOnFailure(t, dumpUIPluginDebug(plugin.Name))
```

Cleanups run in LIFO order, so `DumpOnFailure` should be called **before** `CleanUp` to ensure debug info is captured while resources still exist.

<details>
<summary>Example output (truncated) — namespace with 6 deployments, 7 pods, 137 events</summary>

```
=== RUN   TestObservabilityInstallerController/ObservabilityInstallerTracing
    framework.go: --- Dumping debug info for namespace openshift-cluster-observability-operator ---
    framework.go: === BEGIN DEBUG DUMP ===
    framework.go: Deployments in namespace openshift-cluster-observability-operator: 6
    framework.go:   Deployment: name=health-analyzer replicas=1 readyReplicas=1 availableReplicas=1
    framework.go:     condition: type=Available status=True reason=MinimumReplicasAvailable ...
    framework.go:   Deployment: name=obo-prometheus-operator replicas=1 readyReplicas=1 availableReplicas=1
    framework.go:     condition: type=Available status=True reason=MinimumReplicasAvailable ...
    framework.go:   ... (6 deployments total)
    framework.go: Pods in namespace openshift-cluster-observability-operator: 7
    framework.go:   Pod: name=health-analyzer-85bf6b7b69-ctcrp phase=Running
    framework.go:     container=health-analyzer ready=true restarts=0 state=Running
    framework.go:   Pod: name=observability-operator-fc695d7-jbxj5 phase=Running
    framework.go:     container=operator ready=true restarts=0 state=Running
    framework.go:   ... (7 pods total)
    framework.go: Events in namespace openshift-cluster-observability-operator: 137
    framework.go:   Event: involvedObject=Pod/obo-prometheus-operator-... reason=Failed message=Error: ImagePullBackOff type=Warning count=5
    framework.go:   Event: involvedObject=CSV/cluster-observability-operator.v1.5.0 reason=InstallWaiting ...
    framework.go:   ... (137 events total)
    framework.go: === END DEBUG DUMP ===
--- FAIL: TestObservabilityInstallerController/ObservabilityInstallerTracing (1.05s)
```

</details>

<details>
<summary>Example — empty namespace (instant, no noise)</summary>

```
=== RUN   TestMonitoringStackController
    framework.go: --- Dumping debug info for namespace e2e-tests ---
    framework.go: === BEGIN DEBUG DUMP ===
    framework.go: Deployments in namespace e2e-tests: 0
    framework.go: Pods in namespace e2e-tests: 0
    framework.go: Events in namespace e2e-tests: 0
    framework.go: === END DEBUG DUMP ===
--- FAIL: TestMonitoringStackController (0.52s)
```

</details>

<details>
<summary>Example — no output on passing tests</summary>

```
=== RUN   TestUIPluginUninstallCleanup
--- PASS: TestUIPluginUninstallCleanup (60.33s)
    --- PASS: .../monitoring_plugin_deployment_is_deleted (0.18s)
    --- PASS: .../health-analyzer_deployment_is_deleted (0.20s)
    --- PASS: .../no_UIPlugin-managed_pods_remain_in_operator_namespace (10.55s)
```

</details>

## Test plan

- [x] `go build ./test/e2e/...` compiles cleanly
- [ ] Full e2e suite passes on OCP cluster (dump output only appears for genuinely failing tests)

Made with [Cursor](https://cursor.com)