### PR TITLE
COO-2340: remove nonroot SCC to have PSA restricted

### DIFF
--- a/bundle/manifests/observability-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/observability-operator.clusterserviceversion.yaml
@@ -303,7 +303,6 @@ spec:
           - security.openshift.io
           resourceNames:
           - nonroot-v2
-          - nonroot
           resources:
           - securitycontextconstraints
           verbs:
@@ -314,7 +313,6 @@ spec:
           - security.openshift.io
           resourceNames:
           - nonroot-v2
-          - nonroot
           resources:
           - securitycontextconstraints
           verbs:
@@ -712,7 +710,6 @@ spec:
         - apiGroups:
           - security.openshift.io
           resourceNames:
-          - nonroot
           - nonroot-v2
           resources:
           - securitycontextconstraints

--- a/deploy/dependencies/admission-webhook/cluster-role.yaml
+++ b/deploy/dependencies/admission-webhook/cluster-role.yaml
@@ -11,7 +11,6 @@ rules:
   - security.openshift.io
   resourceNames:
     - nonroot-v2
-    - nonroot
   resources:
     - securitycontextconstraints
   verbs:

--- a/deploy/dependencies/kustomization.yaml
+++ b/deploy/dependencies/kustomization.yaml
@@ -110,7 +110,6 @@ patches:
           - security.openshift.io
         resourceNames:
           - nonroot-v2
-          - nonroot
         resources:
           - securitycontextconstraints
         verbs:

--- a/deploy/operator/observability-operator-cluster-role.yaml
+++ b/deploy/operator/observability-operator-cluster-role.yaml
@@ -395,7 +395,6 @@ rules:
 - apiGroups:
   - security.openshift.io
   resourceNames:
-  - nonroot
   - nonroot-v2
   resources:
   - securitycontextconstraints

--- a/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
+++ b/pkg/controllers/monitoring/monitoring-stack/alertmanager.go
@@ -167,7 +167,7 @@ func newAlertManagerClusterRole(rbacResourceName string, rbacVerbs []string) *rb
 		Rules: []rbacv1.PolicyRule{{
 			APIGroups:     []string{"security.openshift.io"},
 			Resources:     []string{"securitycontextconstraints"},
-			ResourceNames: []string{"nonroot", "nonroot-v2"},
+			ResourceNames: []string{"nonroot-v2"},
 			Verbs:         []string{"use"},
 		}},
 	}

--- a/pkg/controllers/monitoring/monitoring-stack/components.go
+++ b/pkg/controllers/monitoring/monitoring-stack/components.go
@@ -111,7 +111,7 @@ func newPrometheusClusterRole(rbacResourceName string, rbacVerbs []string) *rbac
 		}, {
 			APIGroups:     []string{"security.openshift.io"},
 			Resources:     []string{"securitycontextconstraints"},
-			ResourceNames: []string{"nonroot", "nonroot-v2"},
+			ResourceNames: []string{"nonroot-v2"},
 			Verbs:         []string{"use"},
 		}},
 	}

--- a/pkg/controllers/monitoring/monitoring-stack/controller.go
+++ b/pkg/controllers/monitoring/monitoring-stack/controller.go
@@ -81,8 +81,8 @@ const finalizerName = "monitoring.observability.openshift.io/finalizer"
 //+kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 //+kubebuilder:rbac:groups=extensions;networking.k8s.io,resources=ingresses,verbs=get;list;watch
 
-// RBAC for delegating the use of SCC nonroot-v2 (for OpenShift >= 4.11) and nonroot (for OpenShift < 4.11)
-//+kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,resourceNames=nonroot;nonroot-v2,verbs=use
+// RBAC for delegating the use of SCC nonroot-v2
+//+kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,resourceNames=nonroot-v2,verbs=use
 
 // RegisterWithManager registers the controller with Manager
 func RegisterWithManager(mgr ctrl.Manager, opts Options) error {

--- a/pkg/controllers/uiplugin/controller.go
+++ b/pkg/controllers/uiplugin/controller.go
@@ -91,8 +91,8 @@ const (
 // +kubebuilder:rbac:groups=perses.dev,resources=perses/status;persesdatasources/status;persesglobaldatasources/status;persesdashboards/status,verbs=get;patch;update
 // +kubebuilder:rbac:groups=perses.dev,resources=perses/finalizers;persesglobaldatasources/finalizers;persesdashboards/finalizers;persesdatasources/finalizers;persesdashboards/finalizers,verbs=update
 
-// RBAC for delegating the use of SCC nonroot-v2 (for OpenShift >= 4.11) and nonroot (for OpenShift < 4.11) for Perses
-//+kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,resourceNames=nonroot;nonroot-v2,verbs=use
+// RBAC for delegating the use of SCC nonroot-v2 for Perses
+//+kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,resourceNames=nonroot-v2,verbs=use
 
 // RBAC for korrel8r
 //+kubebuilder:rbac:groups=apps,resources=daemonsets;deployments;replicasets;statefulsets,verbs=get;list;watch

--- a/pkg/controllers/uiplugin/monitoring.go
+++ b/pkg/controllers/uiplugin/monitoring.go
@@ -344,7 +344,7 @@ func newPersesClusterRole() *rbacv1.ClusterRole {
 			{
 				APIGroups:     []string{"security.openshift.io"},
 				Resources:     []string{"securitycontextconstraints"},
-				ResourceNames: []string{"nonroot", "nonroot-v2"},
+				ResourceNames: []string{"nonroot-v2"},
 				Verbs:         []string{"use"},
 			},
 		},


### PR DESCRIPTION
This is an attempt to "increase" PSA level of the COO namespace to `restricted`. 

```
    pod-security.kubernetes.io/audit: restricted
    pod-security.kubernetes.io/warn: restricted
```