### PR TITLE
fix(COO-1863): pass TLS profile args to korrel8r deployment

### DIFF
--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -546,6 +546,14 @@ func componentsHealthClusterRole(name string) *rbacv1.ClusterRole {
 }
 
 func newKorrel8rDeployment(name string, namespace string, info UIPluginInfo) *appsv1.Deployment {
+	command := []string{"korrel8r", "web", fmt.Sprintf("--https=:%d", port), "--cert=/secrets/tls.crt", "--key=/secrets/tls.key", "--config=/config/korrel8r.yaml"}
+	if info.TLSMinVersion != "" {
+		command = append(command, fmt.Sprintf("--tls-min-version=%s", info.TLSMinVersion))
+	}
+	if len(info.TLSCiphers) > 0 {
+		command = append(command, fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(info.TLSCiphers, ",")))
+	}
+
 	volumes := []corev1.Volume{
 		{
 			Name: servingCertVolumeName,
@@ -607,7 +615,7 @@ func newKorrel8rDeployment(name string, namespace string, info UIPluginInfo) *ap
 						{
 							Name:    name,
 							Image:   info.Korrel8rImage,
-							Command: []string{"korrel8r", "web", fmt.Sprintf("--https=:%d", port), "--cert=/secrets/tls.crt", "--key=/secrets/tls.key", "--config=/config/korrel8r.yaml"},
+							Command: command,
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: port,

--- a/pkg/controllers/uiplugin/components_test.go
+++ b/pkg/controllers/uiplugin/components_test.go
@@ -142,6 +142,87 @@ func TestNewDeploymentTLSArgs(t *testing.T) {
 	}
 }
 
+func TestNewKorrel8rDeploymentTLSArgs(t *testing.T) {
+	testCases := []struct {
+		name          string
+		tlsMinVersion string
+		tlsCiphers    []string
+		expectArgs    []string
+		notExpectArgs []string
+	}{
+		{
+			name:          "TLS profile with min version and ciphers",
+			tlsMinVersion: "VersionTLS12",
+			tlsCiphers:    []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+			expectArgs: []string{
+				"--tls-min-version=VersionTLS12",
+				"--tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384",
+			},
+		},
+		{
+			name:          "no TLS profile",
+			tlsMinVersion: "",
+			tlsCiphers:    nil,
+			notExpectArgs: []string{
+				"--tls-min-version=",
+				"--tls-cipher-suites=",
+			},
+		},
+		{
+			name:          "TLS min version only",
+			tlsMinVersion: "VersionTLS13",
+			tlsCiphers:    nil,
+			expectArgs: []string{
+				"--tls-min-version=VersionTLS13",
+			},
+			notExpectArgs: []string{
+				"--tls-cipher-suites=",
+			},
+		},
+		{
+			name:          "TLS ciphers only",
+			tlsMinVersion: "",
+			tlsCiphers:    []string{"TLS_AES_128_GCM_SHA256"},
+			expectArgs: []string{
+				"--tls-cipher-suites=TLS_AES_128_GCM_SHA256",
+			},
+			notExpectArgs: []string{
+				"--tls-min-version=",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := UIPluginInfo{
+				Name:          "test-plugin",
+				Korrel8rImage: "korrel8r:latest",
+				TLSMinVersion: tc.tlsMinVersion,
+				TLSCiphers:    tc.tlsCiphers,
+			}
+
+			deploy := newKorrel8rDeployment("korrel8r", "test-ns", info)
+			command := deploy.Spec.Template.Spec.Containers[0].Command
+
+			// Always expect base command args
+			assert.Assert(t, containsArg(command, "korrel8r"))
+			assert.Assert(t, containsArg(command, "web"))
+			assert.Assert(t, containsArg(command, "--https=:9443"))
+			assert.Assert(t, containsArg(command, "--cert=/secrets/tls.crt"))
+			assert.Assert(t, containsArg(command, "--key=/secrets/tls.key"))
+			assert.Assert(t, containsArg(command, "--config=/config/korrel8r.yaml"))
+
+			for _, expected := range tc.expectArgs {
+				assert.Assert(t, containsArg(command, expected), "expected arg %q not found in %v", expected, command)
+			}
+
+			for _, notExpected := range tc.notExpectArgs {
+				assert.Assert(t, !containsArgPrefix(command, notExpected), "unexpected arg prefix %q found in %v", notExpected, command)
+			}
+		})
+	}
+}
+
 func containsArg(args []string, target string) bool {
 	for _, arg := range args {
 		if arg == target {


### PR DESCRIPTION
Add --tls-min-version and --tls-cipher-suites to the korrel8r deployment.