### PR TITLE
COO-1849: warn when AI Navigation is used on unsupported OCP

### DIFF
--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -68,7 +68,7 @@ func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interfac
 		}
 
 	case uiv1alpha1.TypeTroubleshootingPanel:
-		pluginInfo, err = createTroubleshootingPanelPluginInfo(plugin, namespace, plugin.Name, image, []string{})
+		pluginInfo, err = createTroubleshootingPanelPluginInfo(plugin, namespace, plugin.Name, image, []string{}, clusterVersion, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controllers/uiplugin/troubleshooting_panel.go
+++ b/pkg/controllers/uiplugin/troubleshooting_panel.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -22,7 +23,7 @@ const (
 	alertmanagerRoleName = "monitoring-alertmanager-view"
 )
 
-func createTroubleshootingPanelPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, image string, features []string) (*UIPluginInfo, error) {
+func createTroubleshootingPanelPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace, name, image string, features []string, clusterVersion string, logger logr.Logger) (*UIPluginInfo, error) {
 	troubleshootingPanelConfig := plugin.Spec.TroubleshootingPanel
 
 	configYaml, err := marshalTroubleshootingPanelPluginConfig(troubleshootingPanelConfig)
@@ -34,8 +35,12 @@ func createTroubleshootingPanelPluginInfo(plugin *uiv1alpha1.UIPlugin, namespace
 		"-plugin-config-path=/etc/plugin/config/config.yaml",
 	}
 	if plugin.Spec.TroubleshootingPanel != nil && plugin.Spec.TroubleshootingPanel.EnableAgentNavigation {
-		if !slices.Contains(features, "agent-navigation") {
-			features = append(features, "agent-navigation")
+		if IsVersionAheadOrEqual(clusterVersion, "v4.22") {
+			if !slices.Contains(features, "agent-navigation") {
+				features = append(features, "agent-navigation")
+			}
+		} else {
+			logger.Info("Agent Navigation only available as a Dev Preview in OpenShift 4.22+")
 		}
 	}
 	if len(features) > 0 {

--- a/pkg/controllers/uiplugin/troubleshooting_panel_test.go
+++ b/pkg/controllers/uiplugin/troubleshooting_panel_test.go
@@ -7,7 +7,9 @@ import (
 	"gotest.tools/v3/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 
+	"github.com/go-logr/logr"
 	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
 )
 
@@ -43,8 +45,8 @@ func newTroubleshootingPanelPlugin(cfg *uiv1alpha1.TroubleshootingPanelConfig) *
 	}
 }
 
-func getTroubleshootingPanelPluginInfo(plugin *uiv1alpha1.UIPlugin, features []string) (*UIPluginInfo, error) {
-	return createTroubleshootingPanelPluginInfo(plugin, "openshift-operators", plugin.Name, "quay.io/tp-test:latest", features)
+func getTroubleshootingPanelPluginInfo(plugin *uiv1alpha1.UIPlugin, features []string, clusterVersion string, logger logr.Logger) (*UIPluginInfo, error) {
+	return createTroubleshootingPanelPluginInfo(plugin, "openshift-operators", plugin.Name, "quay.io/tp-test:latest", features, clusterVersion, logger)
 }
 
 func findFeaturesArg(args []string) string {
@@ -57,11 +59,22 @@ func findFeaturesArg(args []string) string {
 }
 
 func TestCreateTroubleshootingPanelPluginInfo(t *testing.T) {
+	logger := ctrl.Log.WithName("troubleshooting-tests")
 	t.Run("no features when EnableAgentNavigation is false", func(t *testing.T) {
 		plugin := newTroubleshootingPanelPlugin(&uiv1alpha1.TroubleshootingPanelConfig{
 			Timeout: "30s",
 		})
-		info, err := getTroubleshootingPanelPluginInfo(plugin, nil)
+		info, err := getTroubleshootingPanelPluginInfo(plugin, nil, "v4.19.0", logger)
+		assert.NilError(t, err)
+		assert.Equal(t, findFeaturesArg(info.ExtraArgs), "")
+	})
+
+	t.Run("agent-navigation feature is not set in < 4.22", func(t *testing.T) {
+		plugin := newTroubleshootingPanelPlugin(&uiv1alpha1.TroubleshootingPanelConfig{
+			EnableAgentNavigation: true,
+			Timeout:               "30s",
+		})
+		info, err := getTroubleshootingPanelPluginInfo(plugin, nil, "v4.19.0", logger)
 		assert.NilError(t, err)
 		assert.Equal(t, findFeaturesArg(info.ExtraArgs), "")
 	})
@@ -71,14 +84,14 @@ func TestCreateTroubleshootingPanelPluginInfo(t *testing.T) {
 			EnableAgentNavigation: true,
 			Timeout:               "30s",
 		})
-		info, err := getTroubleshootingPanelPluginInfo(plugin, nil)
+		info, err := getTroubleshootingPanelPluginInfo(plugin, nil, "v4.22.0", logger)
 		assert.NilError(t, err)
 		assert.Equal(t, findFeaturesArg(info.ExtraArgs), "agent-navigation")
 	})
 
 	t.Run("nil TroubleshootingPanel config", func(t *testing.T) {
 		plugin := newTroubleshootingPanelPlugin(nil)
-		info, err := getTroubleshootingPanelPluginInfo(plugin, nil)
+		info, err := getTroubleshootingPanelPluginInfo(plugin, nil, "v4.19.0", logger)
 		assert.NilError(t, err)
 		assert.Equal(t, findFeaturesArg(info.ExtraArgs), "")
 	})
@@ -87,7 +100,7 @@ func TestCreateTroubleshootingPanelPluginInfo(t *testing.T) {
 		plugin := newTroubleshootingPanelPlugin(&uiv1alpha1.TroubleshootingPanelConfig{
 			Timeout: "5m",
 		})
-		info, err := getTroubleshootingPanelPluginInfo(plugin, nil)
+		info, err := getTroubleshootingPanelPluginInfo(plugin, nil, "v4.19.0", logger)
 		assert.NilError(t, err)
 		assert.Assert(t, info.ConfigMap != nil)
 		assert.Assert(t, strings.Contains(info.ConfigMap.Data["config.yaml"], "timeout: 5m"))
@@ -95,7 +108,7 @@ func TestCreateTroubleshootingPanelPluginInfo(t *testing.T) {
 
 	t.Run("proxies are configured for korrel8r", func(t *testing.T) {
 		plugin := newTroubleshootingPanelPlugin(nil)
-		info, err := getTroubleshootingPanelPluginInfo(plugin, nil)
+		info, err := getTroubleshootingPanelPluginInfo(plugin, nil, "v4.19.0", logger)
 		assert.NilError(t, err)
 		assert.Equal(t, len(info.Proxies), 1)
 		assert.Equal(t, info.Proxies[0].Alias, "korrel8r")
@@ -105,7 +118,7 @@ func TestCreateTroubleshootingPanelPluginInfo(t *testing.T) {
 
 	t.Run("multiple features are comma-joined", func(t *testing.T) {
 		plugin := newTroubleshootingPanelPlugin(nil)
-		info, err := getTroubleshootingPanelPluginInfo(plugin, []string{"agent-navigation", "other-feature"})
+		info, err := getTroubleshootingPanelPluginInfo(plugin, []string{"agent-navigation", "other-feature"}, "v4.22.0", logger)
 		assert.NilError(t, err)
 		assert.Equal(t, findFeaturesArg(info.ExtraArgs), "agent-navigation,other-feature")
 	})


### PR DESCRIPTION
The AI navigation feature is only enabled as a dev preview feature in OCP 4.22+. Since the feature is dev preview I have added only a warning, not a failure of the reconciliation loop for enabling an unsupported feature