### PR TITLE
COO-1975: fix: use case sensitive dao to check correctly uppercase user names

### DIFF
--- a/pkg/controllers/uiplugin/monitoring.go
+++ b/pkg/controllers/uiplugin/monitoring.go
@@ -259,8 +259,9 @@ func newPerses(namespace string, persesImage string) *persesv1alpha2.Perses {
 					},
 					Database: persesconfig.Database{
 						File: &persesconfig.File{
-							Folder:    "/perses",
-							Extension: persesconfig.YAMLExtension,
+							Folder:        "/perses",
+							Extension:     persesconfig.YAMLExtension,
+							CaseSensitive: true,
 						},
 					},
 				},


### PR DESCRIPTION
This enables the case sensitive option for the Perses DAO so the SAR checks also consider user names that need case sensitivity