### PR TITLE
fix: skip ThanosQuerier reconciliation during deletion to prevent foregroundDeletion deadlock

### DIFF
--- a/pkg/controllers/monitoring/thanos-querier/controller.go
+++ b/pkg/controllers/monitoring/thanos-querier/controller.go
@@ -155,6 +155,11 @@ func (rm resourceManager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, err
 	}
 
+	if querier.DeletionTimestamp != nil {
+		logger.Info("ThanosQuerier is being deleted, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
 	sidecarServices, err := rm.findSidecarServices(ctx, querier)
 	if client.IgnoreNotFound(err) != nil {
 		// we encountered an error other then NotFound, don't try to delete


### PR DESCRIPTION
## Problem

The ThanosQuerier controller enters a race condition with the Kubernetes garbage collector during CR deletion, causing ThanosQuerier resources to get stuck in terminating state for 600+ seconds.

### How the deadlock occurs

1. A consumer (e.g. the ODH/RHOAI operator) creates ThanosQuerier CRs with an ownerReference to a parent resource (e.g. a Monitoring CR) with `blockOwnerDeletion: true` and `controller: true`.

2. When the parent is deleted or the consumer's GC action removes the ThanosQuerier, Kubernetes initiates **foreground cascading deletion**: it adds a `foregroundDeletion` finalizer to the ThanosQuerier and begins deleting its dependents (the Deployment, Service, ServiceAccount, ConfigMap that the ThanosQuerier controller created via `Owns()`).

3. The ThanosQuerier controller's `Reconcile` method has **no `DeletionTimestamp` check**. It continues to run while the CR is being deleted — calling `thanosComponentReconcilers()` which updates the same Deployment, Service, etc. that the garbage collector is trying to delete.

4. The controller's updates bump `resourceVersion` on the owned resources. The GC, which was working with the previous `resourceVersion`, encounters a conflict and retries. On the next attempt, the controller updates again. This cycle prevents the GC from deleting all dependents, so the `foregroundDeletion` finalizer is never removed.

5. The ThanosQuerier CR is stuck in terminating state indefinitely.

### Observed impact

In the opendatahub-operator E2E suite, this causes `Test_ThanosQuerier_not_deployed_without_metrics` to time out after 600s waiting for the ThanosQuerier to be deleted. The test disables metrics on the Monitoring CR, the operator's GC action deletes the ThanosQuerier, and the foreground deletion deadlock prevents it from completing. This failure is deterministic and reproduces on every CI run.

Failing build: [pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-rhoai-e2e / 2090374980800876544](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/opendatahub-io_opendatahub-operator/3984/pull-ci-opendatahub-io-opendatahub-operator-main-opendatahub-operator-rhoai-e2e/2090374980800876544)

## Fix

Add a `DeletionTimestamp` check at the top of `Reconcile` to skip reconciliation when the ThanosQuerier is being deleted. This allows the garbage collector to delete owned resources without interference and clear the `foregroundDeletion` finalizer.

This is consistent with the MonitoringStack controller, which already has the same guard at `monitoring-stack/controller.go:132`:

```go
if !ms.ObjectMeta.DeletionTimestamp.IsZero() {
    logger.V(6).Info("removing cluster scoped resources")
    // ...cleanup...
}
```

The ThanosQuerier controller doesn't need active cleanup (unlike MonitoringStack, which has cluster-scoped resources) — it relies entirely on Kubernetes GC via `Owns()` for owned Deployments, Services, ServiceAccounts, and ConfigMaps. Skipping reconciliation is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)