### PR TITLE
fix: handle nil Capabilities/Tracing in ObservabilityInstaller controller

### DIFF
--- a/pkg/controllers/observability/observability_controller.go
+++ b/pkg/controllers/observability/observability_controller.go
@@ -206,7 +206,7 @@ func (o observabilityInstallerController) getInstance(ctx context.Context, req c
 func (o observabilityInstallerController) updateStatus(ctx context.Context, instance *obsv1alpha1.ObservabilityInstaller, reconcileErr error) reconcile.Result {
 	if instance.Spec.Capabilities != nil {
 		capabilities := instance.Spec.Capabilities
-		if capabilities.Tracing.Enabled {
+		if capabilities.Tracing != nil && capabilities.Tracing.Enabled {
 			otelcol := &otelv1beta1.OpenTelemetryCollector{}
 			err := o.client.Get(ctx, types.NamespacedName{
 				Namespace: instance.Namespace,

--- a/pkg/controllers/observability/tempo_components_test.go
+++ b/pkg/controllers/observability/tempo_components_test.go
@@ -1,0 +1,264 @@
+package observability
+
+import (
+	"testing"
+
+	tempov1alpha1 "github.com/grafana/tempo-operator/api/tempo/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
+)
+
+func TestTempoStack(t *testing.T) {
+	tests := []struct {
+		name               string
+		instance           *obsv1alpha1.ObservabilityInstaller
+		wantStorageType    tempov1alpha1.ObjectStorageSecretType
+		wantCredentialMode tempov1alpha1.CredentialMode
+		wantTLSEnabled     bool
+		wantTLSCASet       bool
+		wantTLSCertSet     bool
+	}{
+		{
+			name: "nil capabilities - does not panic",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec:       obsv1alpha1.ObservabilityInstallerSpec{},
+			},
+		},
+		{
+			name: "nil tracing - does not panic",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: obsv1alpha1.ObservabilityInstallerSpec{
+					Capabilities: &obsv1alpha1.CapabilitiesSpec{},
+				},
+			},
+		},
+		{
+			name: "nil storage - does not panic",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: obsv1alpha1.ObservabilityInstallerSpec{
+					Capabilities: &obsv1alpha1.CapabilitiesSpec{
+						Tracing: &obsv1alpha1.TracingSpec{},
+					},
+				},
+			},
+		},
+		{
+			name: "nil object storage spec - does not panic",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: obsv1alpha1.ObservabilityInstallerSpec{
+					Capabilities: &obsv1alpha1.CapabilitiesSpec{
+						Tracing: &obsv1alpha1.TracingSpec{
+							Storage: &obsv1alpha1.TracingStorageSpec{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "S3 storage - sets S3 type and static credential mode",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: obsv1alpha1.ObservabilityInstallerSpec{
+					Capabilities: &obsv1alpha1.CapabilitiesSpec{
+						Tracing: &obsv1alpha1.TracingSpec{
+							Storage: &obsv1alpha1.TracingStorageSpec{
+								ObjectStorageSpec: &obsv1alpha1.TracingObjectStorageSpec{
+									S3: &obsv1alpha1.S3Spec{
+										Bucket:   "test-bucket",
+										Endpoint: "http://minio:9000",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStorageType:    tempov1alpha1.ObjectStorageSecretS3,
+			wantCredentialMode: tempov1alpha1.CredentialModeStatic,
+		},
+		{
+			name: "S3STS storage - sets S3 type and token credential mode",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: obsv1alpha1.ObservabilityInstallerSpec{
+					Capabilities: &obsv1alpha1.CapabilitiesSpec{
+						Tracing: &obsv1alpha1.TracingSpec{
+							Storage: &obsv1alpha1.TracingStorageSpec{
+								ObjectStorageSpec: &obsv1alpha1.TracingObjectStorageSpec{
+									S3STS: &obsv1alpha1.S3STSpec{
+										Bucket:  "test-bucket",
+										RoleARN: "arn:aws:iam::123:role/test",
+										Region:  "us-east-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStorageType:    tempov1alpha1.ObjectStorageSecretS3,
+			wantCredentialMode: tempov1alpha1.CredentialModeToken,
+		},
+		{
+			name: "Azure storage - sets Azure type and static credential mode",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: obsv1alpha1.ObservabilityInstallerSpec{
+					Capabilities: &obsv1alpha1.CapabilitiesSpec{
+						Tracing: &obsv1alpha1.TracingSpec{
+							Storage: &obsv1alpha1.TracingStorageSpec{
+								ObjectStorageSpec: &obsv1alpha1.TracingObjectStorageSpec{
+									Azure: &obsv1alpha1.AzureSpec{
+										Container:   "test-container",
+										AccountName: "test-account",
+										AccountKeySecret: obsv1alpha1.SecretKeySelector{
+											Name: "secret",
+											Key:  "key",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStorageType:    tempov1alpha1.ObjectStorageSecretAzure,
+			wantCredentialMode: tempov1alpha1.CredentialModeStatic,
+		},
+		{
+			name: "GCS storage - sets GCS type and static credential mode",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: obsv1alpha1.ObservabilityInstallerSpec{
+					Capabilities: &obsv1alpha1.CapabilitiesSpec{
+						Tracing: &obsv1alpha1.TracingSpec{
+							Storage: &obsv1alpha1.TracingStorageSpec{
+								ObjectStorageSpec: &obsv1alpha1.TracingObjectStorageSpec{
+									GCS: &obsv1alpha1.GCSSpec{
+										Bucket: "test-bucket",
+										KeyJSONSecret: obsv1alpha1.SecretKeySelector{
+											Name: "secret",
+											Key:  "key.json",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStorageType:    tempov1alpha1.ObjectStorageSecretGCS,
+			wantCredentialMode: tempov1alpha1.CredentialModeStatic,
+		},
+		{
+			name: "S3 with HTTPS endpoint - enables TLS automatically",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: obsv1alpha1.ObservabilityInstallerSpec{
+					Capabilities: &obsv1alpha1.CapabilitiesSpec{
+						Tracing: &obsv1alpha1.TracingSpec{
+							Storage: &obsv1alpha1.TracingStorageSpec{
+								ObjectStorageSpec: &obsv1alpha1.TracingObjectStorageSpec{
+									S3: &obsv1alpha1.S3Spec{
+										Bucket:   "test-bucket",
+										Endpoint: "https://s3.amazonaws.com",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStorageType:    tempov1alpha1.ObjectStorageSecretS3,
+			wantCredentialMode: tempov1alpha1.CredentialModeStatic,
+			wantTLSEnabled:     true,
+		},
+		{
+			name: "S3 with explicit TLS CA configmap - sets TLS CA reference",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: obsv1alpha1.ObservabilityInstallerSpec{
+					Capabilities: &obsv1alpha1.CapabilitiesSpec{
+						Tracing: &obsv1alpha1.TracingSpec{
+							Storage: &obsv1alpha1.TracingStorageSpec{
+								ObjectStorageSpec: &obsv1alpha1.TracingObjectStorageSpec{
+									S3: &obsv1alpha1.S3Spec{
+										Bucket:   "test-bucket",
+										Endpoint: "http://minio:9000",
+									},
+									TLS: &obsv1alpha1.TLSSpec{
+										CAConfigMap: &obsv1alpha1.ConfigMapKeySelector{
+											Name: "ca-configmap",
+											Key:  "ca.crt",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStorageType:    tempov1alpha1.ObjectStorageSecretS3,
+			wantCredentialMode: tempov1alpha1.CredentialModeStatic,
+			wantTLSEnabled:     true,
+			wantTLSCASet:       true,
+		},
+		{
+			name: "S3 with explicit TLS cert secret - sets TLS cert reference",
+			instance: &obsv1alpha1.ObservabilityInstaller{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "test-ns"},
+				Spec: obsv1alpha1.ObservabilityInstallerSpec{
+					Capabilities: &obsv1alpha1.CapabilitiesSpec{
+						Tracing: &obsv1alpha1.TracingSpec{
+							Storage: &obsv1alpha1.TracingStorageSpec{
+								ObjectStorageSpec: &obsv1alpha1.TracingObjectStorageSpec{
+									S3: &obsv1alpha1.S3Spec{
+										Bucket:   "test-bucket",
+										Endpoint: "http://minio:9000",
+									},
+									TLS: &obsv1alpha1.TLSSpec{
+										CertSecret: &obsv1alpha1.SecretKeySelector{
+											Name: "cert-secret",
+											Key:  "tls.crt",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantStorageType:    tempov1alpha1.ObjectStorageSecretS3,
+			wantCredentialMode: tempov1alpha1.CredentialModeStatic,
+			wantTLSEnabled:     true,
+			wantTLSCertSet:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tempoStack(tt.instance)
+
+			require.NotNil(t, result)
+			assert.Equal(t, tt.instance.Name, result.Name)
+			assert.Equal(t, tt.instance.Namespace, result.Namespace)
+			assert.Equal(t, tt.wantStorageType, result.Spec.Storage.Secret.Type)
+			assert.Equal(t, tt.wantCredentialMode, result.Spec.Storage.Secret.CredentialMode)
+			assert.Equal(t, tt.wantTLSEnabled, result.Spec.Storage.TLS.Enabled)
+
+			if tt.wantTLSCASet {
+				assert.NotEmpty(t, result.Spec.Storage.TLS.CA)
+			}
+			if tt.wantTLSCertSet {
+				assert.NotEmpty(t, result.Spec.Storage.TLS.Cert)
+			}
+		})
+	}
+}

--- a/test/e2e/observability_installer_test.go
+++ b/test/e2e/observability_installer_test.go
@@ -42,6 +42,7 @@ func TestObservabilityInstallerController(t *testing.T) {
 	assertCRDExists(t, "observabilityinstallers.observability.openshift.io")
 
 	t.Run("ObservabilityInstallerTracing", testObservabilityInstallerTracing)
+	t.Run("ObservabilityInstallerEmptySpec", testObservabilityInstallerEmptySpec)
 }
 
 func testObservabilityInstallerTracing(t *testing.T) {
@@ -222,6 +223,88 @@ func testObservabilityInstallerTracing(t *testing.T) {
 		return false, nil
 	})
 	require.NoError(t, err)
+}
+
+// testObservabilityInstallerEmptySpec verifies that the controller handles an
+// ObservabilityInstaller with spec: {} gracefully — no panic, no operands deployed.
+//
+// Regression test for: nil pointer dereference when Capabilities is nil.
+func testObservabilityInstallerEmptySpec(t *testing.T) {
+	ctx := context.Background()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "obs-empty-spec-test-"},
+	}
+	err := f.K8sClient.Create(ctx, ns)
+	require.NoError(t, err)
+	f.CleanUp(t, func() { f.K8sClient.Delete(ctx, ns) })
+
+	obsInstaller := &obsv1alpha1.ObservabilityInstaller{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "empty-spec",
+			Namespace: ns.Name,
+		},
+		Spec: obsv1alpha1.ObservabilityInstallerSpec{},
+	}
+	f.CleanUp(t, func() { f.K8sClient.Delete(ctx, obsInstaller) })
+
+	err = f.K8sClient.Create(ctx, obsInstaller)
+	require.NoError(t, err, "creating ObservabilityInstaller with empty spec should succeed")
+
+	// Give the controller time to reconcile. A panic would restart the pod;
+	// a nil-pointer dereference in updateStatus would show up as a crash loop.
+	time.Sleep(30 * time.Second)
+
+	// Operator deployment must still be available — if the controller panicked
+	// it would be crash-looping and AvailableReplicas would drop to zero.
+	var operatorDeploy appsv1.Deployment
+	err = f.K8sClient.Get(ctx, types.NamespacedName{
+		Name:      "observability-operator",
+		Namespace: f.OperatorNamespace,
+	}, &operatorDeploy)
+	require.NoError(t, err, "observability-operator deployment must exist")
+	require.Greater(t, operatorDeploy.Status.AvailableReplicas, int32(0),
+		"observability-operator must have available replicas (controller must not be crash-looping)")
+
+	// No TempoStack should exist in the test namespace — tracing is not enabled.
+	var stsList appsv1.StatefulSetList
+	err = f.K8sClient.List(ctx, &stsList, client.InNamespace(ns.Name))
+	require.NoError(t, err)
+	for _, sts := range stsList.Items {
+		t.Errorf("unexpected StatefulSet %q in namespace %q — no operands should be deployed for empty spec", sts.Name, ns.Name)
+	}
+
+	// No OpenTelemetryCollector Deployment should exist in the test namespace.
+	var deployList appsv1.DeploymentList
+	err = f.K8sClient.List(ctx, &deployList, client.InNamespace(ns.Name))
+	require.NoError(t, err)
+	for _, d := range deployList.Items {
+		t.Errorf("unexpected Deployment %q in namespace %q — no operands should be deployed for empty spec", d.Name, ns.Name)
+	}
+
+	// Status fields must remain empty — tracing.enabled is false.
+	var current obsv1alpha1.ObservabilityInstaller
+	err = f.K8sClient.Get(ctx, types.NamespacedName{Name: obsInstaller.Name, Namespace: ns.Name}, &current)
+	require.NoError(t, err)
+	assert.Equal(t, "", current.Status.Tempo, "Status.Tempo must be empty when tracing is not enabled")
+	assert.Equal(t, "", current.Status.OpenTelemetry, "Status.OpenTelemetry must be empty when tracing is not enabled")
+
+	// Clean deletion must work without errors.
+	err = f.K8sClient.Delete(ctx, obsInstaller)
+	require.NoError(t, err, "deleting ObservabilityInstaller with empty spec should succeed")
+
+	err = wait.PollUntilContextTimeout(ctx, 1*time.Second, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		var deleted obsv1alpha1.ObservabilityInstaller
+		err := f.K8sClient.Get(ctx, types.NamespacedName{Name: obsInstaller.Name, Namespace: ns.Name}, &deleted)
+		if err == nil {
+			return false, nil
+		}
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+	require.NoError(t, err, "ObservabilityInstaller with empty spec should be fully deleted")
 }
 
 func deployManifest(t *testing.T, manifest string) client.Object {


### PR DESCRIPTION
## Summary

Resolves bug https://redhat.atlassian.net/browse/COO-1257 

- Fix nil pointer dereference panic in `updateStatus` when `Capabilities` is non-nil but `Tracing` is nil (e.g. `spec: { capabilities: {} }`)
- Add 11 unit tests for `tempoStack()` covering all nil-input combinations (nil Capabilities, nil Tracing, nil Storage, nil ObjectStorageSpec) and all storage backends (S3, S3STS, Azure, GCS) including TLS variants
- Add e2e test `ObservabilityInstallerEmptySpec` that creates an `ObservabilityInstaller` with `spec: {}` on a live cluster, verifies the controller does not crash-loop, no operands are deployed, status fields remain empty, and the resource deletes cleanly

## Root Cause

`observability_controller.go updateStatus` accessed `capabilities.Tracing.Enabled` (a field dereference) without first checking `capabilities.Tracing != nil`. When an `ObservabilityInstaller` is created with `spec: { capabilities: {} }`, `Capabilities` is non-nil but `Tracing` is nil, causing a nil pointer panic. The fix adds the missing nil guard:

```go
// Before
if capabilities.Tracing.Enabled {

// After
if capabilities.Tracing != nil && capabilities.Tracing.Enabled {
```

Note: the related panic in `tempoStack()` (when `spec: {}` leaves `Capabilities` nil) was already fixed via safe getter methods (`GetCapabilities()`, `GetTracing()`, etc.) on the API types.

## Test plan

- [x] `go test ./pkg/controllers/observability/...` — all 17 tests pass including new `TestTempoStack` with nil/empty input cases
- [x] E2e test `TestObservabilityInstallerController/ObservabilityInstallerEmptySpec` passes on a live OCP cluster — controller stays available, no operands deployed, clean deletion.