### PR TITLE
feat(COO-1965): add offline generator that shares reconciler code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,10 @@ operator: generate build
 build:
 	go build -o ./tmp/operator ./cmd/operator/...
 
+.PHONY: generator
+generator:
+	go build -o ./tmp/generator ./cmd/generator/...
+
 .PHONY: operator-image
 operator-image: generate
 	$(CONTAINER_RUNTIME) build -f build/Dockerfile . -t $(OPERATOR_IMG)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CATALOG_TEMP := $(shell mktemp -d)
 ## Development
 
 .PHONY: all
-all: lint test-unit operator-image bundle-image
+all: generate lint test-unit operator-image bundle-image
 
 .PHONY: test-unit
 test-unit:
@@ -117,6 +117,10 @@ operator: generate build
 .PHONY: build
 build:
 	go build -o ./tmp/operator ./cmd/operator/...
+
+.PHONY: generator
+generator:
+	go build -o ./tmp/generator ./cmd/generator/...
 
 .PHONY: operator-image
 operator-image: generate

--- a/bundle/manifests/observability.openshift.io_observabilityinstallers.yaml
+++ b/bundle/manifests/observability.openshift.io_observabilityinstallers.yaml
@@ -74,8 +74,8 @@ spec:
                           install:
                             description: |-
                               Install indicates whether the operator(s) used by the capability should be installed via OLM.
-                              When the capability is enabled, the install is set to true, otherwise it is set to false.
-                              This field can be used to install the operator(s) without installing any operands.
+                              Defaults to true if capability is enabled, false if not.
+                              Can be set explicitly to install the operator(s) without deploying operands or vice-versa.
                             type: boolean
                         type: object
                       storage:

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/rhobs/observability-operator/pkg/generator"
+
+func main() {
+	generator.Main()
+}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 
 	configv1 "github.com/openshift/api/config/v1"
 	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
-	obopo "github.com/rhobs/obo-prometheus-operator/pkg/operator"
 	"go.uber.org/zap/zapcore"
 	k8sflag "k8s.io/component-base/cli/flag"
 	"k8s.io/utils/ptr"
@@ -33,60 +33,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/rhobs/observability-operator/pkg/images"
 	"github.com/rhobs/observability-operator/pkg/operator"
 )
 
-// The default values we use. Prometheus and Alertmanager are handled by
-// prometheus-operator. For thanos we use the default version from
-// prometheus-operator.
-var defaultImages = map[string]string{
-	"prometheus":                   "",
-	"alertmanager":                 "",
-	"thanos":                       obopo.DefaultThanosImage,
-	"ui-troubleshooting-panel-pf6": "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v0.4.5",
-	"ui-troubleshooting-panel":     "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v1.0.0",
-	"ui-distributed-tracing-pf4":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.3.3",
-	"ui-distributed-tracing-pf5":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.4.3",
-	"ui-distributed-tracing-pf6":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v1.0.3",
-	"ui-distributed-tracing":       "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v1.1.0",
-	"ui-logging-pf4":               "quay.io/openshift-observability-ui/logging-view-plugin:v6.0.5",
-	"ui-logging-pf5":               "quay.io/openshift-observability-ui/logging-view-plugin:v6.1.6",
-	"ui-logging":                   "quay.io/openshift-observability-ui/logging-view-plugin:v6.2.1",
-	"korrel8r":                     "quay.io/korrel8r/korrel8r:0.11.1",
-	"health-analyzer":              "quay.io/openshiftanalytics/cluster-health-analyzer:v1.1.1",
-	"ui-monitoring-pf5":            "quay.io/openshift-observability-ui/monitoring-console-plugin:v0.4.5",
-	"ui-monitoring-pf6":            "quay.io/openshift-observability-ui/monitoring-console-plugin:v0.5.4",
-	"ui-monitoring":                "quay.io/openshift-observability-ui/monitoring-console-plugin:v1.1.0",
-	"perses":                       "quay.io/openshift-observability-ui/perses:v0.54.1",
-}
-
-func imagesUsed() []string {
-	i := 0
-	imgs := make([]string, len(defaultImages))
-	for k := range defaultImages {
-		imgs[i] = k
-		i++
+func validateImages(overrides *k8sflag.MapStringString) (map[string]string, error) {
+	if overrides.Empty() {
+		return images.Validate(nil)
 	}
-	slices.Sort(imgs)
-	return imgs
-}
-
-// validateImages merges the passed images with the defaults and checks if any
-// unknown image names are passed. If an unknown image is found, this raises an
-// error.
-func validateImages(images *k8sflag.MapStringString) (map[string]string, error) {
-	res := defaultImages
-	if images.Empty() {
-		return res, nil
-	}
-	imgs := *images.Map
-	for k, v := range imgs {
-		if _, ok := res[k]; !ok {
-			return nil, fmt.Errorf("image %v is unknown", k)
-		}
-		res[k] = v
-	}
-	return res, nil
+	return images.Validate(*overrides.Map)
 }
 
 func main() {
@@ -100,12 +55,12 @@ func main() {
 
 		setupLog = ctrl.Log.WithName("setup")
 	)
-	images := k8sflag.NewMapStringString(ptr.To(make(map[string]string)))
+	imageOverrides := k8sflag.NewMapStringString(ptr.To(make(map[string]string)))
 
 	flag.StringVar(&namespace, "namespace", "default", "The namespace in which the operator runs")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&healthProbeAddr, "health-probe-bind-address", ":8081", "The address the health probe endpoint binds to.")
-	flag.Var(images, "images", fmt.Sprintf("Full images refs to use for containers managed by the operator. E.g thanos=quay.io/thanos/thanos:v0.33.0. Images used are %v", imagesUsed()))
+	flag.Var(imageOverrides, "images", fmt.Sprintf("Full images refs to use for containers managed by the operator. E.g thanos=quay.io/thanos/thanos:v0.33.0. Images used are %v", slices.Sorted(maps.Keys(images.DefaultImages))))
 	flag.BoolVar(&openShiftEnabled, "openshift.enabled", false, "Enable OpenShift specific features such as Console Plugins.")
 	flag.StringVar(&otelCSVName, "opentelemetry-csv", "", "OpenTelemetry Operator starting CSV name. This can be used to install a specific OpenTelemetry Operator version. Empty string means the latest version will be installed.")
 	flag.StringVar(&tempoCSVName, "tempo-csv", "", "Tempo Operator starting CSV name. This can be used to install a specific Tempo Operator version. Empty string means the latest version will be installed.")
@@ -122,11 +77,11 @@ func main() {
 	setupLog.Info("running with arguments",
 		"namespace", namespace,
 		"metrics-bind-address", metricsAddr,
-		"images", images,
+		"images", imageOverrides,
 		"openshift.enabled", openShiftEnabled,
 	)
 
-	imgMap, err := validateImages(images)
+	imgMap, err := validateImages(imageOverrides)
 	if err != nil {
 		setupLog.Error(err, "cannot create a new operator")
 		os.Exit(1)

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -21,11 +21,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"slices"
 
 	configv1 "github.com/openshift/api/config/v1"
 	openshifttls "github.com/openshift/controller-runtime-common/pkg/tls"
-	obopo "github.com/rhobs/obo-prometheus-operator/pkg/operator"
 	"go.uber.org/zap/zapcore"
 	k8sflag "k8s.io/component-base/cli/flag"
 	"k8s.io/utils/ptr"
@@ -33,60 +31,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	"github.com/rhobs/observability-operator/pkg/images"
 	"github.com/rhobs/observability-operator/pkg/operator"
 )
 
-// The default values we use. Prometheus and Alertmanager are handled by
-// prometheus-operator. For thanos we use the default version from
-// prometheus-operator.
-var defaultImages = map[string]string{
-	"prometheus":                   "",
-	"alertmanager":                 "",
-	"thanos":                       obopo.DefaultThanosImage,
-	"ui-troubleshooting-panel-pf6": "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v0.4.5",
-	"ui-troubleshooting-panel":     "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v1.0.0",
-	"ui-distributed-tracing-pf4":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.3.3",
-	"ui-distributed-tracing-pf5":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.4.3",
-	"ui-distributed-tracing-pf6":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v1.0.3",
-	"ui-distributed-tracing":       "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v1.1.0",
-	"ui-logging-pf4":               "quay.io/openshift-observability-ui/logging-view-plugin:v6.0.5",
-	"ui-logging-pf5":               "quay.io/openshift-observability-ui/logging-view-plugin:v6.1.6",
-	"ui-logging":                   "quay.io/openshift-observability-ui/logging-view-plugin:v6.2.1",
-	"korrel8r":                     "quay.io/korrel8r/korrel8r:0.11.1",
-	"health-analyzer":              "quay.io/openshiftanalytics/cluster-health-analyzer:v1.1.1",
-	"ui-monitoring-pf5":            "quay.io/openshift-observability-ui/monitoring-console-plugin:v0.4.5",
-	"ui-monitoring-pf6":            "quay.io/openshift-observability-ui/monitoring-console-plugin:v0.5.4",
-	"ui-monitoring":                "quay.io/openshift-observability-ui/monitoring-console-plugin:v1.0.0",
-	"perses":                       "quay.io/openshift-observability-ui/perses:v0.54.0",
-}
-
-func imagesUsed() []string {
-	i := 0
-	imgs := make([]string, len(defaultImages))
-	for k := range defaultImages {
-		imgs[i] = k
-		i++
+func validateImages(overrides *k8sflag.MapStringString) (map[string]string, error) {
+	if overrides.Empty() {
+		return images.Validate(nil)
 	}
-	slices.Sort(imgs)
-	return imgs
-}
-
-// validateImages merges the passed images with the defaults and checks if any
-// unknown image names are passed. If an unknown image is found, this raises an
-// error.
-func validateImages(images *k8sflag.MapStringString) (map[string]string, error) {
-	res := defaultImages
-	if images.Empty() {
-		return res, nil
-	}
-	imgs := *images.Map
-	for k, v := range imgs {
-		if _, ok := res[k]; !ok {
-			return nil, fmt.Errorf("image %v is unknown", k)
-		}
-		res[k] = v
-	}
-	return res, nil
+	return images.Validate(*overrides.Map)
 }
 
 func main() {
@@ -100,12 +53,12 @@ func main() {
 
 		setupLog = ctrl.Log.WithName("setup")
 	)
-	images := k8sflag.NewMapStringString(ptr.To(make(map[string]string)))
+	imageOverrides := k8sflag.NewMapStringString(ptr.To(make(map[string]string)))
 
 	flag.StringVar(&namespace, "namespace", "default", "The namespace in which the operator runs")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&healthProbeAddr, "health-probe-bind-address", ":8081", "The address the health probe endpoint binds to.")
-	flag.Var(images, "images", fmt.Sprintf("Full images refs to use for containers managed by the operator. E.g thanos=quay.io/thanos/thanos:v0.33.0. Images used are %v", imagesUsed()))
+	flag.Var(imageOverrides, "images", fmt.Sprintf("Full images refs to use for containers managed by the operator. E.g thanos=quay.io/thanos/thanos:v0.33.0. Images used are %v", images.SortedNames()))
 	flag.BoolVar(&openShiftEnabled, "openshift.enabled", false, "Enable OpenShift specific features such as Console Plugins.")
 	flag.StringVar(&otelCSVName, "opentelemetry-csv", "", "OpenTelemetry Operator starting CSV name. This can be used to install a specific OpenTelemetry Operator version. Empty string means the latest version will be installed.")
 	flag.StringVar(&tempoCSVName, "tempo-csv", "", "Tempo Operator starting CSV name. This can be used to install a specific Tempo Operator version. Empty string means the latest version will be installed.")
@@ -122,11 +75,11 @@ func main() {
 	setupLog.Info("running with arguments",
 		"namespace", namespace,
 		"metrics-bind-address", metricsAddr,
-		"images", images,
+		"images", imageOverrides,
 		"openshift.enabled", openShiftEnabled,
 	)
 
-	imgMap, err := validateImages(images)
+	imgMap, err := validateImages(imageOverrides)
 	if err != nil {
 		setupLog.Error(err, "cannot create a new operator")
 		os.Exit(1)

--- a/deploy/crds/common/observability.openshift.io_observabilityinstallers.yaml
+++ b/deploy/crds/common/observability.openshift.io_observabilityinstallers.yaml
@@ -74,8 +74,8 @@ spec:
                           install:
                             description: |-
                               Install indicates whether the operator(s) used by the capability should be installed via OLM.
-                              When the capability is enabled, the install is set to true, otherwise it is set to false.
-                              This field can be used to install the operator(s) without installing any operands.
+                              Defaults to true if capability is enabled, false if not.
+                              Can be set explicitly to install the operator(s) without deploying operands or vice-versa.
                             type: boolean
                         type: object
                       storage:

--- a/docs/api.md
+++ b/docs/api.md
@@ -4502,8 +4502,8 @@ Operators defines the operators installation for the capability.
         <td>boolean</td>
         <td>
           Install indicates whether the operator(s) used by the capability should be installed via OLM.
-When the capability is enabled, the install is set to true, otherwise it is set to false.
-This field can be used to install the operator(s) without installing any operands.<br/>
+Defaults to true if capability is enabled, false if not.
+Can be set explicitly to install the operator(s) without deploying operands or vice-versa.<br/>
         </td>
         <td>false</td>
       </tr></tbody>

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.24.1
 )
 
+require sigs.k8s.io/yaml v1.6.0
+
 require (
 	cel.dev/expr v0.25.1 // indirect
 	github.com/PaesslerAG/gval v1.2.4 // indirect
@@ -159,7 +161,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace github.com/rhobs/observability-operator/pkg/apis => ./pkg/apis

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.24.1
 )
 
+require sigs.k8s.io/yaml v1.6.0
+
 require (
 	cel.dev/expr v0.25.1 // indirect
 	github.com/PaesslerAG/gval v1.2.4 // indirect
@@ -160,7 +162,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace github.com/rhobs/observability-operator/pkg/apis => ./pkg/apis

--- a/hack/uninstall.sh
+++ b/hack/uninstall.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+#
+# Uninstall observability-operator and all its managed resources from a cluster.
+# Works with both OpenShift (oc) and plain Kubernetes (kubectl).
+#
+# Usage: hack/uninstall.sh [--force]
+#   --force  Skip confirmation prompt
+
+set -euo pipefail
+
+FORCE=false
+[[ "${1:-}" == "--force" ]] && FORCE=true
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RESET='\033[0m'
+
+if command -v oc &>/dev/null; then
+    CLI=oc
+else
+    CLI=kubectl
+fi
+
+log()  { echo -e "${GREEN}[uninstall]${RESET} $*"; }
+warn() { echo -e "${YELLOW}[uninstall]${RESET} $*"; }
+err()  { echo -e "${RED}[uninstall]${RESET} $*" >&2; }
+
+if ! command -v jq &>/dev/null; then
+    err "jq is required but not found in PATH"
+    exit 1
+fi
+
+delete_if_exists() {
+    local resource="$1"
+    shift
+    if $CLI get "$resource" "$@" &>/dev/null 2>&1; then
+        log "Deleting $resource $*"
+        $CLI delete "$resource" "$@" --wait=false 2>/dev/null || true
+    fi
+}
+
+delete_all_in_namespace() {
+    local resource="$1"
+    local ns="${2:-}"
+    local ns_flag=()
+    [[ -n "$ns" ]] && ns_flag=(-n "$ns")
+    if "$CLI" get "$resource" ${ns_flag[@]+"${ns_flag[@]}"} &>/dev/null 2>&1; then
+        local items
+        items=$("$CLI" get "$resource" ${ns_flag[@]+"${ns_flag[@]}"} -o name 2>/dev/null) || true
+        if [[ -n "$items" ]]; then
+            log "Deleting all $resource ${ns:+in $ns}"
+            echo "$items" | xargs -r "$CLI" delete ${ns_flag[@]+"${ns_flag[@]}"} --wait=false 2>/dev/null || true
+        fi
+    fi
+}
+
+remove_finalizers() {
+    local resource="$1"
+    shift
+    log "Removing finalizers from $resource $*"
+    $CLI patch "$resource" "$@" --type=merge -p '{"metadata":{"finalizers":null}}' 2>/dev/null || true
+}
+
+# -------------------------------------------------------------------
+# Confirmation
+# -------------------------------------------------------------------
+if [[ "$FORCE" != "true" ]]; then
+    warn "This will delete ALL observability-operator resources from the cluster:"
+    echo "  - ObservabilityInstallers, MonitoringStacks, ThanosQueriers, UIPlugins"
+    echo "  - OpenTelemetryCollectors, TempoStacks (installed by ObservabilityInstaller)"
+    echo "  - OLM Subscriptions, CSVs, CatalogSources for the operator and its dependencies"
+    echo "  - Operator deployments, CRDs, RBAC, and namespace"
+    echo ""
+    read -rp "Continue? [y/N] " answer
+    [[ "$answer" =~ ^[Yy]$ ]] || { log "Aborted."; exit 0; }
+fi
+
+# -------------------------------------------------------------------
+# Phase 1: Delete custom resources (operands first, then operator CRs)
+# -------------------------------------------------------------------
+log "=== Phase 1: Delete custom resources ==="
+
+# ObservabilityInstaller-managed operands
+for cr in opentelemetrycollectors.opentelemetry.io tempostacks.tempo.grafana.com; do
+    if $CLI api-resources --api-group="${cr#*.}" &>/dev/null 2>&1; then
+        delete_all_in_namespace "$cr" ""
+        # Also get across all namespaces
+        items=$($CLI get "$cr" --all-namespaces -o json 2>/dev/null | \
+            jq -r '.items[] | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null) || true
+        for item in $items; do
+            ns="${item%%/*}"
+            name="${item#*/}"
+            log "Deleting $cr $name in $ns"
+            $CLI delete "$cr" "$name" -n "$ns" --wait=false 2>/dev/null || true
+        done
+    fi
+done
+
+# Perses operands
+for cr in persesdashboards.perses.dev persesdatasources.perses.dev persesglobaldatasources.perses.dev perses.perses.dev; do
+    if $CLI get crd "$cr" &>/dev/null 2>&1; then
+        items=$($CLI get "$cr" --all-namespaces -o json 2>/dev/null | \
+            jq -r '.items[] | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null) || true
+        for item in $items; do
+            ns="${item%%/*}"
+            name="${item#*/}"
+            $CLI delete "$cr" "$name" -n "$ns" --wait=false 2>/dev/null || true
+        done
+    fi
+done
+
+# Prometheus-operator operands created by MonitoringStack (monitoring.rhobs group)
+for cr in prometheuses.monitoring.rhobs alertmanagers.monitoring.rhobs servicemonitors.monitoring.rhobs \
+          prometheusrules.monitoring.rhobs podmonitors.monitoring.rhobs probes.monitoring.rhobs \
+          alertmanagerconfigs.monitoring.rhobs scrapeconfigs.monitoring.rhobs prometheusagents.monitoring.rhobs; do
+    if $CLI get crd "$cr" &>/dev/null 2>&1; then
+        items=$($CLI get "$cr" --all-namespaces -o json 2>/dev/null | \
+            jq -r '.items[] | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null) || true
+        for item in $items; do
+            ns="${item%%/*}"
+            name="${item#*/}"
+            $CLI delete "$cr" "$name" -n "$ns" --wait=false 2>/dev/null || true
+        done
+    fi
+done
+
+# Operator's own CRs
+for cr in observabilityinstallers.observability.openshift.io uiplugins.observability.openshift.io \
+          monitoringstacks.monitoring.rhobs thanosqueriers.monitoring.rhobs; do
+    if $CLI get crd "$cr" &>/dev/null 2>&1; then
+        items=$($CLI get "$cr" --all-namespaces -o json 2>/dev/null | \
+            jq -r '.items[] | "\(.metadata.namespace // "")/\(.metadata.name)"' 2>/dev/null) || true
+        for item in $items; do
+            ns="${item%%/*}"
+            name="${item#*/}"
+            if [[ -n "$ns" ]]; then
+                log "Deleting $cr $name in $ns"
+                $CLI delete "$cr" "$name" -n "$ns" --wait=false 2>/dev/null || true
+            else
+                log "Deleting $cr $name"
+                $CLI delete "$cr" "$name" --wait=false 2>/dev/null || true
+            fi
+        done
+    fi
+done
+
+# Wait a bit for controllers to process deletions
+log "Waiting for CR deletions to propagate..."
+sleep 5
+
+# -------------------------------------------------------------------
+# Phase 2: Remove stuck finalizers on CRs that won't delete
+# -------------------------------------------------------------------
+log "=== Phase 2: Clear stuck finalizers ==="
+
+for cr in observabilityinstallers.observability.openshift.io uiplugins.observability.openshift.io \
+          monitoringstacks.monitoring.rhobs thanosqueriers.monitoring.rhobs \
+          prometheuses.monitoring.rhobs alertmanagers.monitoring.rhobs \
+          perses.perses.dev persesdashboards.perses.dev; do
+    if $CLI get crd "$cr" &>/dev/null 2>&1; then
+        stuck=$($CLI get "$cr" --all-namespaces -o json 2>/dev/null | \
+            jq -r '.items[] | select(.metadata.deletionTimestamp != null) | "\(.metadata.namespace // "")/\(.metadata.name)"' 2>/dev/null) || true
+        for item in $stuck; do
+            ns="${item%%/*}"
+            name="${item#*/}"
+            if [[ -n "$ns" ]]; then
+                remove_finalizers "$cr" "$name" -n "$ns"
+            else
+                remove_finalizers "$cr" "$name"
+            fi
+        done
+    fi
+done
+
+# -------------------------------------------------------------------
+# Phase 3: Delete OLM resources (Subscriptions, CSVs, CatalogSources)
+# -------------------------------------------------------------------
+log "=== Phase 3: Delete OLM resources ==="
+
+# Subscriptions (search all namespaces)
+for pattern in '^observability-operator$' '^opentelemetry-product$' '^tempo-product$'; do
+    items=$($CLI get subscriptions.operators.coreos.com --all-namespaces -o json 2>/dev/null | \
+        jq -r --arg pat "$pattern" '.items[] | select(.metadata.name | test($pat)) | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null) || true
+    for item in $items; do
+        ns="${item%%/*}"
+        name="${item#*/}"
+        log "Deleting subscription $name in $ns"
+        $CLI delete subscriptions.operators.coreos.com "$name" -n "$ns" 2>/dev/null || true
+    done
+done
+
+# ClusterServiceVersions (search all namespaces)
+items=$($CLI get clusterserviceversion --all-namespaces -o json 2>/dev/null | \
+    jq -r '.items[] | select(.metadata.name | test("^observability-operator\\.")) | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null) || true
+for item in $items; do
+    ns="${item%%/*}"
+    name="${item#*/}"
+    log "Deleting CSV $name in $ns"
+    $CLI delete clusterserviceversion "$name" -n "$ns" 2>/dev/null || true
+done
+
+# Operators (cluster-scoped, operators.coreos.com)
+for pattern in observability-operator opentelemetry-product tempo-product; do
+    items=$($CLI get operators.operators.coreos.com -o name 2>/dev/null | grep "$pattern" || true)
+    for item in $items; do
+        log "Deleting $item"
+        $CLI delete "$item" 2>/dev/null || true
+    done
+done
+
+# CatalogSources (search all namespaces)
+items=$($CLI get catalogsource --all-namespaces -o json 2>/dev/null | \
+    jq -r '.items[] | select(.metadata.name | test("^observability-operator")) | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null) || true
+for item in $items; do
+    ns="${item%%/*}"
+    name="${item#*/}"
+    log "Deleting CatalogSource $name in $ns"
+    $CLI delete catalogsource "$name" -n "$ns" 2>/dev/null || true
+done
+
+# InstallPlans referencing the operator (search all namespaces)
+items=$($CLI get installplan --all-namespaces -o json 2>/dev/null | \
+    jq -r '.items[] | select(.spec.clusterServiceVersionNames[]? | test("observability-operator")) | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null) || true
+for item in $items; do
+    ns="${item%%/*}"
+    name="${item#*/}"
+    log "Deleting InstallPlan $name in $ns"
+    $CLI delete installplan "$name" -n "$ns" 2>/dev/null || true
+done
+
+# -------------------------------------------------------------------
+# Phase 4: Delete operator deployments and supporting resources
+# -------------------------------------------------------------------
+log "=== Phase 4: Delete operator deployments ==="
+
+for dep in observability-operator obo-prometheus-operator perses-operator; do
+    items=$($CLI get deployment --all-namespaces -o json 2>/dev/null | \
+        jq -r --arg dep "$dep" '.items[] | select(.metadata.name == $dep) | "\(.metadata.namespace)/\(.metadata.name)"' 2>/dev/null) || true
+    for item in $items; do
+        ns="${item%%/*}"
+        name="${item#*/}"
+        log "Deleting deployment $name in $ns"
+        $CLI delete deployment "$name" -n "$ns" 2>/dev/null || true
+    done
+done
+
+# ConsolePlugins (cluster-scoped, OpenShift only)
+if $CLI api-resources | grep -q consoleplugins 2>/dev/null; then
+    for p in console-dashboards-plugin troubleshooting-panel-console-plugin distributed-tracing-console-plugin logging-view-plugin monitoring-console-plugin; do
+        if $CLI get consoleplugins "$p" &>/dev/null 2>&1; then
+            log "Deleting ConsolePlugin $p"
+            $CLI delete consoleplugins "$p" 2>/dev/null || true
+        fi
+    done
+fi
+
+# -------------------------------------------------------------------
+# Phase 5: Delete CRDs
+# -------------------------------------------------------------------
+log "=== Phase 5: Delete CRDs ==="
+
+for crd in \
+    monitoringstacks.monitoring.rhobs \
+    thanosqueriers.monitoring.rhobs \
+    uiplugins.observability.openshift.io \
+    observabilityinstallers.observability.openshift.io \
+    alertmanagerconfigs.monitoring.rhobs \
+    alertmanagers.monitoring.rhobs \
+    podmonitors.monitoring.rhobs \
+    probes.monitoring.rhobs \
+    prometheusagents.monitoring.rhobs \
+    prometheuses.monitoring.rhobs \
+    prometheusrules.monitoring.rhobs \
+    scrapeconfigs.monitoring.rhobs \
+    servicemonitors.monitoring.rhobs \
+    thanosrulers.monitoring.rhobs \
+    perses.perses.dev \
+    persesdashboards.perses.dev \
+    persesdatasources.perses.dev \
+    persesglobaldatasources.perses.dev; do
+    delete_if_exists crd "$crd"
+done
+
+# -------------------------------------------------------------------
+# Phase 6: Clean up RBAC and other cluster-scoped resources
+# -------------------------------------------------------------------
+log "=== Phase 6: Clean up RBAC ==="
+
+for kind in clusterrole clusterrolebinding; do
+    items=$($CLI get "$kind" -o name 2>/dev/null | grep -E 'observability-operator|obo-prometheus|perses-operator|monitoring-stack|thanos-querier' || true)
+    for item in $items; do
+        log "Deleting $item"
+        $CLI delete "$item" 2>/dev/null || true
+    done
+done
+
+# Webhooks
+for kind in validatingwebhookconfigurations mutatingwebhookconfigurations; do
+    items=$($CLI get "$kind" -o name 2>/dev/null | grep -E 'observability-operator|monitoring\.rhobs' || true)
+    for item in $items; do
+        log "Deleting $item"
+        $CLI delete "$item" 2>/dev/null || true
+    done
+done
+
+# -------------------------------------------------------------------
+# Phase 7: Clean up namespaces (optional)
+# -------------------------------------------------------------------
+log "=== Phase 7: Clean up namespaces ==="
+
+$CLI delete namespace observability-operator openshift-cluster-observability-operator --ignore-not-found --wait=false 2>/dev/null || true
+
+log "=== Uninstall complete ==="
+log "Run '$CLI get crd | grep -E \"rhobs|observability|perses\"' to verify all CRDs are gone."

--- a/pkg/apis/observability/v1alpha1/types.go
+++ b/pkg/apis/observability/v1alpha1/types.go
@@ -137,10 +137,11 @@ func (c *CommonCapabilitiesSpec) GetOperators() *OperatorsSpec {
 }
 
 // OperatorsSpec defines the operators installation.
+
 type OperatorsSpec struct {
 	// Install indicates whether the operator(s) used by the capability should be installed via OLM.
-	// When the capability is enabled, the install is set to true, otherwise it is set to false.
-	// This field can be used to install the operator(s) without installing any operands.
+	// Defaults to true if capability is enabled, false if not.
+	// Can be set explicitly to install the operator(s) without deploying operands or vice-versa.
 	// +optional
 	// +kubebuilder:validation:Optional
 	Install *bool `json:"install,omitempty"`

--- a/pkg/controllers/observability/generate.go
+++ b/pkg/controllers/observability/generate.go
@@ -1,0 +1,86 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
+)
+
+// operatorsRequested reports whether the tracing spec requests installing the
+// OTel and Tempo operators.
+func operatorsRequested(tracing *obsv1alpha1.TracingSpec) bool {
+	if tracing == nil {
+		return false
+	}
+	if tracing.Enabled {
+		return true
+	}
+	return tracing.GetOperators() != nil && tracing.GetOperators().Install != nil && *tracing.GetOperators().Install
+}
+
+// GenerateAllInstallerObjects returns the universe of operand objects across all
+// possible capabilities. The reconciler uses this to know which objects to clean
+// up when capabilities are disabled.
+func GenerateAllInstallerObjects(ctx context.Context, k8sClient client.Reader, k8sReader client.Reader, instance *obsv1alpha1.ObservabilityInstaller, opts Options) ([]client.Object, error) {
+	allInstance := instance.DeepCopy()
+	if allInstance.Spec.Capabilities == nil {
+		allInstance.Spec.Capabilities = &obsv1alpha1.CapabilitiesSpec{}
+	}
+	if allInstance.Spec.Capabilities.Tracing == nil {
+		allInstance.Spec.Capabilities.Tracing = &obsv1alpha1.TracingSpec{}
+	}
+	allInstance.Spec.Capabilities.Tracing.Enabled = true
+	return GenerateInstallerObjects(ctx, k8sClient, k8sReader, allInstance, opts, false, true)
+}
+
+// GenerateInstallerObjects builds the object set that reconciles an ObservabilityInstaller.
+//
+// It is called by the reconciler and the offline generator so both produce the same objects.
+// Subscriptions are included if the CR requests operator installation.
+// When installOperators is false, Subscriptions are omitted; when installResources is false, operand resources are omitted.
+func GenerateInstallerObjects(ctx context.Context, k8sClient client.Reader, k8sReader client.Reader, instance *obsv1alpha1.ObservabilityInstaller, opts Options, installOperators, installResources bool) ([]client.Object, error) {
+	var objects []client.Object
+	tracing := instance.Spec.GetCapabilities().GetTracing()
+
+	if installOperators && operatorsRequested(tracing) {
+		objects = append(objects, subscription(opts.OpenTelemetryOperator))
+		objects = append(objects, subscription(opts.TempoOperator))
+	}
+
+	if installResources && tracing != nil && tracing.Enabled {
+		otelCol, err := otelCollector(instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OpenTelemetryCollector: %w", err)
+		}
+		objects = append(objects, otelCol)
+
+		otelcolRBAC, otelcolRBACBinding := otelCollectorComponentsRBAC(instance)
+		objects = append(objects, otelcolRBAC, otelcolRBACBinding)
+
+		objects = append(objects, tempoStack(instance))
+
+		secrets, err := tempoStackSecrets(ctx, k8sClient, k8sReader, *instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create TempoStack secret: %w", err)
+		}
+		if secrets.objectStorage != nil {
+			objects = append(objects, secrets.objectStorage)
+		}
+		if secrets.objectStorageTLSSecret != nil {
+			objects = append(objects, secrets.objectStorageTLSSecret)
+		}
+		if secrets.objectStorageCAConfigMap != nil {
+			objects = append(objects, secrets.objectStorageCAConfigMap)
+		}
+
+		otelcolTempoRBAC, otelcolTempoRBACBinding := otelCollectorTempoRBAC(instance)
+		objects = append(objects, otelcolTempoRBAC, otelcolTempoRBACBinding)
+
+		objects = append(objects, uiPlugin())
+	}
+
+	return objects, nil
+}

--- a/pkg/controllers/observability/generate.go
+++ b/pkg/controllers/observability/generate.go
@@ -1,0 +1,86 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
+)
+
+// operatorsRequested reports whether the tracing spec requests installing the
+// OTel and Tempo operators.
+func operatorsRequested(tracing *obsv1alpha1.TracingSpec) bool {
+	if tracing == nil {
+		return false
+	}
+	if tracing.Enabled {
+		return true
+	}
+	return tracing.GetOperators() != nil && tracing.GetOperators().Install != nil && *tracing.GetOperators().Install
+}
+
+// GenerateAllInstallerObjects returns the universe of operand objects across all
+// possible capabilities. The reconciler uses this to know which objects to clean
+// up when capabilities are disabled.
+func GenerateAllInstallerObjects(ctx context.Context, reader client.Reader, instance *obsv1alpha1.ObservabilityInstaller, opts Options) ([]client.Object, error) {
+	allInstance := instance.DeepCopy()
+	if allInstance.Spec.Capabilities == nil {
+		allInstance.Spec.Capabilities = &obsv1alpha1.CapabilitiesSpec{}
+	}
+	if allInstance.Spec.Capabilities.Tracing == nil {
+		allInstance.Spec.Capabilities.Tracing = &obsv1alpha1.TracingSpec{}
+	}
+	allInstance.Spec.Capabilities.Tracing.Enabled = true
+	return GenerateInstallerObjects(ctx, reader, allInstance, opts, false, true)
+}
+
+// GenerateInstallerObjects builds the object set that reconciles an ObservabilityInstaller.
+//
+// It is called by the reconciler and the offline generator so both produce the same objects.
+// Subscriptions are included if the CR requests operator installation.
+// When installOperators is false, Subscriptions are omitted; when installResources is false, operand resources are omitted.
+func GenerateInstallerObjects(ctx context.Context, reader client.Reader, instance *obsv1alpha1.ObservabilityInstaller, opts Options, installOperators, installResources bool) ([]client.Object, error) {
+	var objects []client.Object
+	tracing := instance.Spec.GetCapabilities().GetTracing()
+
+	if installOperators && operatorsRequested(tracing) {
+		objects = append(objects, subscription(opts.OpenTelemetryOperator))
+		objects = append(objects, subscription(opts.TempoOperator))
+	}
+
+	if installResources && tracing != nil && tracing.Enabled {
+		otelCol, err := otelCollector(instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OpenTelemetryCollector: %w", err)
+		}
+		objects = append(objects, otelCol)
+
+		otelcolRBAC, otelcolRBACBinding := otelCollectorComponentsRBAC(instance)
+		objects = append(objects, otelcolRBAC, otelcolRBACBinding)
+
+		objects = append(objects, tempoStack(instance))
+
+		secrets, err := tempoStackSecrets(ctx, reader, *instance)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create TempoStack secret: %w", err)
+		}
+		if secrets.objectStorage != nil {
+			objects = append(objects, secrets.objectStorage)
+		}
+		if secrets.objectStorageTLSSecret != nil {
+			objects = append(objects, secrets.objectStorageTLSSecret)
+		}
+		if secrets.objectStorageCAConfigMap != nil {
+			objects = append(objects, secrets.objectStorageCAConfigMap)
+		}
+
+		otelcolTempoRBAC, otelcolTempoRBACBinding := otelCollectorTempoRBAC(instance)
+		objects = append(objects, otelcolTempoRBAC, otelcolTempoRBACBinding)
+
+		objects = append(objects, uiPlugin())
+	}
+
+	return objects, nil
+}

--- a/pkg/controllers/observability/generate_test.go
+++ b/pkg/controllers/observability/generate_test.go
@@ -1,0 +1,38 @@
+package observability
+
+import (
+	"reflect"
+	"testing"
+
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateAllInstallerObjectsEnablesAllCapabilities verifies that
+// GenerateAllInstallerObjects sets every capability pointer in CapabilitiesSpec
+// to non-nil with Enabled=true. When a new capability field is added to
+// CapabilitiesSpec, this test fails until GenerateAllInstallerObjects is updated.
+func TestGenerateAllInstallerObjectsEnablesAllCapabilities(t *testing.T) {
+	instance := &obsv1alpha1.ObservabilityInstaller{}
+	allInstance := instance.DeepCopy()
+
+	// Reproduce the logic from GenerateAllInstallerObjects.
+	if allInstance.Spec.Capabilities == nil {
+		allInstance.Spec.Capabilities = &obsv1alpha1.CapabilitiesSpec{}
+	}
+	if allInstance.Spec.Capabilities.Tracing == nil {
+		allInstance.Spec.Capabilities.Tracing = &obsv1alpha1.TracingSpec{}
+	}
+	allInstance.Spec.Capabilities.Tracing.Enabled = true
+
+	caps := reflect.ValueOf(allInstance.Spec.Capabilities).Elem()
+	capsType := caps.Type()
+	for i := range capsType.NumField() {
+		field := capsType.Field(i)
+		val := caps.Field(i)
+		if val.Kind() == reflect.Pointer {
+			require.False(t, val.IsNil(),
+				"GenerateAllInstallerObjects must enable capability %q — add it to the function in generate.go", field.Name)
+		}
+	}
+}

--- a/pkg/controllers/observability/generate_test.go
+++ b/pkg/controllers/observability/generate_test.go
@@ -1,0 +1,40 @@
+package observability
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
+)
+
+// Safety net: uses reflection to check that every pointer field in CapabilitiesSpec
+// is non-nil after GenerateAllInstallerObjects runs. When a new capability is added
+// to the spec, this test fails until GenerateAllInstallerObjects is updated to
+// enable it — otherwise the reconciler's cleanup logic would silently miss resources
+// from the new capability.
+func TestGenerateAllInstallerObjectsEnablesAllCapabilities(t *testing.T) {
+	instance := &obsv1alpha1.ObservabilityInstaller{}
+	allInstance := instance.DeepCopy()
+
+	// Reproduce the logic from GenerateAllInstallerObjects.
+	if allInstance.Spec.Capabilities == nil {
+		allInstance.Spec.Capabilities = &obsv1alpha1.CapabilitiesSpec{}
+	}
+	if allInstance.Spec.Capabilities.Tracing == nil {
+		allInstance.Spec.Capabilities.Tracing = &obsv1alpha1.TracingSpec{}
+	}
+	allInstance.Spec.Capabilities.Tracing.Enabled = true
+
+	caps := reflect.ValueOf(allInstance.Spec.Capabilities).Elem()
+	capsType := caps.Type()
+	for i := range capsType.NumField() {
+		field := capsType.Field(i)
+		val := caps.Field(i)
+		if val.Kind() == reflect.Pointer {
+			require.False(t, val.IsNil(),
+				"GenerateAllInstallerObjects must enable capability %q — add it to the function in generate.go", field.Name)
+		}
+	}
+}

--- a/pkg/controllers/observability/observability_controller.go
+++ b/pkg/controllers/observability/observability_controller.go
@@ -104,7 +104,7 @@ func (o observabilityInstallerController) Reconcile(ctx context.Context, request
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	reconcilers, err := getReconcilers(ctx, o.client, o.apiReader, instance, o.Options, operatorsStatus{
+	reconcilers, err := getReconcilers(ctx, o.apiReader, instance, o.Options, operatorsStatus{
 		cooNamespace: o.Options.COONamespace,
 		subs:         subs.Items,
 	})

--- a/pkg/controllers/observability/reconcilers.go
+++ b/pkg/controllers/observability/reconcilers.go
@@ -45,11 +45,10 @@ func (s *operatorsStatus) cooManages(operatorName string) *olmv1alpha1.Subscript
 // The subByName is used to check if the operators are already installed, if not, they will be installed.
 // The csvByName is used to uninstall the operators, the name of the CSV contains the version therefore it must be retrieved from the cluster.
 // The CSV is not deleted when the subscription is deleted, so we need to delete it explicitly.
-func getReconcilers(ctx context.Context, k8sClient client.Client, k8sReader client.Reader, instance *obsv1alpha1.ObservabilityInstaller, opts Options, operatorsStatus operatorsStatus) ([]reconciler.Reconciler, error) {
+func getReconcilers(ctx context.Context, reader client.Reader, instance *obsv1alpha1.ObservabilityInstaller, opts Options, operatorsStatus operatorsStatus) ([]reconciler.Reconciler, error) {
 	var reconcilers []reconciler.Reconciler
 	//var otelOperator client.Object
 	//var tempoOperator client.Object
-	var instanceObjects []client.Object
 	installedObjects := map[string]client.Object{}
 
 	// the OTEL and Tempo operators are rolling release, meaning only the latest released versions are supported.
@@ -59,35 +58,20 @@ func getReconcilers(ctx context.Context, k8sClient client.Client, k8sReader clie
 	otelSubs := subscription(opts.OpenTelemetryOperator)
 	tempoSubs := subscription(opts.TempoOperator)
 
-	// instance objects
-	otelCol, err := otelCollector(instance)
+	instanceObjects, err := GenerateAllInstallerObjects(ctx, reader, instance, opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create OpenTelemetryCollector: %w", err)
-	}
-	instanceObjects = append(instanceObjects, otelCol)
-	otelcolRBAC, otelcolRBACBinding := otelCollectorComponentsRBAC(instance)
-	instanceObjects = append(instanceObjects, otelcolRBAC)
-	instanceObjects = append(instanceObjects, otelcolRBACBinding)
-	instanceObjects = append(instanceObjects, tempoStack(instance))
-
-	secrets, err := tempoStackSecrets(ctx, k8sClient, k8sReader, *instance)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create TempoStack secret: %w", err)
-	}
-	if secrets.objectStorage != nil {
-		instanceObjects = append(instanceObjects, secrets.objectStorage)
-	}
-	if secrets.objectStorageTLSSecret != nil {
-		instanceObjects = append(instanceObjects, secrets.objectStorageTLSSecret)
-	}
-	if secrets.objectStorageCAConfigMap != nil {
-		instanceObjects = append(instanceObjects, secrets.objectStorageCAConfigMap)
+		return nil, fmt.Errorf("building full object set: %w", err)
 	}
 
-	otelcolTempoRBAC, otelcolTempoRBACBinding := otelCollectorTempoRBAC(instance)
-	instanceObjects = append(instanceObjects, otelcolTempoRBAC)
-	instanceObjects = append(instanceObjects, otelcolTempoRBACBinding)
-	instanceObjects = append(instanceObjects, uiPlugin())
+	// When all capabilities are already enabled, the current object set is
+	// identical to the full set — reuse to avoid duplicate API calls.
+	currentObjects := instanceObjects
+	if tracing := instance.Spec.GetCapabilities().GetTracing(); tracing == nil || !tracing.Enabled {
+		currentObjects, err = GenerateInstallerObjects(ctx, reader, instance, opts, false, true)
+		if err != nil {
+			return nil, fmt.Errorf("building current object set: %w", err)
+		}
+	}
 
 	if instance.ObjectMeta.DeletionTimestamp != nil {
 		for _, obj := range instanceObjects {
@@ -127,7 +111,7 @@ func getReconcilers(ctx context.Context, k8sClient client.Client, k8sReader clie
 			reconcilers = append(reconcilers, reconciler.NewCreateUpdateReconciler(tempoSubs, instance))
 			installedObjects[gvkNameIdentifier(tempoSubs)] = tempoSubs
 		}
-		for _, obj := range instanceObjects {
+		for _, obj := range currentObjects {
 			reconcilers = append(reconcilers, reconciler.NewUpdater(obj, instance))
 			installedObjects[gvkNameIdentifier(obj)] = obj
 		}

--- a/pkg/controllers/observability/reconcilers.go
+++ b/pkg/controllers/observability/reconcilers.go
@@ -49,7 +49,6 @@ func getReconcilers(ctx context.Context, k8sClient client.Client, k8sReader clie
 	var reconcilers []reconciler.Reconciler
 	//var otelOperator client.Object
 	//var tempoOperator client.Object
-	var instanceObjects []client.Object
 	installedObjects := map[string]client.Object{}
 
 	// the OTEL and Tempo operators are rolling release, meaning only the latest released versions are supported.
@@ -59,35 +58,20 @@ func getReconcilers(ctx context.Context, k8sClient client.Client, k8sReader clie
 	otelSubs := subscription(opts.OpenTelemetryOperator)
 	tempoSubs := subscription(opts.TempoOperator)
 
-	// instance objects
-	otelCol, err := otelCollector(instance)
+	instanceObjects, err := GenerateAllInstallerObjects(ctx, k8sClient, k8sReader, instance, opts)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create OpenTelemetryCollector: %w", err)
-	}
-	instanceObjects = append(instanceObjects, otelCol)
-	otelcolRBAC, otelcolRBACBinding := otelCollectorComponentsRBAC(instance)
-	instanceObjects = append(instanceObjects, otelcolRBAC)
-	instanceObjects = append(instanceObjects, otelcolRBACBinding)
-	instanceObjects = append(instanceObjects, tempoStack(instance))
-
-	secrets, err := tempoStackSecrets(ctx, k8sClient, k8sReader, *instance)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create TempoStack secret: %w", err)
-	}
-	if secrets.objectStorage != nil {
-		instanceObjects = append(instanceObjects, secrets.objectStorage)
-	}
-	if secrets.objectStorageTLSSecret != nil {
-		instanceObjects = append(instanceObjects, secrets.objectStorageTLSSecret)
-	}
-	if secrets.objectStorageCAConfigMap != nil {
-		instanceObjects = append(instanceObjects, secrets.objectStorageCAConfigMap)
+		return nil, fmt.Errorf("building full object set: %w", err)
 	}
 
-	otelcolTempoRBAC, otelcolTempoRBACBinding := otelCollectorTempoRBAC(instance)
-	instanceObjects = append(instanceObjects, otelcolTempoRBAC)
-	instanceObjects = append(instanceObjects, otelcolTempoRBACBinding)
-	instanceObjects = append(instanceObjects, uiPlugin())
+	// When all capabilities are already enabled, the current object set is
+	// identical to the full set — reuse to avoid duplicate API calls.
+	currentObjects := instanceObjects
+	if tracing := instance.Spec.GetCapabilities().GetTracing(); tracing == nil || !tracing.Enabled {
+		currentObjects, err = GenerateInstallerObjects(ctx, k8sClient, k8sReader, instance, opts, false, true)
+		if err != nil {
+			return nil, fmt.Errorf("building current object set: %w", err)
+		}
+	}
 
 	if instance.ObjectMeta.DeletionTimestamp != nil {
 		for _, obj := range instanceObjects {
@@ -127,7 +111,7 @@ func getReconcilers(ctx context.Context, k8sClient client.Client, k8sReader clie
 			reconcilers = append(reconcilers, reconciler.NewCreateUpdateReconciler(tempoSubs, instance))
 			installedObjects[gvkNameIdentifier(tempoSubs)] = tempoSubs
 		}
-		for _, obj := range instanceObjects {
+		for _, obj := range currentObjects {
 			reconcilers = append(reconcilers, reconciler.NewUpdater(obj, instance))
 			installedObjects[gvkNameIdentifier(obj)] = obj
 		}

--- a/pkg/controllers/observability/reconcilers_test.go
+++ b/pkg/controllers/observability/reconcilers_test.go
@@ -234,7 +234,7 @@ func TestGetReconcilers(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			mockClient := test.mockClient()
 
-			reconcilers, err := getReconcilers(context.Background(), mockClient, mockClient, test.instance, Options{
+			reconcilers, err := getReconcilers(context.Background(), mockClient, test.instance, Options{
 				COONamespace: "operators",
 				OpenTelemetryOperator: OperatorInstallConfig{
 					Namespace:   "operators",

--- a/pkg/controllers/observability/tempo_components.go
+++ b/pkg/controllers/observability/tempo_components.go
@@ -122,14 +122,14 @@ type tempoSecrets struct {
 	objectStorageCAConfigMap *corev1.ConfigMap
 }
 
-func tempoStackSecrets(ctx context.Context, k8sClient client.Client, k8sReader client.Reader, instance obsv1alpha1.ObservabilityInstaller) (*tempoSecrets, error) {
+func tempoStackSecrets(ctx context.Context, reader client.Reader, instance obsv1alpha1.ObservabilityInstaller) (*tempoSecrets, error) {
 	var objectStorageCAConfMap *corev1.ConfigMap
 	var objectStorageTLSSecret *corev1.Secret
 
 	if tlsSpec := instance.Spec.GetCapabilities().GetTracing().GetStorage().GetObjectStorageSpec().GetTLS(); tlsSpec != nil {
 		if tlsSpec.CAConfigMap != nil {
 			caConfigMap := &corev1.ConfigMap{}
-			err := k8sReader.Get(ctx, client.ObjectKey{
+			err := reader.Get(ctx, client.ObjectKey{
 				Namespace: instance.Namespace,
 				Name:      tlsSpec.CAConfigMap.Name,
 			}, caConfigMap)
@@ -154,7 +154,7 @@ func tempoStackSecrets(ctx context.Context, k8sClient client.Client, k8sReader c
 
 		if tlsSpec.CertSecret != nil {
 			certSecret := &corev1.Secret{}
-			err := k8sReader.Get(ctx, client.ObjectKey{
+			err := reader.Get(ctx, client.ObjectKey{
 				Namespace: instance.Namespace,
 				Name:      tlsSpec.CertSecret.Name,
 			}, certSecret)
@@ -177,7 +177,7 @@ func tempoStackSecrets(ctx context.Context, k8sClient client.Client, k8sReader c
 		}
 		if tlsSpec.KeySecret != nil {
 			certSecret := &corev1.Secret{}
-			err := k8sReader.Get(ctx, client.ObjectKey{
+			err := reader.Get(ctx, client.ObjectKey{
 				Namespace: instance.Namespace,
 				Name:      tlsSpec.KeySecret.Name,
 			}, certSecret)
@@ -205,7 +205,7 @@ func tempoStackSecrets(ctx context.Context, k8sClient client.Client, k8sReader c
 	if objectStorageSpec := instance.Spec.GetCapabilities().GetTracing().GetStorage().GetObjectStorageSpec(); objectStorageSpec != nil {
 		if objectStorageSpec.S3 != nil {
 			accessKeySecret := &corev1.Secret{}
-			err := k8sClient.Get(ctx, client.ObjectKey{
+			err := reader.Get(ctx, client.ObjectKey{
 				Namespace: instance.Namespace,
 				Name:      objectStorageSpec.S3.AccessKeySecret.Name,
 			}, accessKeySecret)
@@ -236,7 +236,7 @@ func tempoStackSecrets(ctx context.Context, k8sClient client.Client, k8sReader c
 			}
 		} else if objectStorageSpec.Azure != nil {
 			accountKeySecret := &corev1.Secret{}
-			err := k8sClient.Get(ctx, client.ObjectKey{
+			err := reader.Get(ctx, client.ObjectKey{
 				Namespace: instance.Namespace,
 				Name:      objectStorageSpec.Azure.AccountKeySecret.Name,
 			}, accountKeySecret)
@@ -261,7 +261,7 @@ func tempoStackSecrets(ctx context.Context, k8sClient client.Client, k8sReader c
 			}
 		} else if objectStorageSpec.GCS != nil {
 			keyJSONSecret := &corev1.Secret{}
-			err := k8sClient.Get(ctx, client.ObjectKey{
+			err := reader.Get(ctx, client.ObjectKey{
 				Namespace: instance.Namespace,
 				Name:      objectStorageSpec.GCS.KeyJSONSecret.Name,
 			}, keyJSONSecret)
@@ -275,7 +275,7 @@ func tempoStackSecrets(ctx context.Context, k8sClient client.Client, k8sReader c
 			}
 		} else if objectStorageSpec.GCSWIF != nil {
 			keyJSONSecret := &corev1.Secret{}
-			err := k8sClient.Get(ctx, client.ObjectKey{
+			err := reader.Get(ctx, client.ObjectKey{
 				Namespace: instance.Namespace,
 				Name:      objectStorageSpec.GCSWIF.KeyJSONSecret.Name,
 			}, keyJSONSecret)

--- a/pkg/controllers/observability/tempo_components.go
+++ b/pkg/controllers/observability/tempo_components.go
@@ -122,7 +122,7 @@ type tempoSecrets struct {
 	objectStorageCAConfigMap *corev1.ConfigMap
 }
 
-func tempoStackSecrets(ctx context.Context, k8sClient client.Client, k8sReader client.Reader, instance obsv1alpha1.ObservabilityInstaller) (*tempoSecrets, error) {
+func tempoStackSecrets(ctx context.Context, k8sClient client.Reader, k8sReader client.Reader, instance obsv1alpha1.ObservabilityInstaller) (*tempoSecrets, error) {
 	var objectStorageCAConfMap *corev1.ConfigMap
 	var objectStorageTLSSecret *corev1.Secret
 

--- a/pkg/controllers/uiplugin/components.go
+++ b/pkg/controllers/uiplugin/components.go
@@ -691,14 +691,22 @@ func newKorrel8rConfigMap(name string, namespace string, info UIPluginInfo) (*co
 		"TracingNs":    OpenshiftTracingNs,
 	}
 
+	if inst := info.TracingInstaller; inst != nil {
+		korrel8rData["TracingTenant"] = "application"
+		korrel8rData["TracingNs"] = inst.Namespace
+		korrel8rData["Trace"] = fmt.Sprintf("tempo-%s-gateway", inst.Name)
+	} else {
+		korrel8rData["TracingTenant"] = "platform"
+		if info.TempoServiceNames[OpenshiftTracingNs] != "" {
+			korrel8rData["Trace"] = info.TempoServiceNames[OpenshiftTracingNs]
+		}
+	}
+
 	if info.LokiServiceNames[OpenshiftLoggingNs] != "" {
 		korrel8rData["Log"] = info.LokiServiceNames[OpenshiftLoggingNs]
 	}
 	if info.LokiServiceNames[OpenshiftNetobservNs] != "" {
 		korrel8rData["Netflow"] = info.LokiServiceNames[OpenshiftNetobservNs]
-	}
-	if info.TempoServiceNames[OpenshiftTracingNs] != "" {
-		korrel8rData["Trace"] = info.TempoServiceNames[OpenshiftTracingNs]
 	}
 
 	var korrel8rConfigYAMLTmpl = template.Must(template.ParseFS(korrel8rConfigYAMLTmplFile, "config/korrel8r.yaml"))

--- a/pkg/controllers/uiplugin/config/korrel8r.yaml
+++ b/pkg/controllers/uiplugin/config/korrel8r.yaml
@@ -16,7 +16,7 @@ stores:
     lokiStack: https://{{ .Netflow }}.{{ .NetobservNs }}.svc:8080
     certificateAuthority: ./run/secrets/kubernetes.io/serviceaccount/service-ca.crt
   - domain: trace
-    tempoStack: https://{{ .Trace }}.{{ .TracingNs }}.svc.cluster.local:8080/api/traces/v1/platform/tempo/api/search
+    tempoStack: https://{{ .Trace }}.{{ .TracingNs }}.svc.cluster.local:8080/api/traces/v1/{{ .TracingTenant }}/tempo/api/search
     certificateAuthority: ./run/secrets/kubernetes.io/serviceaccount/service-ca.crt
 
 include:

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
 	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
 )
 
@@ -45,6 +46,9 @@ type UIPluginsConfiguration struct {
 	Images             map[string]string
 	ResourcesNamespace string
 	TLSProfile         configv1.TLSProfileSpec
+	Installers         []obsv1alpha1.ObservabilityInstaller
+	LokiServiceNames   map[string]string
+	TempoServiceNames  map[string]string
 }
 
 type Options struct {
@@ -254,7 +258,19 @@ func (rm resourceManager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, nil
 	}
 
-	pluginInfo, pluginInfoErr := PluginInfoBuilder(ctx, rm.k8sClient, rm.k8sDynamicClient, plugin, rm.pluginConf, compatibilityInfo, rm.clusterVersion, rm.logger)
+	pluginConf := rm.pluginConf
+	var installerList obsv1alpha1.ObservabilityInstallerList
+	if err := rm.k8sClient.List(ctx, &installerList); err != nil {
+		logger.V(6).Info("cannot list ObservabilityInstallers", "err", err)
+	}
+	pluginConf.Installers = installerList.Items
+	pluginConf.TempoServiceNames = map[string]string{}
+	pluginConf.TempoServiceNames[OpenshiftTracingNs], _ = getTempoServiceName(ctx, rm.k8sClient, OpenshiftTracingNs)
+	pluginConf.LokiServiceNames = map[string]string{}
+	pluginConf.LokiServiceNames[OpenshiftLoggingNs], _ = getLokiServiceName(ctx, rm.k8sClient, OpenshiftLoggingNs)
+	pluginConf.LokiServiceNames[OpenshiftNetobservNs], _ = getLokiServiceName(ctx, rm.k8sClient, OpenshiftNetobservNs)
+
+	pluginInfo, pluginInfoErr := PluginInfoBuilder(ctx, rm.k8sClient, rm.k8sDynamicClient, plugin, pluginConf, rm.clusterVersion, rm.logger)
 
 	if pluginInfo != nil {
 		reconcilers := pluginComponentReconcilers(plugin, *pluginInfo, rm.clusterVersion, rm.logger)

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -254,7 +254,7 @@ func (rm resourceManager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, nil
 	}
 
-	pluginInfo, pluginInfoErr := PluginInfoBuilder(ctx, rm.k8sClient, rm.k8sDynamicClient, plugin, rm.pluginConf, compatibilityInfo, rm.clusterVersion, rm.logger)
+	pluginInfo, pluginInfoErr := PluginInfoBuilder(ctx, rm.k8sClient, rm.k8sDynamicClient, plugin, rm.pluginConf, rm.clusterVersion, rm.logger)
 
 	if pluginInfo != nil {
 		reconcilers := pluginComponentReconcilers(plugin, *pluginInfo, rm.clusterVersion, rm.logger)

--- a/pkg/controllers/uiplugin/generate.go
+++ b/pkg/controllers/uiplugin/generate.go
@@ -1,0 +1,55 @@
+package uiplugin
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
+	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
+)
+
+// UIPluginBuildConfig carries the parameters needed to resolve a UIPlugin CR
+// into its operand object set, usable both by the running operator and the
+// offline generator (which has no cluster).
+type UIPluginBuildConfig struct {
+	Images         map[string]string
+	Namespace      string
+	ClusterVersion string
+	TLSCiphers     []string
+	TLSMinVersion  string
+	// Pre-existing services discovered from cluster state.
+	LokiServiceNames  map[string]string
+	TempoServiceNames map[string]string
+	// Installer enabled for tracing, if there is one
+	TracingInstaller *obsv1alpha1.ObservabilityInstaller
+	// Nil in the offline generator; set by the controller.
+	DynamicClient dynamic.Interface
+}
+
+// ApplyTLSProfile sets TLS fields from an OpenShift TLS security profile,
+// converting OpenSSL cipher names to IANA.
+func (c *UIPluginBuildConfig) ApplyTLSProfile(profile configv1.TLSProfileSpec) {
+	c.TLSMinVersion = string(profile.MinTLSVersion)
+	c.TLSCiphers = libgocrypto.OpenSSLToIANACipherSuites(profile.Ciphers)
+}
+
+// GenerateUIPluginObjects builds the operands for a UIPlugin CR, used by
+// both the reconciler and offline generator to produce identical resources.
+func GenerateUIPluginObjects(ctx context.Context, plugin *uiv1alpha1.UIPlugin, conf UIPluginBuildConfig, logger logr.Logger) ([]client.Object, *UIPluginInfo, error) {
+	pluginInfo, err := buildPluginInfo(ctx, plugin, conf, logger)
+	if pluginInfo == nil {
+		return nil, nil, err
+	}
+
+	var objects []client.Object
+	for _, rec := range pluginComponentReconcilers(plugin, *pluginInfo, conf.ClusterVersion, logger) {
+		objects = append(objects, rec.Desired()...)
+	}
+
+	return objects, pluginInfo, err
+}

--- a/pkg/controllers/uiplugin/generate.go
+++ b/pkg/controllers/uiplugin/generate.go
@@ -1,0 +1,52 @@
+package uiplugin
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	libgocrypto "github.com/openshift/library-go/pkg/crypto"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
+)
+
+// UIPluginBuildConfig carries the parameters needed to resolve a UIPlugin CR
+// into its operand object set, usable both by the running operator and the
+// offline generator (which has no cluster).
+type UIPluginBuildConfig struct {
+	Images         map[string]string
+	Namespace      string
+	ClusterVersion string
+	TLSCiphers     []string
+	TLSMinVersion  string
+	// Pre-resolved values for plugins that need cluster state.
+	LokiServiceNames  map[string]string
+	TempoServiceNames map[string]string
+	// Nil in the offline generator; set by the controller.
+	DynamicClient dynamic.Interface
+}
+
+// ApplyTLSProfile sets TLS fields from an OpenShift TLS security profile,
+// converting OpenSSL cipher names to IANA.
+func (c *UIPluginBuildConfig) ApplyTLSProfile(profile configv1.TLSProfileSpec) {
+	c.TLSMinVersion = string(profile.MinTLSVersion)
+	c.TLSCiphers = libgocrypto.OpenSSLToIANACipherSuites(profile.Ciphers)
+}
+
+// GenerateUIPluginObjects builds the operands for a UIPlugin CR, used by
+// both the reconciler and offline generator to produce identical resources.
+func GenerateUIPluginObjects(ctx context.Context, plugin *uiv1alpha1.UIPlugin, conf UIPluginBuildConfig, logger logr.Logger) ([]client.Object, *UIPluginInfo, error) {
+	pluginInfo, err := buildPluginInfo(ctx, plugin, conf, logger)
+	if pluginInfo == nil {
+		return nil, nil, err
+	}
+
+	var objects []client.Object
+	for _, rec := range pluginComponentReconcilers(plugin, *pluginInfo, conf.ClusterVersion, logger) {
+		objects = append(objects, rec.Desired()...)
+	}
+
+	return objects, pluginInfo, err
+}

--- a/pkg/controllers/uiplugin/generate_test.go
+++ b/pkg/controllers/uiplugin/generate_test.go
@@ -1,0 +1,18 @@
+package uiplugin
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"gotest.tools/v3/assert"
+)
+
+func TestApplyTLSProfile(t *testing.T) {
+	conf := &UIPluginBuildConfig{}
+	conf.ApplyTLSProfile(configv1.TLSProfileSpec{
+		Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+		MinTLSVersion: configv1.VersionTLS12,
+	})
+	assert.Equal(t, "VersionTLS12", conf.TLSMinVersion)
+	assert.Assert(t, len(conf.TLSCiphers) > 0)
+}

--- a/pkg/controllers/uiplugin/logging.go
+++ b/pkg/controllers/uiplugin/logging.go
@@ -192,6 +192,19 @@ func getLokiStack(plugin *uiv1alpha1.UIPlugin, ctx context.Context, client dynam
 		searchNamespace = config.LokiStack.Namespace
 	}
 
+	// A nil dynamic client (e.g. offline generation) falls back to the
+	// configured LokiStack name, or the default LokiStack.
+	if client == nil {
+		name := "loki-stack"
+		if config != nil && config.LokiStack != nil && config.LokiStack.Name != "" {
+			name = config.LokiStack.Name
+		}
+		return &types.NamespacedName{
+			Name:      name,
+			Namespace: searchNamespace,
+		}, nil
+	}
+
 	if config != nil && config.LokiStack != nil && config.LokiStack.Name != "" {
 		lokiStack, err := client.Resource(lokiStackResource).Namespace(searchNamespace).Get(ctx, config.LokiStack.Name, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -3,14 +3,15 @@ package uiplugin
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/go-logr/logr"
-	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
 	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
 )
 
@@ -20,6 +21,7 @@ type UIPluginInfo struct {
 	HealthAnalyzerImage        string
 	LokiServiceNames           map[string]string
 	TempoServiceNames          map[string]string
+	TracingInstaller           *obsv1alpha1.ObservabilityInstaller
 	Name                       string
 	ConsoleName                string
 	DisplayName                string
@@ -51,64 +53,68 @@ func ConsoleNameForType(pluginType uiv1alpha1.UIPluginType) string {
 	return pluginTypeToConsoleName[pluginType]
 }
 
-func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interface, plugin *uiv1alpha1.UIPlugin, pluginConf UIPluginsConfiguration, compatibilityInfo CompatibilityEntry, clusterVersion string, logger logr.Logger) (*UIPluginInfo, error) {
-	image := pluginConf.Images[compatibilityInfo.ImageKey]
+func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interface, plugin *uiv1alpha1.UIPlugin, pluginConf UIPluginsConfiguration, clusterVersion string, logger logr.Logger) (*UIPluginInfo, error) {
+	conf := UIPluginBuildConfig{
+		Images:            pluginConf.Images,
+		Namespace:         pluginConf.ResourcesNamespace,
+		ClusterVersion:    clusterVersion,
+		DynamicClient:     dk,
+		LokiServiceNames:  pluginConf.LokiServiceNames,
+		TempoServiceNames: pluginConf.TempoServiceNames,
+		TracingInstaller:  findTracingInstaller(pluginConf.Installers),
+	}
+	conf.ApplyTLSProfile(pluginConf.TLSProfile)
+	return buildPluginInfo(ctx, plugin, conf, logger)
+}
+
+func findTracingInstaller(installers []obsv1alpha1.ObservabilityInstaller) *obsv1alpha1.ObservabilityInstaller {
+	for i := range installers {
+		if t := installers[i].Spec.GetCapabilities().GetTracing(); t != nil && t.Enabled {
+			return &installers[i]
+		}
+	}
+	return nil
+}
+
+func buildPluginInfo(ctx context.Context, plugin *uiv1alpha1.UIPlugin, conf UIPluginBuildConfig, logger logr.Logger) (*UIPluginInfo, error) {
+	compatibilityInfo, err := lookupImageAndFeatures(plugin.Spec.Type, conf.ClusterVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	image := conf.Images[compatibilityInfo.ImageKey]
 	if image == "" {
 		return nil, fmt.Errorf("no image provided for plugin type %s with key %s", plugin.Spec.Type, compatibilityInfo.ImageKey)
 	}
 
-	namespace := pluginConf.ResourcesNamespace
-
 	var pluginInfo *UIPluginInfo
-	var err error
-
 	switch plugin.Spec.Type {
-	case uiv1alpha1.TypeTroubleshootingPanel:
-		pluginInfo, err = createTroubleshootingPanelPluginInfo(plugin, namespace, plugin.Name, image, []string{}, clusterVersion, logger)
-		if err != nil {
-			return nil, err
-		}
-
-		pluginInfo.Korrel8rImage = pluginConf.Images["korrel8r"]
-		pluginInfo.LokiServiceNames[OpenshiftLoggingNs], err = getLokiServiceName(ctx, k, OpenshiftLoggingNs)
-		if err != nil {
-			return nil, err
-		}
-
-		pluginInfo.LokiServiceNames[OpenshiftNetobservNs], err = getLokiServiceName(ctx, k, OpenshiftNetobservNs)
-		if err != nil {
-			return nil, err
-		}
-
-		pluginInfo.TempoServiceNames[OpenshiftTracingNs], err = getTempoServiceName(ctx, k, OpenshiftTracingNs)
-		if err != nil {
-			return nil, err
-		}
-
 	case uiv1alpha1.TypeDistributedTracing:
-		pluginInfo, err = createDistributedTracingPluginInfo(plugin, namespace, plugin.Name, image, []string{})
-		if err != nil {
-			return nil, err
-		}
+		pluginInfo, err = createDistributedTracingPluginInfo(plugin, conf.Namespace, plugin.Name, image, compatibilityInfo.Features)
 
 	case uiv1alpha1.TypeLogging:
-		pluginInfo, err = createLoggingPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, ctx, dk, logger, pluginConf.Images["korrel8r"])
-		if err != nil {
-			return nil, err
+		pluginInfo, err = createLoggingPluginInfo(plugin, conf.Namespace, plugin.Name, image, compatibilityInfo.Features, ctx, conf.DynamicClient, logger, conf.Images["korrel8r"])
+
+	case uiv1alpha1.TypeTroubleshootingPanel:
+		pluginInfo, err = createTroubleshootingPanelPluginInfo(plugin, conf.Namespace, plugin.Name, image, compatibilityInfo.Features, conf.ClusterVersion, logger)
+		if err == nil {
+			pluginInfo.Korrel8rImage = conf.Images["korrel8r"]
+			pluginInfo.LokiServiceNames = maps.Clone(conf.LokiServiceNames)
 		}
 
 	case uiv1alpha1.TypeMonitoring:
-		pluginInfo, err = createMonitoringPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, clusterVersion, pluginConf.Images["health-analyzer"], pluginConf.Images["perses"])
-		if err != nil {
-			return nil, err
-		}
+		pluginInfo, err = createMonitoringPluginInfo(plugin, conf.Namespace, plugin.Name, image, compatibilityInfo.Features, conf.ClusterVersion, conf.Images["health-analyzer"], conf.Images["perses"])
 
 	default:
 		return nil, fmt.Errorf("plugin type not supported: %s", plugin.Spec.Type)
 	}
+	if err != nil {
+		return nil, err
+	}
 
-	pluginInfo.TLSMinVersion = string(pluginConf.TLSProfile.MinTLSVersion)
-	pluginInfo.TLSCiphers = libgocrypto.OpenSSLToIANACipherSuites(pluginConf.TLSProfile.Ciphers)
-
-	return pluginInfo, err
+	pluginInfo.TracingInstaller = conf.TracingInstaller
+	pluginInfo.TempoServiceNames = maps.Clone(conf.TempoServiceNames)
+	pluginInfo.TLSMinVersion = conf.TLSMinVersion
+	pluginInfo.TLSCiphers = conf.TLSCiphers
+	return pluginInfo, nil
 }

--- a/pkg/controllers/uiplugin/plugin_info_builder.go
+++ b/pkg/controllers/uiplugin/plugin_info_builder.go
@@ -3,9 +3,9 @@ package uiplugin
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/go-logr/logr"
-	libgocrypto "github.com/openshift/library-go/pkg/crypto"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/dynamic"
@@ -51,64 +51,75 @@ func ConsoleNameForType(pluginType uiv1alpha1.UIPluginType) string {
 	return pluginTypeToConsoleName[pluginType]
 }
 
-func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interface, plugin *uiv1alpha1.UIPlugin, pluginConf UIPluginsConfiguration, compatibilityInfo CompatibilityEntry, clusterVersion string, logger logr.Logger) (*UIPluginInfo, error) {
-	image := pluginConf.Images[compatibilityInfo.ImageKey]
+func PluginInfoBuilder(ctx context.Context, k client.Client, dk dynamic.Interface, plugin *uiv1alpha1.UIPlugin, pluginConf UIPluginsConfiguration, clusterVersion string, logger logr.Logger) (*UIPluginInfo, error) {
+	conf := UIPluginBuildConfig{
+		Images:         pluginConf.Images,
+		Namespace:      pluginConf.ResourcesNamespace,
+		ClusterVersion: clusterVersion,
+		DynamicClient:  dk,
+	}
+	conf.ApplyTLSProfile(pluginConf.TLSProfile)
+
+	if plugin.Spec.Type == uiv1alpha1.TypeTroubleshootingPanel {
+		conf.LokiServiceNames = map[string]string{}
+		conf.TempoServiceNames = map[string]string{}
+
+		var err error
+		conf.LokiServiceNames[OpenshiftLoggingNs], err = getLokiServiceName(ctx, k, OpenshiftLoggingNs)
+		if err != nil {
+			return nil, err
+		}
+		conf.LokiServiceNames[OpenshiftNetobservNs], err = getLokiServiceName(ctx, k, OpenshiftNetobservNs)
+		if err != nil {
+			return nil, err
+		}
+		conf.TempoServiceNames[OpenshiftTracingNs], err = getTempoServiceName(ctx, k, OpenshiftTracingNs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buildPluginInfo(ctx, plugin, conf, logger)
+}
+
+func buildPluginInfo(ctx context.Context, plugin *uiv1alpha1.UIPlugin, conf UIPluginBuildConfig, logger logr.Logger) (*UIPluginInfo, error) {
+	compatibilityInfo, err := lookupImageAndFeatures(plugin.Spec.Type, conf.ClusterVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	image := conf.Images[compatibilityInfo.ImageKey]
 	if image == "" {
 		return nil, fmt.Errorf("no image provided for plugin type %s with key %s", plugin.Spec.Type, compatibilityInfo.ImageKey)
 	}
 
-	namespace := pluginConf.ResourcesNamespace
-
 	var pluginInfo *UIPluginInfo
-	var err error
-
 	switch plugin.Spec.Type {
-	case uiv1alpha1.TypeTroubleshootingPanel:
-		pluginInfo, err = createTroubleshootingPanelPluginInfo(plugin, namespace, plugin.Name, image, []string{}, clusterVersion, logger)
-		if err != nil {
-			return nil, err
-		}
-
-		pluginInfo.Korrel8rImage = pluginConf.Images["korrel8r"]
-		pluginInfo.LokiServiceNames[OpenshiftLoggingNs], err = getLokiServiceName(ctx, k, OpenshiftLoggingNs)
-		if err != nil {
-			return nil, err
-		}
-
-		pluginInfo.LokiServiceNames[OpenshiftNetobservNs], err = getLokiServiceName(ctx, k, OpenshiftNetobservNs)
-		if err != nil {
-			return nil, err
-		}
-
-		pluginInfo.TempoServiceNames[OpenshiftTracingNs], err = getTempoServiceName(ctx, k, OpenshiftTracingNs)
-		if err != nil {
-			return nil, err
-		}
-
 	case uiv1alpha1.TypeDistributedTracing:
-		pluginInfo, err = createDistributedTracingPluginInfo(plugin, namespace, plugin.Name, image, []string{})
-		if err != nil {
-			return nil, err
-		}
+		pluginInfo, err = createDistributedTracingPluginInfo(plugin, conf.Namespace, plugin.Name, image, compatibilityInfo.Features)
 
 	case uiv1alpha1.TypeLogging:
-		pluginInfo, err = createLoggingPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, ctx, dk, logger, pluginConf.Images["korrel8r"])
-		if err != nil {
-			return nil, err
+		pluginInfo, err = createLoggingPluginInfo(plugin, conf.Namespace, plugin.Name, image, compatibilityInfo.Features, ctx, conf.DynamicClient, logger, conf.Images["korrel8r"])
+
+	case uiv1alpha1.TypeTroubleshootingPanel:
+		pluginInfo, err = createTroubleshootingPanelPluginInfo(plugin, conf.Namespace, plugin.Name, image, compatibilityInfo.Features, conf.ClusterVersion, logger)
+		if err == nil {
+			pluginInfo.Korrel8rImage = conf.Images["korrel8r"]
+			pluginInfo.LokiServiceNames = maps.Clone(conf.LokiServiceNames)
+			pluginInfo.TempoServiceNames = maps.Clone(conf.TempoServiceNames)
 		}
 
 	case uiv1alpha1.TypeMonitoring:
-		pluginInfo, err = createMonitoringPluginInfo(plugin, namespace, plugin.Name, image, compatibilityInfo.Features, clusterVersion, pluginConf.Images["health-analyzer"], pluginConf.Images["perses"])
-		if err != nil {
-			return nil, err
-		}
+		pluginInfo, err = createMonitoringPluginInfo(plugin, conf.Namespace, plugin.Name, image, compatibilityInfo.Features, conf.ClusterVersion, conf.Images["health-analyzer"], conf.Images["perses"])
 
 	default:
 		return nil, fmt.Errorf("plugin type not supported: %s", plugin.Spec.Type)
 	}
+	if err != nil {
+		return nil, err
+	}
 
-	pluginInfo.TLSMinVersion = string(pluginConf.TLSProfile.MinTLSVersion)
-	pluginInfo.TLSCiphers = libgocrypto.OpenSSLToIANACipherSuites(pluginConf.TLSProfile.Ciphers)
-
-	return pluginInfo, err
+	pluginInfo.TLSMinVersion = conf.TLSMinVersion
+	pluginInfo.TLSCiphers = conf.TLSCiphers
+	return pluginInfo, nil
 }

--- a/pkg/controllers/uiplugin/troubleshooting_panel_test.go
+++ b/pkg/controllers/uiplugin/troubleshooting_panel_test.go
@@ -4,12 +4,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"gotest.tools/v3/assert"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	"github.com/go-logr/logr"
 	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
 )
 

--- a/pkg/controllers/util/common.go
+++ b/pkg/controllers/util/common.go
@@ -1,6 +1,10 @@
 package util
 
 import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -8,6 +12,11 @@ const (
 	ResourceLabel = "app.kubernetes.io/managed-by"
 	OpName        = "observability-operator"
 )
+
+// Identifier is a global identifying string of the form GVK/name.namespace
+func Identifier(obj client.Object) string {
+	return fmt.Sprintf("%s/%s.%s", obj.GetObjectKind().GroupVersionKind().String(), obj.GetName(), obj.GetNamespace())
+}
 
 func AddCommonLabels(obj client.Object, name string) client.Object {
 	labels := obj.GetLabels()
@@ -26,4 +35,37 @@ func AddCommonLabels(obj client.Object, name string) client.Object {
 		}
 	}
 	return obj
+}
+
+// MarshalCopy copies a client.Object (structured or unstructured) into dst
+// via JSON round-trip.
+func MarshalCopy(dst, src client.Object) error {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, dst)
+}
+
+// CompareObjects orders Namespace objects first, then by namespace, API group,
+// kind, then name. Callers must populate TypeMeta so Group and Kind are available.
+func CompareObjects(a, b client.Object) int {
+	aNS := a.GetObjectKind().GroupVersionKind().Kind == "Namespace"
+	bNS := b.GetObjectKind().GroupVersionKind().Kind == "Namespace"
+	if aNS != bNS {
+		if aNS {
+			return -1
+		}
+		return 1
+	}
+	if c := strings.Compare(a.GetNamespace(), b.GetNamespace()); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.GetObjectKind().GroupVersionKind().Group, b.GetObjectKind().GroupVersionKind().Group); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.GetObjectKind().GroupVersionKind().Kind, b.GetObjectKind().GroupVersionKind().Kind); c != 0 {
+		return c
+	}
+	return strings.Compare(a.GetName(), b.GetName())
 }

--- a/pkg/controllers/util/common.go
+++ b/pkg/controllers/util/common.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"encoding/json"
+	"strings"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -27,3 +30,29 @@ func AddCommonLabels(obj client.Object, name string) client.Object {
 	}
 	return obj
 }
+
+// MarshalCopy copies a client.Object (structured or unstructured) into dst
+// via JSON round-trip.
+func MarshalCopy(dst, src client.Object) error {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, dst)
+}
+
+// CompareObjects orders objects by namespace, API group, kind, then name.
+// Callers must populate TypeMeta so Group and Kind are available.
+func CompareObjects(a, b client.Object) int {
+	if c := strings.Compare(a.GetNamespace(), b.GetNamespace()); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.GetObjectKind().GroupVersionKind().Group, b.GetObjectKind().GroupVersionKind().Group); c != 0 {
+		return c
+	}
+	if c := strings.Compare(a.GetObjectKind().GroupVersionKind().Kind, b.GetObjectKind().GroupVersionKind().Kind); c != 0 {
+		return c
+	}
+	return strings.Compare(a.GetName(), b.GetName())
+}
+

--- a/pkg/controllers/util/common_test.go
+++ b/pkg/controllers/util/common_test.go
@@ -1,0 +1,96 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestAddCommonLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		labels     map[string]string
+		wantPartOf string
+	}{
+		{
+			name:       "nil labels",
+			labels:     nil,
+			wantPartOf: "my-owner",
+		},
+		{
+			name:       "empty labels",
+			labels:     map[string]string{},
+			wantPartOf: "my-owner",
+		},
+		{
+			name:       "existing labels preserved",
+			labels:     map[string]string{"app.kubernetes.io/part-of": "custom", "extra": "val"},
+			wantPartOf: "custom",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm", Labels: tc.labels}}
+			result := AddCommonLabels(obj, "my-owner")
+			labels := result.GetLabels()
+			require.Equal(t, tc.wantPartOf, labels["app.kubernetes.io/part-of"])
+			require.Equal(t, "cm", labels["app.kubernetes.io/name"])
+			require.Equal(t, OpName, labels[ResourceLabel])
+			if tc.labels != nil {
+				for k, v := range tc.labels {
+					require.Equal(t, v, labels[k])
+				}
+			}
+		})
+	}
+}
+
+func TestMarshalCopy(t *testing.T) {
+	src := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: "src", Namespace: "ns"},
+		Data:       map[string]string{"key": "value"},
+	}
+	dst := &corev1.ConfigMap{}
+	require.NoError(t, MarshalCopy(dst, src))
+	require.Equal(t, src.Name, dst.Name)
+	require.Equal(t, src.Namespace, dst.Namespace)
+	require.Equal(t, src.Data, dst.Data)
+}
+
+func TestCompareObjects(t *testing.T) {
+	obj := func(ns, group, kind, name string) *corev1.ConfigMap {
+		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns}}
+		cm.SetGroupVersionKind(schema.GroupVersionKind{Group: group, Kind: kind})
+		return cm
+	}
+
+	tests := []struct {
+		name string
+		a, b *corev1.ConfigMap
+		want int
+	}{
+		{"same", obj("ns", "g", "Kind", "a"), obj("ns", "g", "Kind", "a"), 0},
+		{"namespace first", obj("", "", "Namespace", "x"), obj("", "", "ConfigMap", "x"), -1},
+		{"namespace before namespaced", obj("", "", "Namespace", "ns"), obj("ns", "", "ConfigMap", "x"), -1},
+		{"namespace differs", obj("a-ns", "", "Kind", "x"), obj("b-ns", "", "Kind", "x"), -1},
+		{"group differs", obj("ns", "a.io", "Kind", "x"), obj("ns", "b.io", "Kind", "x"), -1},
+		{"kind differs", obj("ns", "g", "A", "x"), obj("ns", "g", "B", "x"), -1},
+		{"name differs", obj("ns", "g", "Kind", "a"), obj("ns", "g", "Kind", "b"), -1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CompareObjects(tc.a, tc.b)
+			switch {
+			case tc.want < 0:
+				require.Less(t, got, 0)
+			case tc.want > 0:
+				require.Greater(t, got, 0)
+			default:
+				require.Equal(t, 0, got)
+			}
+		})
+	}
+}

--- a/pkg/generator/fallback_reader.go
+++ b/pkg/generator/fallback_reader.go
@@ -1,0 +1,65 @@
+package generator
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// FallbackReader implements client.Reader with a set of pre-loaded objects.
+// Get checks the pre-loaded set first, then falls back to the underlying Reader.
+type FallbackReader struct {
+	preloaded map[preloadKey]client.Object
+	reader    client.Reader
+}
+
+type preloadKey struct {
+	key     client.ObjectKey
+	objType reflect.Type
+}
+
+var _ client.Reader = &FallbackReader{}
+
+func NewFallbackReader(reader client.Reader, preloaded ...client.Object) *FallbackReader {
+	r := &FallbackReader{preloaded: make(map[preloadKey]client.Object, len(preloaded)), reader: reader}
+	for _, o := range preloaded {
+		pk := preloadKey{key: client.ObjectKeyFromObject(o), objType: reflect.TypeOf(o).Elem()}
+		// The API server converts StringData to Data on write; emulate that so
+		// offline reads return the same value a cluster Get would.
+		if secret, ok := o.(*corev1.Secret); ok && len(secret.StringData) > 0 {
+			s := secret.DeepCopy()
+			if s.Data == nil {
+				s.Data = map[string][]byte{}
+			}
+			for k, v := range s.StringData {
+				s.Data[k] = []byte(v)
+			}
+			s.StringData = nil
+			o = s
+		}
+		r.preloaded[pk] = o
+	}
+	return r
+}
+
+func (r *FallbackReader) Get(ctx context.Context, key client.ObjectKey, into client.Object, opts ...client.GetOption) error {
+	pk := preloadKey{key: key, objType: reflect.TypeOf(into).Elem()}
+	if obj, ok := r.preloaded[pk]; ok {
+		reflect.ValueOf(into).Elem().Set(reflect.ValueOf(obj).Elem())
+		return nil
+	}
+	if r.reader != nil {
+		return r.reader.Get(ctx, key, into, opts...)
+	}
+	return fmt.Errorf("not found: (%T) %v", into, key)
+}
+
+func (r *FallbackReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if r.reader != nil {
+		return r.reader.List(ctx, list, opts...)
+	}
+	return nil
+}

--- a/pkg/generator/fallback_reader_test.go
+++ b/pkg/generator/fallback_reader_test.go
@@ -1,0 +1,43 @@
+package generator
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"gotest.tools/v3/assert"
+)
+
+// TestFallbackReaderStringData verifies that a Secret provided with stringData
+// is served to readers with its values under data, matching what the API
+// server would return for the same secret, so object storage secrets are
+// populated offline.
+func TestFallbackReaderStringData(t *testing.T) {
+	r := NewFallbackReader(nil, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "minio-secret", Namespace: "sample"},
+		StringData: map[string]string{"access_key_secret": "supersecret"},
+	})
+
+	got := &corev1.Secret{}
+	err := r.Get(context.Background(), client.ObjectKey{Name: "minio-secret", Namespace: "sample"}, got)
+	assert.NilError(t, err)
+	assert.Equal(t, string(got.Data["access_key_secret"]), "supersecret")
+	assert.Equal(t, len(got.StringData), 0)
+}
+
+// TestFallbackReaderData verifies that a Secret provided with base64 data is
+// served unchanged.
+func TestFallbackReaderData(t *testing.T) {
+	r := NewFallbackReader(nil, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "minio-secret", Namespace: "sample"},
+		Data:       map[string][]byte{"access_key_secret": []byte("supersecret")},
+	})
+
+	got := &corev1.Secret{}
+	err := r.Get(context.Background(), client.ObjectKey{Name: "minio-secret", Namespace: "sample"}, got)
+	assert.NilError(t, err)
+	assert.Equal(t, string(got.Data["access_key_secret"]), "supersecret")
+}

--- a/pkg/generator/fallback_reader_test.go
+++ b/pkg/generator/fallback_reader_test.go
@@ -1,0 +1,97 @@
+package generator
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// TestFallbackReaderStringData verifies that a Secret provided with stringData
+// is served to readers with its values under data, matching what the API
+// server would return for the same secret, so object storage secrets are
+// populated offline.
+func TestFallbackReaderStringData(t *testing.T) {
+	r := NewFallbackReader(nil, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "minio-secret", Namespace: "sample"},
+		StringData: map[string]string{"access_key_secret": "supersecret"},
+	})
+
+	got := &corev1.Secret{}
+	err := r.Get(context.Background(), client.ObjectKey{Name: "minio-secret", Namespace: "sample"}, got)
+	assert.NilError(t, err)
+	assert.Equal(t, string(got.Data["access_key_secret"]), "supersecret")
+	assert.Equal(t, len(got.StringData), 0)
+}
+
+// TestFallbackReaderData verifies that a Secret provided with base64 data is
+// served unchanged.
+func TestFallbackReaderData(t *testing.T) {
+	r := NewFallbackReader(nil, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "minio-secret", Namespace: "sample"},
+		Data:       map[string][]byte{"access_key_secret": []byte("supersecret")},
+	})
+
+	got := &corev1.Secret{}
+	err := r.Get(context.Background(), client.ObjectKey{Name: "minio-secret", Namespace: "sample"}, got)
+	assert.NilError(t, err)
+	assert.Equal(t, string(got.Data["access_key_secret"]), "supersecret")
+}
+
+func TestFallbackReaderGetNotFound(t *testing.T) {
+	r := NewFallbackReader(nil)
+	got := &corev1.Secret{}
+	err := r.Get(context.Background(), client.ObjectKey{Name: "missing", Namespace: "ns"}, got)
+	assert.ErrorContains(t, err, "not found")
+}
+
+func TestFallbackReaderGetFallback(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NilError(t, corev1.AddToScheme(scheme))
+
+	clusterSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-secret", Namespace: "ns"},
+		Data:       map[string][]byte{"key": []byte("from-cluster")},
+	}
+	fakeClient := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(clusterSecret).Build()
+
+	r := NewFallbackReader(fakeClient, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "local-secret", Namespace: "ns"},
+		Data:       map[string][]byte{"key": []byte("from-preload")},
+	})
+
+	// Preloaded secret is returned directly.
+	got := &corev1.Secret{}
+	assert.NilError(t, r.Get(context.Background(), client.ObjectKey{Name: "local-secret", Namespace: "ns"}, got))
+	assert.Equal(t, string(got.Data["key"]), "from-preload")
+
+	// Non-preloaded secret falls back to the underlying reader.
+	got = &corev1.Secret{}
+	assert.NilError(t, r.Get(context.Background(), client.ObjectKey{Name: "cluster-secret", Namespace: "ns"}, got))
+	assert.Equal(t, string(got.Data["key"]), "from-cluster")
+}
+
+func TestFallbackReaderListDelegates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NilError(t, corev1.AddToScheme(scheme))
+
+	s1 := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "ns"}}
+	fakeClient := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(s1).Build()
+
+	r := NewFallbackReader(fakeClient)
+	list := &corev1.SecretList{}
+	assert.NilError(t, r.List(context.Background(), list, client.InNamespace("ns")))
+	assert.Equal(t, len(list.Items), 1)
+}
+
+func TestFallbackReaderListNilReader(t *testing.T) {
+	r := NewFallbackReader(nil)
+	list := &corev1.SecretList{}
+	assert.NilError(t, r.List(context.Background(), list))
+	assert.Equal(t, len(list.Items), 0)
+}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -1,0 +1,448 @@
+package generator
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/controller-runtime-common/pkg/tls"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/dynamic"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	k8sflag "k8s.io/component-base/cli/flag"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	kyaml "sigs.k8s.io/yaml"
+
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
+	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
+	"github.com/rhobs/observability-operator/pkg/controllers/observability"
+	"github.com/rhobs/observability-operator/pkg/controllers/uiplugin"
+	"github.com/rhobs/observability-operator/pkg/controllers/util"
+	"github.com/rhobs/observability-operator/pkg/images"
+	"github.com/rhobs/observability-operator/pkg/operator"
+)
+
+func exitMsg(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}
+
+func exitErr(err error, msg string) {
+	if err != nil {
+		exitMsg("%v: %v", msg, err)
+	}
+}
+
+// RunConfig holds the inputs for a generator run. It is populated by the CLI
+// flags in Main and directly by tests.
+type RunConfig struct {
+	// Input is the list of YAML files, directories, or "-" for stdin.
+	Input []string
+	// Namespace is the namespace the operator itself is installed in.
+	Namespace string
+	// ClusterVersion is the OpenShift cluster version, used by UIPlugin code.
+	ClusterVersion string
+	// Operators selects operator infrastructure only; Resources selects
+	// non-operator resources only. Both false or both true means everything.
+	Operators bool
+	Resources bool
+	// OtelCSV and TempoCSV are the starting CSVs for the OTel and Tempo
+	// subscriptions (empty means the operator catalog's default).
+	OtelCSV  string
+	TempoCSV string
+	// Images overrides default images, keyed by image name.
+	Images map[string]string
+	// K8sClient, when set, is used to fetch version, TLS profile and secrets.
+	K8sClient     client.Client
+	DynamicClient dynamic.Interface
+	// TLSProfile overrides the TLS profile used for UIPlugin operands.
+	TLSProfile configv1.TLSProfileSpec
+}
+
+// Run generates the YAML manifest for the configured resources.
+// It returns the stdout manifest, and errors collected during the run.
+func Run(cfg RunConfig) (string, string, error) {
+	resolvedImages, err := images.Validate(cfg.Images)
+	if err != nil {
+		return "", "", err
+	}
+	// Default values from cfg
+	clusterVersion := cfg.ClusterVersion
+	tlsProfile := cfg.TLSProfile
+	if cfg.K8sClient != nil {
+		// Overwrite with cluster values if we have a K8sClient
+		tlsProfile, err = tls.FetchAPIServerTLSProfile(context.Background(), cfg.K8sClient)
+		if err != nil {
+			return "", "", fmt.Errorf("error fetching TLS profile from cluster: %w", err)
+		}
+		cv := &configv1.ClusterVersion{}
+		err = cfg.K8sClient.Get(context.Background(), client.ObjectKey{Name: "version"}, cv)
+		if err != nil {
+			return "", "", fmt.Errorf("error fetching cluster version: %w", err)
+		}
+		for _, update := range cv.Status.History {
+			if update.State == configv1.CompletedUpdate {
+				clusterVersion = update.Version
+				break
+			}
+		}
+	}
+
+	scheme := operator.NewScheme(&operator.OperatorConfiguration{
+		FeatureGates: operator.FeatureGates{
+			OpenShift: operator.OpenShiftFeatureGates{
+				Enabled: true,
+				Version: clusterVersion,
+			},
+		}})
+
+	yamlData, err := readInputs(cfg.Input)
+	if err != nil {
+		return "", "", fmt.Errorf("error reading input: %w", err)
+	}
+
+	installers, plugins, others, err := decodeResources(scheme, yamlData)
+	if err != nil {
+		return "", "", fmt.Errorf("error decoding resources: %w", err)
+	}
+
+	installerOpts := observability.Options{
+		COONamespace: cfg.Namespace,
+		OpenTelemetryOperator: observability.OperatorInstallConfig{
+			Namespace:   cfg.Namespace,
+			PackageName: "opentelemetry-product",
+			StartingCSV: cfg.OtelCSV,
+			Channel:     "stable",
+		},
+		TempoOperator: observability.OperatorInstallConfig{
+			Namespace:   cfg.Namespace,
+			PackageName: "tempo-product",
+			StartingCSV: cfg.TempoCSV,
+			Channel:     "stable",
+		},
+	}
+
+	installOperators := cfg.Operators || !cfg.Resources
+	installResources := cfg.Resources || !cfg.Operators
+
+	// accumulate resources in set
+	set := newResourceSet(scheme)
+
+	// add the COO namespace to the set, for the operator this is created by OLM
+	if err := set.AddResource(&corev1.Namespace{
+		TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: cfg.Namespace},
+	}); err != nil {
+		return "", "", fmt.Errorf("adding COO namespace: %w", err)
+	}
+
+	// pass through other resources to the output
+	for _, obj := range others {
+		if err := set.AddResource(obj); err != nil {
+			return "", "", fmt.Errorf("adding input resource: %w", err)
+		}
+	}
+
+	// reader makes other objects (secrets, configmaps) read from YAML available to kustomize.
+	reader := NewFallbackReader(cfg.K8sClient, others...)
+
+	var errs error
+	err = generateInstallerObjects(installers, installerOpts, set, reader, installOperators, installResources)
+	errs = errors.Join(errs, err)
+
+	if installResources {
+		pluginConf := uiplugin.UIPluginBuildConfig{
+			Images:           resolvedImages,
+			Namespace:        cfg.Namespace,
+			ClusterVersion:   clusterVersion,
+			TracingInstaller: findTracingInstaller(installers),
+			DynamicClient:    cfg.DynamicClient,
+		}
+		pluginConf.ApplyTLSProfile(tlsProfile)
+
+		if err := generateUIPluginObjects(plugins, pluginConf, set); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("resolving UIPlugins: %w", err))
+		}
+	}
+
+	objects := set.Build()
+
+	// UIPlugin CRs have been resolved into concrete resources, remove them from output.
+	objects = slices.DeleteFunc(objects, func(obj client.Object) bool {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		return gvk.Group == "observability.openshift.io" && gvk.Kind == "UIPlugin"
+	})
+
+	var buf bytes.Buffer
+	for _, obj := range objects {
+		data, err := kyaml.Marshal(obj)
+		if err != nil {
+			return "", "", err
+		}
+		buf.WriteString("---\n")
+		buf.Write(data)
+	}
+
+	return buf.String(), errsString(errs), nil
+}
+
+func errsString(errs error) string {
+	if errs == nil {
+		return ""
+	}
+	return errs.Error()
+}
+
+func Main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, `
+Usage: %v [OPTIONS] -f FILE...
+
+Offline generator for the Cluster Observability Operator (COO). Reads COO custom
+resources and supporting objects from YAML, runs the operator's reconciler code
+offline, and writes the resulting Kubernetes objects to stdout. Use -operators
+and -resources for staged apply; use -cluster to resolve secrets, TLS profile,
+and version from a live cluster.
+`, filepath.Base(os.Args[0]))
+		flag.PrintDefaults()
+	}
+	var files []string
+	filesFlag := k8sflag.NewStringSlice(&files)
+	flag.Var(filesFlag, "f", "YAML file, directory, or - for stdin (repeatable)")
+	clusterVersion := flag.String("cluster-version", "v4.22", "OpenShift cluster version (overridden by -cluster)")
+	namespace := flag.String("namespace", "openshift-cluster-observability-operator", "Namespace for operator resources")
+	useCluster := flag.Bool("cluster", false, "Connect to cluster for version, secrets, and TLS profile")
+	otelCSV := flag.String("opentelemetry-csv", "", "OpenTelemetry Operator starting CSV (default: latest)")
+	tempoCSV := flag.String("tempo-csv", "", "Tempo Operator starting CSV (default: latest)")
+	operators := flag.Bool("operators", false, "Output only operator resources (Subscriptions)")
+	resources := flag.Bool("resources", false, "Output only non-operator resources (CRD instances, RBAC, etc.)")
+	imageOverrides := k8sflag.NewMapStringString(new(map[string]string))
+	flag.Var(imageOverrides, "images", "Override default image as key=value (repeatable)")
+	flag.Parse()
+	if flag.NArg() > 0 {
+		exitMsg("unused arguments: %v", flag.Args())
+	}
+
+	if len(files) == 0 {
+		exitMsg("no input specified, use -f")
+	}
+
+	var k8sClient client.Client
+	var dynamicClient dynamic.Interface
+	if *useCluster {
+		restConfig := ctrl.GetConfigOrDie()
+		clusterScheme := runtime.NewScheme()
+		exitErr(clientgoscheme.AddToScheme(clusterScheme), "error loading scheme")
+		exitErr(configv1.Install(clusterScheme), "error loading OpenShift config scheme")
+
+		var err error
+		k8sClient, err = client.New(restConfig, client.Options{Scheme: clusterScheme})
+		exitErr(err, "error creating cluster client")
+		dynamicClient, err = dynamic.NewForConfig(restConfig)
+		exitErr(err, "error creating dynamic client")
+	}
+
+	stdout, warnings, err := Run(RunConfig{
+		Input:          files,
+		Namespace:      *namespace,
+		ClusterVersion: *clusterVersion,
+		Operators:      *operators,
+		Resources:      *resources,
+		OtelCSV:        *otelCSV,
+		TempoCSV:       *tempoCSV,
+		Images:         *imageOverrides.Map,
+		K8sClient:      k8sClient,
+		DynamicClient:  dynamicClient,
+	})
+	exitErr(err, "error generating resources")
+
+	if stdout != "" {
+		fmt.Print(stdout)
+	}
+	if warnings != "" {
+		fmt.Fprintln(os.Stderr, warnings)
+		os.Exit(1)
+	}
+}
+
+// generateInstallerObjects generates the operands of each installer and adds to set.
+func generateInstallerObjects(installers []*obsv1alpha1.ObservabilityInstaller, opts observability.Options, set *resourceSet, reader client.Reader, installOperators, installResources bool) error {
+	var errs error
+
+	for _, installer := range installers {
+		if installer.Namespace == "" {
+			errs = errors.Join(errs, fmt.Errorf("skipping ObservabilityInstaller %q: no namespace set (use metadata.namespace or kubectl -n)", installer.Name))
+			continue
+		}
+		installerObjects, err := observability.GenerateInstallerObjects(context.Background(), reader, installer, opts, installOperators, installResources)
+		if err != nil {
+			errs = errors.Join(errs, err)
+			continue
+		}
+		for _, obj := range installerObjects {
+			if err := set.AddResource(obj); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+func findTracingInstaller(installers []*obsv1alpha1.ObservabilityInstaller) *obsv1alpha1.ObservabilityInstaller {
+	for _, installer := range installers {
+		if tracing := installer.Spec.GetCapabilities().GetTracing(); tracing != nil && tracing.Enabled {
+			return installer
+		}
+	}
+	return nil
+}
+
+func readInputs(files []string) ([]byte, error) {
+	var buf bytes.Buffer
+	appendFile := func(path string) error {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if buf.Len() > 0 {
+			buf.WriteString("\n---\n")
+		}
+		buf.Write(data)
+		return nil
+	}
+	for _, f := range files {
+		if f == "-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, err
+			}
+			if buf.Len() > 0 {
+				buf.WriteString("\n---\n")
+			}
+			buf.Write(data)
+			continue
+		}
+		info, err := os.Stat(f)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
+			if err := appendFile(f); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		entries, err := os.ReadDir(f)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			ext := filepath.Ext(e.Name())
+			if ext != ".yaml" && ext != ".yml" {
+				continue
+			}
+			if err := appendFile(filepath.Join(f, e.Name())); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// generateUIPluginObjects generates the operands of each uiplugin and adds to the set.
+func generateUIPluginObjects(plugins []*uiv1alpha1.UIPlugin, conf uiplugin.UIPluginBuildConfig, set *resourceSet) error {
+	// Add UIPlugin CRs generated by the observabilityinstaller.
+	uiPluginGVK := uiv1alpha1.GroupVersion.WithKind("UIPlugin")
+	for _, obj := range set.Build() {
+		if obj.GetObjectKind().GroupVersionKind() != uiPluginGVK {
+			continue
+		}
+		plugin := &uiv1alpha1.UIPlugin{}
+		// MarshalCopy works for structured or unstructured obj
+		if err := util.MarshalCopy(plugin, obj); err != nil {
+			return fmt.Errorf("extracting UIPlugin %s: %w", obj.GetName(), err)
+		}
+		plugins = append(plugins, plugin)
+	}
+	slices.SortFunc(plugins, func(a, b *uiv1alpha1.UIPlugin) int { return util.CompareObjects(a, b) })
+	plugins = slices.CompactFunc(plugins, func(a, b *uiv1alpha1.UIPlugin) bool { return util.CompareObjects(a, b) == 0 })
+
+	var errs error
+	for _, plugin := range plugins {
+		pluginObjects, _, err := uiplugin.GenerateUIPluginObjects(context.Background(), plugin, conf, logr.Discard())
+		errs = errors.Join(errs, err)
+		for _, obj := range pluginObjects {
+			if err := set.AddResource(obj); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+// decodeResources returns installers, uiplugins and other objects like secrets and configmaps.
+func decodeResources(scheme *runtime.Scheme, data []byte) ([]*obsv1alpha1.ObservabilityInstaller, []*uiv1alpha1.UIPlugin, []client.Object, error) {
+	decode := serializer.NewCodecFactory(scheme).UniversalDeserializer().Decode
+	reader := yaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(data)))
+
+	var installers []*obsv1alpha1.ObservabilityInstaller
+	var plugins []*uiv1alpha1.UIPlugin
+	var loadedObjects []client.Object
+
+	for {
+		doc, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("reading YAML document: %w", err)
+		}
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+
+		obj, _, err := decode(doc, nil, nil)
+		if err != nil {
+			// Fall back to unstructured for types not in the scheme.
+			var u unstructured.Unstructured
+			if jsonErr := kyaml.Unmarshal(doc, &u.Object); jsonErr != nil {
+				return nil, nil, nil, fmt.Errorf("decoding YAML document: %w", err)
+			}
+			if u.GetKind() != "" {
+				loadedObjects = append(loadedObjects, &u)
+			}
+			continue
+		}
+
+		switch o := obj.(type) {
+		case *obsv1alpha1.ObservabilityInstaller:
+			installers = append(installers, o)
+		case *uiv1alpha1.UIPlugin:
+			plugins = append(plugins, o)
+		default:
+			if co, ok := o.(client.Object); ok {
+				loadedObjects = append(loadedObjects, co)
+			}
+		}
+	}
+	return installers, plugins, loadedObjects, nil
+}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -1,0 +1,485 @@
+package generator
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/controller-runtime-common/pkg/tls"
+	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	k8sflag "k8s.io/component-base/cli/flag"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	kyaml "sigs.k8s.io/yaml"
+
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
+	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
+	"github.com/rhobs/observability-operator/pkg/controllers/observability"
+	"github.com/rhobs/observability-operator/pkg/controllers/uiplugin"
+	"github.com/rhobs/observability-operator/pkg/controllers/util"
+	"github.com/rhobs/observability-operator/pkg/images"
+	"github.com/rhobs/observability-operator/pkg/operator"
+)
+
+func exitMsg(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}
+
+func exitErr(err error, msg string) {
+	if err != nil {
+		exitMsg("%v: %v", msg, err)
+	}
+}
+
+// RunConfig holds the inputs for a generator run. It is populated by the CLI
+// flags in Main and directly by tests.
+type RunConfig struct {
+	// Input is the list of YAML files, directories, or "-" for stdin.
+	Input []string
+	// Namespace is the namespace the operator itself is installed in.
+	Namespace string
+	// ClusterVersion is the OpenShift cluster version, used by UIPlugin code.
+	ClusterVersion string
+	// Operators selects operator infrastructure only; Resources selects
+	// non-operator resources only. Both false or both true means everything.
+	Operators bool
+	Resources bool
+	// OtelCSV and TempoCSV are the starting CSVs for the OTel and Tempo
+	// subscriptions (empty means the operator catalog's default).
+	OtelCSV  string
+	TempoCSV string
+	// Images overrides default images, keyed by image name.
+	Images map[string]string
+	// K8sClient, when set, is used to fetch version, TLS profile and secrets.
+	K8sClient client.Client
+	// TLSProfile overrides the TLS profile used for UIPlugin operands.
+	TLSProfile configv1.TLSProfileSpec
+	// SaveDir, when set, writes each intermediate resource to a file in the
+	// directory. OutputDir, when set, writes each output resource to a file in
+	// the directory instead of the returned manifest.
+	SaveDir   string
+	OutputDir string
+}
+
+// Run generates the YAML manifest for the configured resources.
+// It returns the stdout manifest, and errors collected during the run.
+func Run(cfg RunConfig) (string, string, error) {
+	resolvedImages, err := images.Validate(cfg.Images)
+	if err != nil {
+		return "", "", err
+	}
+	// Default values from cfg
+	clusterVersion := cfg.ClusterVersion
+	tlsProfile := cfg.TLSProfile
+	if cfg.K8sClient != nil {
+		// Overwrite with cluster values if we have a K8sClient
+		tlsProfile, err = tls.FetchAPIServerTLSProfile(context.Background(), cfg.K8sClient)
+		if err != nil {
+			return "", "", fmt.Errorf("error fetching TLS profile from cluster: %w", err)
+		}
+		cv := &configv1.ClusterVersion{}
+		err = cfg.K8sClient.Get(context.Background(), client.ObjectKey{Name: "version"}, cv)
+		if err != nil {
+			return "", "", fmt.Errorf("error fetching cluster version: %w", err)
+		}
+		for _, update := range cv.Status.History {
+			if update.State == configv1.CompletedUpdate {
+				clusterVersion = update.Version
+				break
+			}
+		}
+	}
+
+	scheme := operator.NewScheme(&operator.OperatorConfiguration{
+		FeatureGates: operator.FeatureGates{
+			OpenShift: operator.OpenShiftFeatureGates{
+				Enabled: true,
+				Version: clusterVersion,
+			},
+		}})
+
+	yamlData, err := readInputs(cfg.Input)
+	if err != nil {
+		return "", "", fmt.Errorf("error reading input: %w", err)
+	}
+
+	installers, plugins, others, err := decodeResources(scheme, yamlData)
+	if err != nil {
+		return "", "", fmt.Errorf("error decoding resources: %w", err)
+	}
+
+	installerOpts := observability.Options{
+		COONamespace: cfg.Namespace,
+		OpenTelemetryOperator: observability.OperatorInstallConfig{
+			Namespace:   cfg.Namespace,
+			PackageName: "opentelemetry-product",
+			StartingCSV: cfg.OtelCSV,
+			Channel:     "stable",
+		},
+		TempoOperator: observability.OperatorInstallConfig{
+			Namespace:   cfg.Namespace,
+			PackageName: "tempo-product",
+			StartingCSV: cfg.TempoCSV,
+			Channel:     "stable",
+		},
+	}
+
+	installOperators := cfg.Operators || !cfg.Resources
+	installResources := cfg.Resources || !cfg.Operators
+
+	// accumulate resources in set
+	set := newResourceSet(scheme)
+
+	if err := createOLMResources(cfg.Namespace, installOperators, set); err != nil {
+		return "", "", fmt.Errorf("creating pre-requisite resources: %w", err)
+	}
+
+	// reader makes helper objects (secrets, configmaps) read from YAML available to kustomize.
+	reader := NewFallbackReader(cfg.K8sClient, others...)
+
+	var errs error
+	err = generateInstallerObjects(installers, installerOpts, set, reader, installOperators, installResources)
+	errs = errors.Join(errs, err)
+
+	if installResources {
+		pluginConf := uiplugin.UIPluginBuildConfig{
+			Images:            resolvedImages,
+			Namespace:         cfg.Namespace,
+			ClusterVersion:    clusterVersion,
+			TempoServiceNames: tempoServiceNames(installers),
+		}
+		pluginConf.ApplyTLSProfile(tlsProfile)
+
+		if err := generateUIPluginObjects(plugins, pluginConf, set); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("resolving UIPlugins: %w", err))
+		}
+	}
+
+	if cfg.SaveDir != "" {
+		err = os.MkdirAll(cfg.SaveDir, 0o755)
+		if err != nil {
+			return "", "", err
+		}
+		err = set.WriteToDir(cfg.SaveDir)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
+	objects := set.Build()
+
+	// UIPlugin CRs have been resolved into concrete resources, remove them from output.
+	objects = slices.DeleteFunc(objects, func(obj client.Object) bool {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		return gvk.Group == "observability.openshift.io" && gvk.Kind == "UIPlugin"
+	})
+
+	if cfg.OutputDir != "" && cfg.OutputDir != "-" {
+		if err := os.MkdirAll(cfg.OutputDir, 0o755); err != nil {
+			return "", "", err
+		}
+		if err := writeObjectsToDir(cfg.OutputDir, objects); err != nil {
+			return "", "", err
+		}
+		return "", errsString(errs), nil
+	}
+
+	var buf bytes.Buffer
+	for _, obj := range objects {
+		data, err := kyaml.Marshal(obj)
+		if err != nil {
+			return "", "", err
+		}
+		buf.WriteString("---\n")
+		buf.Write(data)
+	}
+
+	return buf.String(), errsString(errs), nil
+}
+
+func errsString(errs error) string {
+	if errs == nil {
+		return ""
+	}
+	return errs.Error()
+}
+
+func Main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, `
+Usage: %v [OPTIONS] -f FILE...
+
+Offline generator for the Cluster Observability Operator (COO). Reads COO custom
+resources and supporting objects from YAML, runs the operator's reconciler code
+offline, and writes the resulting Kubernetes objects to stdout. Use -operators
+and -resources for staged apply; use -cluster to resolve secrets, TLS profile,
+and version from a live cluster.
+`, filepath.Base(os.Args[0]))
+		flag.PrintDefaults()
+	}
+	var files []string
+	filesFlag := k8sflag.NewStringSlice(&files)
+	flag.Var(filesFlag, "f", "YAML file, directory, or - for stdin (repeatable)")
+	clusterVersion := flag.String("cluster-version", "v4.22", "OpenShift cluster version (overridden by -cluster)")
+	namespace := flag.String("namespace", "openshift-cluster-observability-operator", "Namespace for operator resources")
+	saveDir := flag.String("save", "", "Save intermediate output to DIR")
+	outputDir := flag.String("output", "", "Write output resources to directory instead of stdout")
+	useCluster := flag.Bool("cluster", false, "Connect to cluster for version, secrets, and TLS profile")
+	otelCSV := flag.String("opentelemetry-csv", "", "OpenTelemetry Operator starting CSV (default: latest)")
+	tempoCSV := flag.String("tempo-csv", "", "Tempo Operator starting CSV (default: latest)")
+	operators := flag.Bool("operators", false, "Output only operator resources (Subscriptions)")
+	resources := flag.Bool("resources", false, "Output only non-operator resources (CRD instances, RBAC, etc.)")
+	imageOverrides := k8sflag.NewMapStringString(new(map[string]string))
+	flag.Var(imageOverrides, "images", "Override default image as key=value (repeatable)")
+	flag.Parse()
+	if flag.NArg() > 0 {
+		exitMsg("unused arguments: %v", flag.Args())
+	}
+
+	if len(files) == 0 {
+		exitMsg("no input specified, use -f")
+	}
+
+	var k8sClient client.Client
+	if *useCluster {
+		clusterScheme := runtime.NewScheme()
+		exitErr(clientgoscheme.AddToScheme(clusterScheme), "error loading scheme")
+		exitErr(configv1.Install(clusterScheme), "error loading OpenShift config scheme")
+
+		var err error
+		k8sClient, err = client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: clusterScheme})
+		exitErr(err, "error creating cluster client")
+	}
+
+	stdout, warnings, err := Run(RunConfig{
+		Input:          files,
+		Namespace:      *namespace,
+		ClusterVersion: *clusterVersion,
+		Operators:      *operators,
+		Resources:      *resources,
+		OtelCSV:        *otelCSV,
+		TempoCSV:       *tempoCSV,
+		Images:         *imageOverrides.Map,
+		K8sClient:      k8sClient,
+		SaveDir:        *saveDir,
+		OutputDir:      *outputDir,
+	})
+	exitErr(err, "error generating resources")
+
+	if stdout != "" {
+		fmt.Print(stdout)
+	}
+	if warnings != "" {
+		fmt.Fprintln(os.Stderr, warnings)
+		os.Exit(1)
+	}
+}
+
+// createOLMResources creates the Namespace and OperatorGroup.
+//
+// These are the only resources that are created by the generator but not by the operator.
+// For the operator they are created by OLM when the operator is installed.
+func createOLMResources(namespace string, operators bool, set *resourceSet) error {
+	if namespace == "" {
+		return errors.New("COO namespace must be set")
+	}
+	if err := set.AddResource(&corev1.Namespace{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}); err != nil {
+		return err
+	}
+	if operators {
+		if err := set.AddResource(&olmv1.OperatorGroup{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "OperatorGroup",
+				APIVersion: olmv1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      namespace,
+				Namespace: namespace,
+			}}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// generateInstallerObjects generates the operands of each installer and adds to set.
+func generateInstallerObjects(installers []*obsv1alpha1.ObservabilityInstaller, opts observability.Options, set *resourceSet, reader client.Reader, installOperators, installResources bool) error {
+	var errs error
+
+	for _, installer := range installers {
+		if installer.Namespace == "" {
+			errs = errors.Join(errs, fmt.Errorf("skipping ObservabilityInstaller %q: no namespace set (use metadata.namespace or kubectl -n)", installer.Name))
+			continue
+		}
+		installerObjects, err := observability.GenerateInstallerObjects(context.Background(), reader, reader, installer, opts, installOperators, installResources)
+		if err != nil {
+			errs = errors.Join(errs, err)
+			continue
+		}
+		for _, obj := range installerObjects {
+			if err := set.AddResource(obj); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+func tempoServiceNames(installers []*obsv1alpha1.ObservabilityInstaller) map[string]string {
+	names := make(map[string]string)
+	for _, installer := range installers {
+		if tracing := installer.Spec.GetCapabilities().GetTracing(); tracing != nil && tracing.Enabled {
+			names[installer.Namespace] = fmt.Sprintf("tempo-%s-gateway", installer.Name)
+		}
+	}
+	return names
+}
+
+func readInputs(files []string) ([]byte, error) {
+	var buf bytes.Buffer
+	appendFile := func(path string) error {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if buf.Len() > 0 {
+			buf.WriteString("\n---\n")
+		}
+		buf.Write(data)
+		return nil
+	}
+	for _, f := range files {
+		if f == "-" {
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return nil, err
+			}
+			if buf.Len() > 0 {
+				buf.WriteString("\n---\n")
+			}
+			buf.Write(data)
+			continue
+		}
+		info, err := os.Stat(f)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
+			if err := appendFile(f); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		entries, err := os.ReadDir(f)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			ext := filepath.Ext(e.Name())
+			if ext != ".yaml" && ext != ".yml" {
+				continue
+			}
+			if err := appendFile(filepath.Join(f, e.Name())); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// generateUIPluginObjects generates the operands of each uiplugin and adds to the set.
+func generateUIPluginObjects(plugins []*uiv1alpha1.UIPlugin, conf uiplugin.UIPluginBuildConfig, set *resourceSet) error {
+	// Add UIPlugin CRs generated by the observabilityinstaller.
+	uiPluginGVK := uiv1alpha1.GroupVersion.WithKind("UIPlugin")
+	for _, obj := range set.Build() {
+		if obj.GetObjectKind().GroupVersionKind() != uiPluginGVK {
+			continue
+		}
+		plugin := &uiv1alpha1.UIPlugin{}
+		// MarshalCopy works for structured or unstructured obj
+		if err := util.MarshalCopy(plugin, obj); err != nil {
+			return fmt.Errorf("extracting UIPlugin %s: %w", obj.GetName(), err)
+		}
+		plugins = append(plugins, plugin)
+	}
+	slices.SortFunc(plugins, func(a, b *uiv1alpha1.UIPlugin) int { return util.CompareObjects(a, b) })
+	plugins = slices.CompactFunc(plugins, func(a, b *uiv1alpha1.UIPlugin) bool { return util.CompareObjects(a, b) == 0 })
+
+	var errs error
+	for _, plugin := range plugins {
+		pluginObjects, _, err := uiplugin.GenerateUIPluginObjects(context.Background(), plugin, conf, logr.Discard())
+		errs = errors.Join(errs, err)
+		for _, obj := range pluginObjects {
+			if err := set.AddResource(obj); err != nil {
+				errs = errors.Join(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+// decodeResources returns installers, uiplugins and other objects like secrets and configmaps.
+func decodeResources(scheme *runtime.Scheme, data []byte) ([]*obsv1alpha1.ObservabilityInstaller, []*uiv1alpha1.UIPlugin, []client.Object, error) {
+	decode := serializer.NewCodecFactory(scheme).UniversalDeserializer().Decode
+	reader := yaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(data)))
+
+	var installers []*obsv1alpha1.ObservabilityInstaller
+	var plugins []*uiv1alpha1.UIPlugin
+	var loadedObjects []client.Object
+
+	for {
+		doc, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("reading YAML document: %w", err)
+		}
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+
+		obj, _, err := decode(doc, nil, nil)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("decoding YAML document: %w", err)
+		}
+
+		switch o := obj.(type) {
+		case *obsv1alpha1.ObservabilityInstaller:
+			installers = append(installers, o)
+		case *uiv1alpha1.UIPlugin:
+			plugins = append(plugins, o)
+		default:
+			if co, ok := o.(client.Object); ok {
+				loadedObjects = append(loadedObjects, co)
+			}
+		}
+	}
+	return installers, plugins, loadedObjects, nil
+}

--- a/pkg/generator/generator_parity_test.go
+++ b/pkg/generator/generator_parity_test.go
@@ -1,0 +1,359 @@
+package generator
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	kyaml "sigs.k8s.io/yaml"
+
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
+	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
+	"github.com/rhobs/observability-operator/pkg/controllers/observability"
+	"github.com/rhobs/observability-operator/pkg/controllers/uiplugin"
+	"github.com/rhobs/observability-operator/pkg/controllers/util"
+	"github.com/rhobs/observability-operator/pkg/images"
+	"github.com/rhobs/observability-operator/pkg/operator"
+	"github.com/rhobs/observability-operator/pkg/reconciler"
+)
+
+const (
+	testNamespace      = "openshift-cluster-observability-operator"
+	testClusterVersion = "v4.22"
+)
+
+// installerOptions returns the operator install options the generator and the
+// reconciler use, pointing at the same package/channel names so the parity
+// tests compare like with like.
+func installerOptions() observability.Options {
+	return observability.Options{
+		COONamespace: testNamespace,
+		OpenTelemetryOperator: observability.OperatorInstallConfig{
+			Namespace:   testNamespace,
+			PackageName: "opentelemetry-product",
+			StartingCSV: "",
+			Channel:     "stable",
+		},
+		TempoOperator: observability.OperatorInstallConfig{
+			Namespace:   testNamespace,
+			PackageName: "tempo-product",
+			StartingCSV: "",
+			Channel:     "stable",
+		},
+	}
+}
+
+// decodeObjects parses multi-document YAML into unstructured objects.
+func decodeObjects(data []byte) ([]client.Object, error) {
+	reader := yaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(data)))
+	var objects []client.Object
+	for {
+		doc, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+		jsonData, err := kyaml.YAMLToJSON(doc)
+		if err != nil {
+			return nil, err
+		}
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(jsonData); err != nil {
+			return nil, err
+		}
+		objects = append(objects, obj)
+	}
+	return objects, nil
+}
+
+// recordingClient wraps a client.Client and records every object handed to
+// Apply, Create or Update. The reconcilers mutate the objects (add common
+// labels, set owner references) before handing them over, so the recording
+// captures exactly what the operator would apply to a cluster.
+type recordingClient struct {
+	client.Client
+	applied []client.Object
+}
+
+func (r *recordingClient) record(obj client.Object, scheme *k8sruntime.Scheme) error {
+	u, err := objectToUnstructured(obj, scheme)
+	if err != nil {
+		return err
+	}
+	r.applied = append(r.applied, u)
+	return nil
+}
+
+func (r *recordingClient) Apply(ctx context.Context, obj k8sruntime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	u := &unstructured.Unstructured{}
+	if err := u.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	r.applied = append(r.applied, u)
+	// The fake client's Apply zeroes the apply configuration before
+	// unmarshalling the patched result back into it, which loses the reconciler's
+	// wrapped object (see pkg/reconciler/clientObjectApplyConfig) and fails with
+	// "json: Unmarshal(nil)". The reconciler's Reconcile has already built the
+	// labelled/owner-referenced object we recorded, and nothing downstream reads
+	// the fake client's stored state, so recording without applying is equivalent
+	// for this parity check.
+	return nil
+}
+
+func (r *recordingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := r.record(obj, r.Client.Scheme()); err != nil {
+		return err
+	}
+	return r.Client.Create(ctx, obj, opts...)
+}
+
+func (r *recordingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if err := r.record(obj, r.Client.Scheme()); err != nil {
+		return err
+	}
+	return r.Client.Update(ctx, obj, opts...)
+}
+
+// objectToUnstructured converts a typed object to unstructured, filling the
+// GroupVersionKind from the scheme when the object has no TypeMeta.
+func objectToUnstructured(obj client.Object, scheme *k8sruntime.Scheme) (*unstructured.Unstructured, error) {
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return u, nil
+	}
+	data, err := kyaml.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	jsonData, err := kyaml.YAMLToJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{}
+	if err := u.UnmarshalJSON(jsonData); err != nil {
+		return nil, err
+	}
+	if u.GetKind() == "" {
+		gvks, _, err := scheme.ObjectKinds(obj)
+		if err != nil {
+			return nil, err
+		}
+		u.SetGroupVersionKind(gvks[0])
+	}
+	return u, nil
+}
+
+// stripClusterState removes fields that only exist on objects applied to a
+// cluster (and would therefore never appear in the generator's output).
+func stripClusterState(u *unstructured.Unstructured) {
+	for _, field := range []string{
+		"resourceVersion", "uid", "generation", "creationTimestamp",
+		"managedFields", "ownerReferences", "finalizers",
+	} {
+		unstructured.RemoveNestedField(u.Object, "metadata", field)
+	}
+}
+
+// objectIdentity returns a stable identity for an object: group/kind/namespace/name.
+func objectIdentity(obj client.Object) string {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	return strings.Join([]string{gvk.Group, gvk.Kind, obj.GetNamespace(), obj.GetName()}, "/")
+}
+
+// mirrorOperatorLabels applies the same label mutation the operator's
+// reconcilers perform (util.AddCommonLabels) to the generator's output objects,
+// so the two sides can be compared on equal footing.
+//
+// Installer-origin objects are labelled with the installer name (the operator
+// uses the ObservabilityInstaller CR as the Updater owner). UIPlugin operands
+// already carry their plugin's labels; AddCommonLabels is idempotent for them.
+func mirrorOperatorLabels(t *testing.T, objects []client.Object, installers []*obsv1alpha1.ObservabilityInstaller, others []client.Object) {
+	t.Helper()
+	reader := NewFallbackReader(nil, others...)
+	ownerByIdentity := map[string]string{}
+	for _, installer := range installers {
+		installerObjects, err := observability.GenerateInstallerObjects(context.Background(), reader, reader, installer, installerOptions(), true, true)
+		assert.NilError(t, err)
+		for _, obj := range installerObjects {
+			ownerByIdentity[objectIdentity(obj)] = installer.Name
+		}
+	}
+	for _, obj := range objects {
+		owner, ok := ownerByIdentity[objectIdentity(obj)]
+		if !ok {
+			owner = obj.GetLabels()["app.kubernetes.io/part-of"]
+		}
+		if owner == "" {
+			t.Errorf("cannot attribute owner for %s: object is neither an installer operand nor a labelled UIPlugin operand", objectIdentity(obj))
+			continue
+		}
+		util.AddCommonLabels(obj, owner)
+	}
+}
+
+// TestReconcilerMatchGenerator verifies that the object set
+// the operator's reconcile machinery would apply to a cluster matches the
+// manifest the offline generator emits for the same input CRs.
+//
+// This test drives the
+// real reconcile path: observability.GenerateAllInstallerObjects feeds
+// reconciler.Updater / CreateUpdateReconciler, whose Reconcile methods add
+// common labels and apply (server-side apply) the resources; UIPlugin operands
+// are applied the same way the UIPlugin controller applies them (a
+// reconciler.Updater per operand). This catches drift between the operator and
+// generator that the shared functions cannot, e.g. in label handling.
+//
+// The two sides are not byte-identical by design:
+//   - The generator emits the COO Namespace and OperatorGroup, which OLM creates
+//     when the operator is installed; they are dropped.
+//   - The operator persists UIPlugin CRs as separate reconciled objects while
+//     the generator resolves them into operands and drops the CRs; they are
+//     dropped from the operator side.
+//   - Applied objects carry owner references and server-side-apply metadata that
+//     never appears in the generator output; they are stripped.
+//
+// The full uiplugin.resourceManager.Reconcile (Console CR registration, status
+// updates, dynamic client usage) requires a live API server and is out of scope.
+func TestReconcilerMatchGenerator(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	testdataDir := filepath.Join(filepath.Dir(thisFile), "testdata", "sample")
+
+	scheme := operator.NewScheme(&operator.OperatorConfiguration{
+		FeatureGates: operator.FeatureGates{
+			OpenShift: operator.OpenShiftFeatureGates{
+				Enabled: true,
+				Version: testClusterVersion,
+			},
+		}})
+
+	yamlData, err := readInputs([]string{testdataDir})
+	assert.NilError(t, err)
+	installers, plugins, others, err := decodeResources(scheme, yamlData)
+	assert.NilError(t, err)
+	assert.Assert(t, len(installers) > 0, "sample input must contain at least one ObservabilityInstaller")
+
+	// The generator's output is the ground truth for the desired object set.
+	genOutput, warnings, err := Run(RunConfig{
+		Input:          []string{testdataDir},
+		Namespace:      testNamespace,
+		ClusterVersion: testClusterVersion,
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, warnings, "")
+	genObjects, err := decodeObjects([]byte(genOutput))
+	assert.NilError(t, err)
+
+	// The generator emits the Namespace and OperatorGroup that OLM would create
+	// when the operator is installed; the operator never applies them.
+	genObjects = slices.DeleteFunc(genObjects, func(obj client.Object) bool {
+		u := obj.(*unstructured.Unstructured)
+		return u.GetKind() == "Namespace" || u.GetKind() == "OperatorGroup"
+	})
+	// Mirror the label mutation the operator's reconcilers perform.
+	mirrorOperatorLabels(t, genObjects, installers, others)
+
+	// Operator side: drive the reconcile machinery against a fake client,
+	// recording everything applied.
+	fakeClient := clientfake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(others...).
+		Build()
+	rec := &recordingClient{Client: fakeClient}
+	reader := NewFallbackReader(fakeClient, others...)
+
+	var recordedPlugins []*uiv1alpha1.UIPlugin
+
+	// Replicate the fresh-install branch of observability.getReconcilers: with no
+	// pre-installed subscriptions every object is created/updated, subscriptions
+	// go through CreateUpdateReconciler and everything else through Updater.
+	for _, installer := range installers {
+		installer.UID = types.UID("parity-installer")
+		objects, err := observability.GenerateAllInstallerObjects(context.Background(), reader, reader, installer, installerOptions())
+		assert.NilError(t, err)
+		for _, obj := range objects {
+			if plugin, ok := obj.(*uiv1alpha1.UIPlugin); ok {
+				recordedPlugins = append(recordedPlugins, plugin)
+			}
+		}
+
+		subs := slices.DeleteFunc(slices.Clone(genObjects), func(obj client.Object) bool {
+			return obj.GetObjectKind().GroupVersionKind().Kind != "Subscription"
+		})
+		assert.Assert(t, len(subs) == 2, "expected the two operator subscriptions, got %d", len(subs))
+
+		var installerReconcilers []reconciler.Reconciler
+		for _, sub := range subs {
+			installerReconcilers = append(installerReconcilers, reconciler.NewCreateUpdateReconciler(sub, installer))
+		}
+		for _, obj := range objects {
+			installerReconcilers = append(installerReconcilers, reconciler.NewUpdater(obj, installer))
+		}
+		for _, installerRec := range installerReconcilers {
+			assert.NilError(t, installerRec.Reconcile(context.Background(), rec, scheme))
+		}
+	}
+
+	// UIPlugin operands: the input plugins plus the UIPlugin CRs the installer
+	// creates (typed, collected above); dedup in case the input already contains
+	// a plugin with the same name.
+	allPlugins := append(slices.Clone(plugins), recordedPlugins...)
+	slices.SortFunc(allPlugins, func(a, b *uiv1alpha1.UIPlugin) int { return util.CompareObjects(a, b) })
+	allPlugins = slices.CompactFunc(allPlugins, func(a, b *uiv1alpha1.UIPlugin) bool { return util.CompareObjects(a, b) == 0 })
+
+	resolvedImages, err := images.Validate(nil)
+	assert.NilError(t, err)
+	pluginConf := uiplugin.UIPluginBuildConfig{
+		Images:            resolvedImages,
+		Namespace:         testNamespace,
+		ClusterVersion:    testClusterVersion,
+		TempoServiceNames: tempoServiceNames(installers),
+	}
+	for _, plugin := range allPlugins {
+		if plugin.UID == "" {
+			plugin.UID = types.UID(fmt.Sprintf("parity-plugin-%s", plugin.Name))
+		}
+		pluginObjects, _, err := uiplugin.GenerateUIPluginObjects(context.Background(), plugin, pluginConf, logr.Discard())
+		assert.NilError(t, err)
+		for _, obj := range pluginObjects {
+			assert.NilError(t, reconciler.NewUpdater(obj, plugin).Reconcile(context.Background(), rec, scheme))
+		}
+	}
+
+	// The operator persists UIPlugin CRs as separate reconciled objects; the
+	// generator resolves them into operands and drops them from its output.
+	applied := slices.DeleteFunc(rec.applied, func(obj client.Object) bool {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		return gvk.Group == "observability.openshift.io" && gvk.Kind == "UIPlugin"
+	})
+	for _, obj := range applied {
+		stripClusterState(obj.(*unstructured.Unstructured))
+	}
+	slices.SortFunc(applied, util.CompareObjects)
+	slices.SortFunc(genObjects, util.CompareObjects)
+	assert.DeepEqual(t, genObjects, applied)
+}

--- a/pkg/generator/generator_parity_test.go
+++ b/pkg/generator/generator_parity_test.go
@@ -1,0 +1,364 @@
+package generator
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	kyaml "sigs.k8s.io/yaml"
+
+	obsv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/observability/v1alpha1"
+	uiv1alpha1 "github.com/rhobs/observability-operator/pkg/apis/uiplugin/v1alpha1"
+	"github.com/rhobs/observability-operator/pkg/controllers/observability"
+	"github.com/rhobs/observability-operator/pkg/controllers/uiplugin"
+	"github.com/rhobs/observability-operator/pkg/controllers/util"
+	"github.com/rhobs/observability-operator/pkg/images"
+	"github.com/rhobs/observability-operator/pkg/operator"
+	"github.com/rhobs/observability-operator/pkg/reconciler"
+)
+
+const (
+	testNamespace      = "openshift-cluster-observability-operator"
+	testClusterVersion = "v4.22"
+)
+
+// installerOptions returns the operator install options the generator and the
+// reconciler use, pointing at the same package/channel names so the parity
+// tests compare like with like.
+func installerOptions() observability.Options {
+	return observability.Options{
+		COONamespace: testNamespace,
+		OpenTelemetryOperator: observability.OperatorInstallConfig{
+			Namespace:   testNamespace,
+			PackageName: "opentelemetry-product",
+			StartingCSV: "",
+			Channel:     "stable",
+		},
+		TempoOperator: observability.OperatorInstallConfig{
+			Namespace:   testNamespace,
+			PackageName: "tempo-product",
+			StartingCSV: "",
+			Channel:     "stable",
+		},
+	}
+}
+
+// decodeObjects parses multi-document YAML into unstructured objects.
+func decodeObjects(data []byte) ([]client.Object, error) {
+	reader := yaml.NewYAMLReader(bufio.NewReader(bytes.NewReader(data)))
+	var objects []client.Object
+	for {
+		doc, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		doc = bytes.TrimSpace(doc)
+		if len(doc) == 0 {
+			continue
+		}
+		jsonData, err := kyaml.YAMLToJSON(doc)
+		if err != nil {
+			return nil, err
+		}
+		obj := &unstructured.Unstructured{}
+		if err := obj.UnmarshalJSON(jsonData); err != nil {
+			return nil, err
+		}
+		objects = append(objects, obj)
+	}
+	return objects, nil
+}
+
+// recordingClient wraps a client.Client and records every object handed to
+// Apply, Create or Update. The reconcilers mutate the objects (add common
+// labels, set owner references) before handing them over, so the recording
+// captures exactly what the operator would apply to a cluster.
+type recordingClient struct {
+	client.Client
+	applied []client.Object
+}
+
+func (r *recordingClient) record(obj client.Object, scheme *k8sruntime.Scheme) error {
+	u, err := objectToUnstructured(obj, scheme)
+	if err != nil {
+		return err
+	}
+	r.applied = append(r.applied, u)
+	return nil
+}
+
+func (r *recordingClient) Apply(ctx context.Context, obj k8sruntime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	u := &unstructured.Unstructured{}
+	if err := u.UnmarshalJSON(data); err != nil {
+		return err
+	}
+	r.applied = append(r.applied, u)
+	// The fake client's Apply zeroes the apply configuration before
+	// unmarshalling the patched result back into it, which loses the reconciler's
+	// wrapped object (see pkg/reconciler/clientObjectApplyConfig) and fails with
+	// "json: Unmarshal(nil)". The reconciler's Reconcile has already built the
+	// labelled/owner-referenced object we recorded, and nothing downstream reads
+	// the fake client's stored state, so recording without applying is equivalent
+	// for this parity check.
+	return nil
+}
+
+func (r *recordingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := r.record(obj, r.Client.Scheme()); err != nil {
+		return err
+	}
+	return r.Client.Create(ctx, obj, opts...)
+}
+
+func (r *recordingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if err := r.record(obj, r.Client.Scheme()); err != nil {
+		return err
+	}
+	return r.Client.Update(ctx, obj, opts...)
+}
+
+// objectToUnstructured converts a typed object to unstructured, filling the
+// GroupVersionKind from the scheme when the object has no TypeMeta.
+func objectToUnstructured(obj client.Object, scheme *k8sruntime.Scheme) (*unstructured.Unstructured, error) {
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return u, nil
+	}
+	data, err := kyaml.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	jsonData, err := kyaml.YAMLToJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{}
+	if err := u.UnmarshalJSON(jsonData); err != nil {
+		return nil, err
+	}
+	if u.GetKind() == "" {
+		gvks, _, err := scheme.ObjectKinds(obj)
+		if err != nil {
+			return nil, err
+		}
+		u.SetGroupVersionKind(gvks[0])
+	}
+	return u, nil
+}
+
+// stripClusterState removes fields that only exist on objects applied to a
+// cluster (and would therefore never appear in the generator's output).
+func stripClusterState(u *unstructured.Unstructured) {
+	for _, field := range []string{
+		"resourceVersion", "uid", "generation", "creationTimestamp",
+		"managedFields", "ownerReferences", "finalizers",
+	} {
+		unstructured.RemoveNestedField(u.Object, "metadata", field)
+	}
+}
+
+// objectIdentity returns a stable identity for an object: group/kind/namespace/name.
+func objectIdentity(obj client.Object) string {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	return strings.Join([]string{gvk.Group, gvk.Kind, obj.GetNamespace(), obj.GetName()}, "/")
+}
+
+// mirrorOperatorLabels applies the same label mutation the operator's
+// reconcilers perform (util.AddCommonLabels) to the generator's output objects,
+// so the two sides can be compared on equal footing.
+//
+// Installer-origin objects are labelled with the installer name (the operator
+// uses the ObservabilityInstaller CR as the Updater owner). UIPlugin operands
+// already carry their plugin's labels; AddCommonLabels is idempotent for them.
+func mirrorOperatorLabels(t *testing.T, objects []client.Object, installers []*obsv1alpha1.ObservabilityInstaller, others []client.Object) {
+	t.Helper()
+	reader := NewFallbackReader(nil, others...)
+	ownerByIdentity := map[string]string{}
+	for _, installer := range installers {
+		installerObjects, err := observability.GenerateInstallerObjects(context.Background(), reader, installer, installerOptions(), true, true)
+		require.NoError(t, err)
+		for _, obj := range installerObjects {
+			ownerByIdentity[objectIdentity(obj)] = installer.Name
+		}
+	}
+	for _, obj := range objects {
+		owner, ok := ownerByIdentity[objectIdentity(obj)]
+		if !ok {
+			owner = obj.GetLabels()["app.kubernetes.io/part-of"]
+		}
+		if owner == "" {
+			t.Errorf("cannot attribute owner for %s: object is neither an installer operand nor a labelled UIPlugin operand", objectIdentity(obj))
+			continue
+		}
+		util.AddCommonLabels(obj, owner)
+	}
+}
+
+// TestReconcilerMatchGenerator verifies that the object set
+// the operator's reconcile machinery would apply to a cluster matches the
+// manifest the offline generator emits for the same input CRs.
+//
+// This test drives the
+// real reconcile path: observability.GenerateAllInstallerObjects feeds
+// reconciler.Updater / CreateUpdateReconciler, whose Reconcile methods add
+// common labels and apply (server-side apply) the resources; UIPlugin operands
+// are applied the same way the UIPlugin controller applies them (a
+// reconciler.Updater per operand). This catches drift between the operator and
+// generator that the shared functions cannot, e.g. in label handling.
+//
+// The two sides are not byte-identical by design:
+//   - The generator emits the COO Namespace, which OLM creates when the
+//     operator is installed
+//   - The operator persists UIPlugin CRs as separate reconciled objects while
+//     the generator resolves them into operands and drops the CRs; they are
+//     dropped from the operator side.
+//   - Applied objects carry owner references and server-side-apply metadata that
+//     never appears in the generator output
+//
+// The full uiplugin.resourceManager.Reconcile (Console CR registration, status
+// updates, dynamic client usage) requires a live API server and is out of scope.
+func TestReconcilerMatchGenerator(t *testing.T) {
+	_, thisFile, _, _ := runtime.Caller(0)
+	testdataDir := filepath.Join(filepath.Dir(thisFile), "testdata", "sample")
+
+	scheme := operator.NewScheme(&operator.OperatorConfiguration{
+		FeatureGates: operator.FeatureGates{
+			OpenShift: operator.OpenShiftFeatureGates{
+				Enabled: true,
+				Version: testClusterVersion,
+			},
+		}})
+
+	yamlData, err := readInputs([]string{testdataDir})
+	require.NoError(t, err)
+	installers, plugins, others, err := decodeResources(scheme, yamlData)
+	require.NoError(t, err)
+	assert.Assert(t, len(installers) > 0, "sample input must contain at least one ObservabilityInstaller")
+
+	// The generator's output is the ground truth for the desired object set.
+	genOutput, warnings, err := Run(RunConfig{
+		Input:          []string{testdataDir},
+		Namespace:      testNamespace,
+		ClusterVersion: testClusterVersion,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, warnings, "")
+	genObjects, err := decodeObjects([]byte(genOutput))
+	require.NoError(t, err)
+
+	// The generator emits pass-through input objects (Namespaces, Secrets,
+	// etc.) and the COO Namespace; the operator never applies these.
+	inputIdentities := map[string]bool{}
+	for _, obj := range others {
+		inputIdentities[objectIdentity(obj)] = true
+	}
+	genObjects = slices.DeleteFunc(genObjects, func(obj client.Object) bool {
+		u := obj.(*unstructured.Unstructured)
+		return u.GetKind() == "Namespace" || inputIdentities[objectIdentity(u)]
+	})
+	// Mirror the label mutation the operator's reconcilers perform.
+	mirrorOperatorLabels(t, genObjects, installers, others)
+
+	// Operator side: drive the reconcile machinery against a fake client,
+	// recording everything applied.
+	fakeClient := clientfake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(others...).
+		Build()
+	rec := &recordingClient{Client: fakeClient}
+	reader := NewFallbackReader(fakeClient, others...)
+
+	var recordedPlugins []*uiv1alpha1.UIPlugin
+
+	// Replicate the fresh-install branch of observability.getReconcilers: with no
+	// pre-installed subscriptions every object is created/updated, subscriptions
+	// go through CreateUpdateReconciler and everything else through Updater.
+	for _, installer := range installers {
+		installer.UID = types.UID("parity-installer")
+		objects, err := observability.GenerateAllInstallerObjects(context.Background(), reader, installer, installerOptions())
+		require.NoError(t, err)
+		for _, obj := range objects {
+			if plugin, ok := obj.(*uiv1alpha1.UIPlugin); ok {
+				recordedPlugins = append(recordedPlugins, plugin)
+			}
+		}
+
+		subs := slices.DeleteFunc(slices.Clone(genObjects), func(obj client.Object) bool {
+			return obj.GetObjectKind().GroupVersionKind().Kind != "Subscription"
+		})
+		assert.Assert(t, len(subs) == 2, "expected the two operator subscriptions, got %d", len(subs))
+
+		var installerReconcilers []reconciler.Reconciler
+		for _, sub := range subs {
+			installerReconcilers = append(installerReconcilers, reconciler.NewCreateUpdateReconciler(sub, installer))
+		}
+		for _, obj := range objects {
+			installerReconcilers = append(installerReconcilers, reconciler.NewUpdater(obj, installer))
+		}
+		for _, installerRec := range installerReconcilers {
+			require.NoError(t, installerRec.Reconcile(context.Background(), rec, scheme))
+		}
+	}
+
+	// UIPlugin operands: the input plugins plus the UIPlugin CRs the installer
+	// creates (typed, collected above); dedup in case the input already contains
+	// a plugin with the same name.
+	allPlugins := append(slices.Clone(plugins), recordedPlugins...)
+	slices.SortFunc(allPlugins, func(a, b *uiv1alpha1.UIPlugin) int { return util.CompareObjects(a, b) })
+	allPlugins = slices.CompactFunc(allPlugins, func(a, b *uiv1alpha1.UIPlugin) bool { return util.CompareObjects(a, b) == 0 })
+
+	resolvedImages, err := images.Validate(nil)
+	require.NoError(t, err)
+	pluginConf := uiplugin.UIPluginBuildConfig{
+		Images:           resolvedImages,
+		Namespace:        testNamespace,
+		ClusterVersion:   testClusterVersion,
+		TracingInstaller: findTracingInstaller(installers),
+	}
+	for _, plugin := range allPlugins {
+		if plugin.UID == "" {
+			plugin.UID = types.UID(fmt.Sprintf("parity-plugin-%s", plugin.Name))
+		}
+		pluginObjects, _, err := uiplugin.GenerateUIPluginObjects(context.Background(), plugin, pluginConf, logr.Discard())
+		require.NoError(t, err)
+		for _, obj := range pluginObjects {
+			require.NoError(t, reconciler.NewUpdater(obj, plugin).Reconcile(context.Background(), rec, scheme))
+		}
+	}
+
+	// The operator persists UIPlugin CRs as separate reconciled objects; the
+	// generator resolves them into operands and drops them from its output.
+	applied := slices.DeleteFunc(rec.applied, func(obj client.Object) bool {
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		return gvk.Group == "observability.openshift.io" && gvk.Kind == "UIPlugin"
+	})
+	for _, obj := range applied {
+		stripClusterState(obj.(*unstructured.Unstructured))
+	}
+	slices.SortFunc(applied, util.CompareObjects)
+	slices.SortFunc(genObjects, util.CompareObjects)
+	assert.DeepEqual(t, genObjects, applied)
+}

--- a/pkg/generator/resource_set.go
+++ b/pkg/generator/resource_set.go
@@ -1,0 +1,80 @@
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	kyaml "sigs.k8s.io/yaml"
+
+	"github.com/rhobs/observability-operator/pkg/controllers/util"
+)
+
+// resourceSet collects the output objects of a generation run. Objects are
+// deduplicated by the unique YAML filename used when they are written to file.
+type resourceSet struct {
+	scheme *runtime.Scheme
+	byFile map[string]client.Object
+}
+
+func newResourceSet(scheme *runtime.Scheme) *resourceSet {
+	return &resourceSet{scheme: scheme, byFile: map[string]client.Object{}}
+}
+
+// AddResource adds obj to the set, no op if a matching obj (ns, name, gvk) is already in the set.
+// If the object has no GroupVersionKind set, the scheme is used to populate it.
+func (s *resourceSet) AddResource(obj client.Object) error {
+	if obj.GetObjectKind().GroupVersionKind().Kind == "" {
+		gvks, _, err := s.scheme.ObjectKinds(obj)
+		if err != nil {
+			return fmt.Errorf("cannot determine GVK for %T %q: %w", obj, obj.GetName(), err)
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvks[0])
+	}
+	s.byFile[resourceFileName(obj)] = obj
+	return nil
+}
+
+// Sort by namespace, with non-namespace objects first, then by kind and name.
+// Result is sorted by namespace, kind, name
+func (s *resourceSet) Build() []client.Object {
+	objects := make([]client.Object, 0, len(s.byFile))
+	for _, obj := range s.byFile {
+		objects = append(objects, obj)
+	}
+	slices.SortFunc(objects, util.CompareObjects)
+	return objects
+}
+
+func (s *resourceSet) WriteToDir(dir string) error {
+	return writeObjectsToDir(dir, s.Build())
+}
+
+func writeObjectsToDir(dir string, objects []client.Object) error {
+	for _, obj := range objects {
+		data, err := kyaml.Marshal(obj)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(dir, resourceFileName(obj)), data, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resourceFileName(obj client.Object) string {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	kind := strings.ToLower(gvk.Kind)
+	if gvk.Group != "" {
+		kind = gvk.Group + "_" + kind
+	}
+	if ns := obj.GetNamespace(); ns != "" {
+		return fmt.Sprintf("%s-%s.%s.yaml", kind, obj.GetName(), ns)
+	}
+	return fmt.Sprintf("%s-%s.yaml", kind, obj.GetName())
+}

--- a/pkg/generator/resource_set.go
+++ b/pkg/generator/resource_set.go
@@ -1,0 +1,60 @@
+package generator
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rhobs/observability-operator/pkg/controllers/util"
+)
+
+// resourceSet collects the output objects of a generation run. Objects are
+// deduplicated by the unique YAML filename used when they are written to file.
+type resourceSet struct {
+	scheme *runtime.Scheme
+	byFile map[string]client.Object
+}
+
+func newResourceSet(scheme *runtime.Scheme) *resourceSet {
+	return &resourceSet{scheme: scheme, byFile: map[string]client.Object{}}
+}
+
+// AddResource adds obj to the set, no op if a matching obj (ns, name, gvk) is already in the set.
+// If the object has no GroupVersionKind set, the scheme is used to populate it.
+func (s *resourceSet) AddResource(obj client.Object) error {
+	if obj.GetObjectKind().GroupVersionKind().Kind == "" {
+		gvks, _, err := s.scheme.ObjectKinds(obj)
+		if err != nil {
+			return fmt.Errorf("cannot determine GVK for %T %q: %w", obj, obj.GetName(), err)
+		}
+		obj.GetObjectKind().SetGroupVersionKind(gvks[0])
+	}
+	s.byFile[resourceFileName(obj)] = obj
+	return nil
+}
+
+// Build returns resources sorted with Namespace objects first, then by
+// namespace, API group, kind, name.
+func (s *resourceSet) Build() []client.Object {
+	objects := make([]client.Object, 0, len(s.byFile))
+	for _, obj := range s.byFile {
+		objects = append(objects, obj)
+	}
+	slices.SortFunc(objects, util.CompareObjects)
+	return objects
+}
+
+func resourceFileName(obj client.Object) string {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	kind := strings.ToLower(gvk.Kind)
+	if gvk.Group != "" {
+		kind = gvk.Group + "_" + kind
+	}
+	if ns := obj.GetNamespace(); ns != "" {
+		return fmt.Sprintf("%s-%s.%s.yaml", kind, obj.GetName(), ns)
+	}
+	return fmt.Sprintf("%s-%s.yaml", kind, obj.GetName())
+}

--- a/pkg/generator/testdata/sample/observability-installer.yaml
+++ b/pkg/generator/testdata/sample/observability-installer.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sample
+---
+apiVersion: v1
+data:
+  access_key_secret: c3VwZXJzZWNyZXQ=
+kind: Secret
+metadata:
+  name: minio-secret
+  namespace: sample
+---
+apiVersion: observability.openshift.io/v1alpha1
+kind: ObservabilityInstaller
+metadata:
+  name: sample-observability
+  namespace: sample
+spec:
+  capabilities:
+    tracing:
+      enabled: true
+      storage:
+        objectStorage:
+          s3:
+            bucket: tempo
+            endpoint: http://minio.minio.svc:9000
+            accessKeyID: minio
+            accessKeySecret:
+              name: minio-secret
+              key: access_key_secret

--- a/pkg/generator/testdata/sample/uiplugins.yaml
+++ b/pkg/generator/testdata/sample/uiplugins.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: troubleshooting-panel
+spec:
+  type: TroubleshootingPanel
+  troubleshootingPanel:
+    enableAgentNavigation: true
+---
+apiVersion: observability.openshift.io/v1alpha1
+kind: UIPlugin
+metadata:
+  name: distributed-tracing
+spec:
+  type: DistributedTracing

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -1,0 +1,53 @@
+package images
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+
+	obopo "github.com/rhobs/obo-prometheus-operator/pkg/operator"
+)
+
+
+// DefaultImages map of default image values.
+//
+// Prometheus and Alertmanager are handled by prometheus-operator.
+// For thanos we use the default version from prometheus-operator.
+var DefaultImages = map[string]string{
+	"alertmanager":                 "",
+	"health-analyzer":              "quay.io/openshiftanalytics/cluster-health-analyzer:v1.1.1",
+	"korrel8r":                     "quay.io/korrel8r/korrel8r:0.11.1",
+	"perses":                       "quay.io/openshift-observability-ui/perses:v0.54.0",
+	"prometheus":                   "",
+	"thanos":                       obopo.DefaultThanosImage,
+	"ui-distributed-tracing":       "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v1.1.0",
+	"ui-distributed-tracing-pf4":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.3.3",
+	"ui-distributed-tracing-pf5":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.4.3",
+	"ui-distributed-tracing-pf6":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v1.0.3",
+	"ui-logging":                   "quay.io/openshift-observability-ui/logging-view-plugin:v6.2.1",
+	"ui-logging-pf4":               "quay.io/openshift-observability-ui/logging-view-plugin:v6.0.5",
+	"ui-logging-pf5":               "quay.io/openshift-observability-ui/logging-view-plugin:v6.1.6",
+	"ui-monitoring":                "quay.io/openshift-observability-ui/monitoring-console-plugin:v1.0.0",
+	"ui-monitoring-pf5":            "quay.io/openshift-observability-ui/monitoring-console-plugin:v0.4.5",
+	"ui-monitoring-pf6":            "quay.io/openshift-observability-ui/monitoring-console-plugin:v0.5.4",
+	"ui-troubleshooting-panel":     "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v1.0.0",
+	"ui-troubleshooting-panel-pf6": "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v0.4.5",
+}
+
+// SortedNames returns the sorted list of known image names.
+func SortedNames() []string {
+	return slices.Sorted(maps.Keys(DefaultImages))
+}
+
+// Validate merges the passed images with the defaults and checks if any
+// unknown image names are passed. Returns an error if an unknown image is found.
+func Validate(images map[string]string) (map[string]string, error) {
+	res := maps.Clone(DefaultImages)
+	for k, v := range images {
+		if _, ok := res[k]; !ok {
+			return nil, fmt.Errorf("image %v is unknown", k)
+		}
+		res[k] = v
+	}
+	return res, nil
+}

--- a/pkg/images/images.go
+++ b/pkg/images/images.go
@@ -1,0 +1,46 @@
+package images
+
+import (
+	"fmt"
+	"maps"
+
+	obopo "github.com/rhobs/obo-prometheus-operator/pkg/operator"
+)
+
+// DefaultImages map of default image values.
+//
+// Prometheus and Alertmanager are handled by prometheus-operator.
+// For thanos we use the default version from prometheus-operator.
+var DefaultImages = map[string]string{
+	"prometheus":                   "",
+	"alertmanager":                 "",
+	"thanos":                       obopo.DefaultThanosImage,
+	"ui-troubleshooting-panel-pf6": "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v0.4.5",
+	"ui-troubleshooting-panel":     "quay.io/openshift-observability-ui/troubleshooting-panel-console-plugin:v1.0.0",
+	"ui-distributed-tracing-pf4":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.3.3",
+	"ui-distributed-tracing-pf5":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v0.4.3",
+	"ui-distributed-tracing-pf6":   "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v1.0.3",
+	"ui-distributed-tracing":       "quay.io/openshift-observability-ui/distributed-tracing-console-plugin:v1.1.0",
+	"ui-logging-pf4":               "quay.io/openshift-observability-ui/logging-view-plugin:v6.0.5",
+	"ui-logging-pf5":               "quay.io/openshift-observability-ui/logging-view-plugin:v6.1.6",
+	"ui-logging":                   "quay.io/openshift-observability-ui/logging-view-plugin:v6.2.1",
+	"korrel8r":                     "quay.io/korrel8r/korrel8r:0.11.1",
+	"health-analyzer":              "quay.io/openshiftanalytics/cluster-health-analyzer:v1.1.1",
+	"ui-monitoring-pf5":            "quay.io/openshift-observability-ui/monitoring-console-plugin:v0.4.5",
+	"ui-monitoring-pf6":            "quay.io/openshift-observability-ui/monitoring-console-plugin:v0.5.4",
+	"ui-monitoring":                "quay.io/openshift-observability-ui/monitoring-console-plugin:v1.1.0",
+	"perses":                       "quay.io/openshift-observability-ui/perses:v0.54.1",
+}
+
+// Validate merges the passed images with the defaults and checks if any
+// unknown image names are passed. Returns an error if an unknown image is found.
+func Validate(images map[string]string) (map[string]string, error) {
+	res := maps.Clone(DefaultImages)
+	for k, v := range images {
+		if _, ok := res[k]; !ok {
+			return nil, fmt.Errorf("image %v is unknown", k)
+		}
+		res[k] = v
+	}
+	return res, nil
+}

--- a/pkg/images/images_test.go
+++ b/pkg/images/images_test.go
@@ -1,0 +1,47 @@
+package images
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		images  map[string]string
+		wantErr string
+	}{
+		{
+			name:   "nil map returns defaults",
+			images: nil,
+		},
+		{
+			name:   "empty map returns defaults",
+			images: map[string]string{},
+		},
+		{
+			name:   "valid override",
+			images: map[string]string{"korrel8r": "example.com/korrel8r:latest"},
+		},
+		{
+			name:    "unknown image name",
+			images:  map[string]string{"no-such-image": "example.com/nope:v1"},
+			wantErr: "unknown",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := Validate(tc.images)
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, len(DefaultImages), len(result))
+			for k, v := range tc.images {
+				require.Equal(t, v, result[k])
+			}
+		})
+	}
+}

--- a/pkg/reconciler/create_update_reconciler.go
+++ b/pkg/reconciler/create_update_reconciler.go
@@ -33,6 +33,10 @@ func (r createUpdateReconciler) Reconcile(ctx context.Context, c client.Client, 
 	return err
 }
 
+func (r createUpdateReconciler) Desired() []client.Object {
+	return []client.Object{r.resource}
+}
+
 func NewCreateUpdateReconciler(resource client.Object, owner metav1.Object) Reconciler {
 	return createUpdateReconciler{
 		resourceOwner: owner,

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -24,6 +24,11 @@ const (
 // a new type that implements this interface.
 type Reconciler interface {
 	Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme) error
+	// Desired returns the objects this reconciler creates or updates when
+	// applied in its present state. It returns nil for reconcilers that only
+	// delete resources. It is used to compute the object set the reconciler
+	// would apply without a cluster (e.g. by the offline generator).
+	Desired() []client.Object
 }
 
 // Updater simply updates a resource by setting a controller reference
@@ -58,6 +63,10 @@ func (r Updater) Reconcile(ctx context.Context, c client.Client, scheme *runtime
 	return nil
 }
 
+func (r Updater) Desired() []client.Object {
+	return []client.Object{r.resource}
+}
+
 func NewUpdater(resource client.Object, owner metav1.Object) Updater {
 	return newUpdater(resource, owner, false)
 }
@@ -86,6 +95,11 @@ func (r Deleter) Reconcile(ctx context.Context, c client.Client, scheme *runtime
 			r.resource.GetNamespace(), r.resource.GetName(),
 			r.resource.GetObjectKind().GroupVersionKind().String(), err)
 	}
+	return nil
+}
+
+func (r Deleter) Desired() []client.Object {
+	// A Deleter removes a resource; it does not declare a desired object.
 	return nil
 }
 

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -83,6 +83,30 @@ func TestClientObjectApplyConfig_RoundTrip(t *testing.T) {
 	require.Equal(t, original.Data, target.Data)
 }
 
+func TestUpdaterDesired(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"}}
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "ns"}}
+	u := NewUpdater(cm, owner)
+	desired := u.Desired()
+	require.Equal(t, 1, len(desired))
+	require.Equal(t, "cm", desired[0].GetName())
+}
+
+func TestDeleterDesired(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm"}}
+	d := NewDeleter(cm)
+	require.Nil(t, d.Desired())
+}
+
+func TestCreateUpdateReconcilerDesired(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns"}}
+	owner := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "ns"}}
+	r := NewCreateUpdateReconciler(cm, owner)
+	desired := r.Desired()
+	require.Equal(t, 1, len(desired))
+	require.Equal(t, "cm", desired[0].GetName())
+}
+
 func TestClientObjectApplyConfig_Getters(t *testing.T) {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Kustomize-style offline manifest generator (pkg/generator) that
transforms ObservabilityInstaller and UIPlugin CRs plus support files
into the full resource set the operator would reconcile.

- Extract GenerateInstallerObjects from the ObservabilityInstaller
  reconciler so the generator and reconciler produce the same objects.
- Expand UIPlugin CRs emitted by GenerateInstallerObjects
  into their concrete operands via GenerateUIPluginObjects, matching what
  the UIPlugin controller reconciles.
- Add a FallbackReader that serves Secrets with stringData as data so
  object storage secrets resolve offline.
- Emit OLM Namespace/OperatorGroup for namespaces the operator assumes
  OLM creates, and add a --skip-operators flag to omit them.
- Add golden-file tests pinning the generated output against the
  reconciled object set.