### PR TITLE
COO-1860: feat: add default global prometheus datasource

### DIFF
--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -158,6 +158,7 @@ func pluginComponentReconcilers(plugin *uiv1alpha1.UIPlugin, pluginInfo UIPlugin
 			reconciler.NewOptionalUpdater(newPersesClusterRole(), plugin, persesEnabled),
 			reconciler.NewOptionalUpdater(newClusterRoleBinding(namespace, persesServiceAccountName, "perses-cr", persesServiceAccountName+"-perses-cr"), plugin, persesEnabled),
 			reconciler.NewOptionalUpdater(newPerses(namespace, pluginInfo.PersesImage), plugin, persesEnabled),
+			reconciler.NewOptionalUpdater(newPrometheusGlobalDatasource(), plugin, persesEnabled),
 			reconciler.NewOptionalUpdater(newAcceleratorsDatasource(namespace), plugin, persesEnabled),
 		)
 

--- a/pkg/controllers/uiplugin/prometheus-global-datasource.go
+++ b/pkg/controllers/uiplugin/prometheus-global-datasource.go
@@ -1,0 +1,58 @@
+package uiplugin
+
+import (
+	specCommon "github.com/perses/spec/go/common"
+	dsSpec "github.com/perses/spec/go/datasource"
+	pluginSpec "github.com/perses/spec/go/plugin"
+	persesv1alpha2 "github.com/rhobs/perses-operator/api/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func newPrometheusGlobalDatasource() *persesv1alpha2.PersesDatasource {
+	return &persesv1alpha2.PersesDatasource{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: persesv1alpha2.GroupVersion.String(),
+			Kind:       "PersesGlobalDatasource",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "global-thanos-querier-datasource",
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "observability-operator",
+			},
+		},
+		Spec: persesv1alpha2.DatasourceSpec{
+			Config: persesv1alpha2.Datasource{
+				Spec: dsSpec.Spec{
+					Display: &specCommon.Display{
+						Name: "Prometheus Global Datasource",
+					},
+					Default: true,
+					Plugin: pluginSpec.Plugin{
+						Kind: "PrometheusDatasource",
+						Spec: map[string]interface{}{
+							"proxy": map[string]interface{}{
+								"kind": "HTTPProxy",
+								"spec": map[string]interface{}{
+									"url":    "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091",
+									"secret": "global-thanos-querier-datasource-secret",
+								},
+							},
+						},
+					},
+				},
+			},
+			Client: &persesv1alpha2.Client{
+				TLS: &persesv1alpha2.TLS{
+					Enable: ptr.To(true),
+					CaCert: &persesv1alpha2.Certificate{
+						SecretSource: persesv1alpha2.SecretSource{
+							Type: persesv1alpha2.SecretSourceTypeFile,
+						},
+						CertPath: "/ca/service-ca.crt",
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Add a default global datasource pointing to the in-cluster Thanos querier. This matches the current behavior of the legacy dashboards included with CMO.