### PR TITLE
COO-1880:  add NetworkPolicy RBAC for Conforma OCP 5.0 compliance

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ metadata:
     certified: "false"
     console.openshift.io/operator-monitoring-default: "true"
     containerImage: observability-operator:1.5.0
-    createdAt: "2026-06-03T20:54:36Z"
+    createdAt: "2026-06-23T14:39:10Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operatorframework.io/cluster-monitoring: "true"
@@ -565,11 +565,13 @@ spec:
         - apiGroups:
           - networking.k8s.io
           resources:
-          - ingresses
           - networkpolicies
           verbs:
+          - create
+          - delete
           - get
           - list
+          - patch
           - watch
         - apiGroups:
           - observability.openshift.io

--- a/deploy/operator/observability-operator-cluster-role.yaml
+++ b/deploy/operator/observability-operator-cluster-role.yaml
@@ -248,11 +248,13 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingresses
   - networkpolicies
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - observability.openshift.io

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -107,6 +107,7 @@ const (
 //+kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses;volumeattachments,verbs=get;list;watch
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies;ingresses,verbs=get;list;watch
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;patch
 //+kubebuilder:rbac:groups=loki.grafana.com,resources=application;infrastructure;audit;network,verbs=get
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,resourceNames=k8s,verbs=get;create;update
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=alertmanagers/api,resourceNames=main,verbs=get;list


### PR DESCRIPTION
Add networking.k8s.io/networkpolicies RBAC permissions (create, delete,
patch) to the operator's cluster role and bundle CSV.

This satisfies the Conforma policy
olm.required_network_policy_rbac_for_operands, which becomes a release
blocker on August 8, 2026.

Signed-off-by: Daniel Mellado <dmellado@fedoraproject.org>