### PR TITLE
fix: add update RBAC for NetworkPolicy resources (#1187)

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ metadata:
     certified: "false"
     console.openshift.io/operator-monitoring-default: "true"
     containerImage: observability-operator:1.5.1
-    createdAt: "2026-06-03T20:54:36Z"
+    createdAt: "2026-08-07T14:07:57Z"
     description: A Go based Kubernetes operator to setup and manage highly available
       Monitoring Stack using Prometheus, Alertmanager and Thanos Querier.
     operatorframework.io/cluster-monitoring: "true"
@@ -565,11 +565,14 @@ spec:
         - apiGroups:
           - networking.k8s.io
           resources:
-          - ingresses
           - networkpolicies
           verbs:
+          - create
+          - delete
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - observability.openshift.io

--- a/deploy/operator/observability-operator-cluster-role.yaml
+++ b/deploy/operator/observability-operator-cluster-role.yaml
@@ -248,11 +248,14 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
-  - ingresses
   - networkpolicies
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - observability.openshift.io

--- a/pkg/apis/doc.go
+++ b/pkg/apis/doc.go
@@ -1,0 +1,4 @@
+// Add RBAC permissions required by the Conforma OCP 5.0 compliance.
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;patch;update
+
+package apis


### PR DESCRIPTION
The Conforma OCP 5.0 compliance policy requires explicitly the `update` permission too.