### PR TITLE
chore: log or return error

### DIFF
--- a/pkg/controllers/monitoring/monitoring-stack/controller.go
+++ b/pkg/controllers/monitoring/monitoring-stack/controller.go
@@ -228,7 +228,6 @@ func (rm resourceManager) getStack(ctx context.Context, req ctrl.Request) (*stac
 			logger.V(3).Info("stack could not be found; may be marked for deletion")
 			return nil, nil
 		}
-		logger.Error(err, "failed to get monitoring stack")
 		return nil, err
 	}
 

--- a/pkg/controllers/observability/observability_controller.go
+++ b/pkg/controllers/observability/observability_controller.go
@@ -102,7 +102,6 @@ func (o observabilityInstallerController) Reconcile(ctx context.Context, request
 	// List all subscriptions to figure out if the operators are already installed
 	err = o.apiReader.List(ctx, subs, &client.ListOptions{})
 	if err != nil {
-		o.logger.Error(err, "Failed to list subscriptions")
 		return ctrl.Result{}, err
 	}
 	reconcilers, err := getReconcilers(ctx, o.client, o.apiReader, instance, o.Options, operatorsStatus{
@@ -110,7 +109,6 @@ func (o observabilityInstallerController) Reconcile(ctx context.Context, request
 		subs:         subs.Items,
 	})
 	if err != nil {
-		o.logger.Error(err, "Failed to get reconcilers")
 		return ctrl.Result{}, err
 	}
 	for _, reconciler := range reconcilers {
@@ -129,7 +127,6 @@ func (o observabilityInstallerController) Reconcile(ctx context.Context, request
 
 	groups, err := o.discoveryClient.ServerGroups()
 	if err != nil {
-		o.logger.Error(err, "Failed to get server groups / CDRs")
 		return ctrl.Result{}, fmt.Errorf("failed to get server groups: %w", err)
 	}
 	for _, group := range groups.Groups {
@@ -196,7 +193,6 @@ func (o observabilityInstallerController) getInstance(ctx context.Context, req c
 			o.logger.V(3).Info("instance could not be found; may be marked for deletion")
 			return nil, nil
 		}
-		o.logger.Error(err, "failed to get cluster observability instance")
 		return nil, err
 	}
 

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -130,7 +130,6 @@ func RegisterWithManager(mgr ctrl.Manager, opts Options) error {
 
 	dynamicClient, err := dynamic.NewForConfig(mgr.GetConfig())
 	if err != nil {
-		logger.Error(err, "failed to create dynamic client")
 		return err
 	}
 
@@ -424,7 +423,6 @@ func (rm resourceManager) getUIPlugin(ctx context.Context, req ctrl.Request) (*u
 			logger.V(3).Info("stack could not be found; may be marked for deletion")
 			return nil, nil
 		}
-		logger.Error(err, "failed to get UIPlugin")
 		return nil, err
 	}
 


### PR DESCRIPTION
This commit removes the "log the error and return it to the caller" patterns. The recommended Go approach is to either log the error or return it to the caller but not both.