### PR TITLE
COO-1973: fix: use patch instead of merge when registering plugins in the console

### DIFF
--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
-	"github.com/rhobs/observability-operator/pkg/reconciler"
 )
 
 type resourceManager struct {
@@ -353,16 +352,9 @@ func (rm resourceManager) registerPluginWithConsole(ctx context.Context, pluginI
 		return nil
 	}
 
-	clusterPlugins := append(cluster.Spec.Plugins, pluginInfo.ConsoleName)
-
-	// Register the plugin with the console
-	cluster.Spec.Plugins = clusterPlugins
-
-	if err := reconciler.NewMerger(cluster, pluginInfo.ConsoleName).Reconcile(ctx, rm.k8sClient, rm.scheme); err != nil {
-		return err
-	}
-
-	return nil
+	patch := client.MergeFrom(cluster.DeepCopy())
+	cluster.Spec.Plugins = append(cluster.Spec.Plugins, pluginInfo.ConsoleName)
+	return rm.k8sClient.Patch(ctx, cluster, patch)
 }
 
 func (rm resourceManager) deregisterPluginFromConsole(ctx context.Context, pluginConsoleName string) error {
@@ -375,18 +367,11 @@ func (rm resourceManager) deregisterPluginFromConsole(ctx context.Context, plugi
 		return nil
 	}
 
-	clusterPlugins := slices.DeleteFunc(cluster.Spec.Plugins, func(currentPluginName string) bool {
+	patch := client.MergeFrom(cluster.DeepCopy())
+	cluster.Spec.Plugins = slices.DeleteFunc(cluster.Spec.Plugins, func(currentPluginName string) bool {
 		return currentPluginName == pluginConsoleName
 	})
-
-	// Deregister the plugin from the console
-	cluster.Spec.Plugins = clusterPlugins
-
-	if err := reconciler.NewMerger(cluster, pluginConsoleName).Reconcile(ctx, rm.k8sClient, rm.scheme); err != nil {
-		return err
-	}
-
-	return nil
+	return rm.k8sClient.Patch(ctx, cluster, patch)
 }
 
 func (rm resourceManager) removeLegacyFinalizer(ctx context.Context, plugin *uiv1alpha1.UIPlugin) error {

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -93,23 +93,6 @@ func NewDeleter(r client.Object) Deleter {
 	return Deleter{resource: r}
 }
 
-type Merger struct {
-	resource client.Object
-}
-
-func NewMerger(r client.Object, owner string) Merger {
-	return Merger{resource: util.AddCommonLabels(r, owner)}
-}
-
-func (r Merger) Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme) error {
-	if err := c.Patch(ctx, r.resource, client.Merge); err != nil {
-		return fmt.Errorf("%s/%s (%s): merger failed to patch: %w",
-			r.resource.GetNamespace(), r.resource.GetName(),
-			r.resource.GetObjectKind().GroupVersionKind().String(), err)
-	}
-	return nil
-}
-
 // NewOptionalUpdater ensures that a resource is present or absent depending on the `cond` value (true: present).
 func NewOptionalUpdater(r client.Object, c metav1.Object, cond bool) Reconciler {
 	if cond {


### PR DESCRIPTION
This PR:

- uses patch instead of merge to avoid polluting the console CR when registering plugins
- removes the merger from the reconciler as is not used anymore