### PR TITLE
OBSINTA-1588: feat/add liveness and readiness probes to health-analyzer deployment

### DIFF
--- a/pkg/controllers/uiplugin/health_analyzer.go
+++ b/pkg/controllers/uiplugin/health_analyzer.go
@@ -182,6 +182,30 @@ func newHealthAnalyzerDeployment(namespace string,
 									Name:          "metrics",
 								},
 							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/livez",
+										Port:   intstr.FromString("metrics"),
+										Scheme: corev1.URISchemeHTTPS,
+									},
+								},
+								InitialDelaySeconds: 15,
+								PeriodSeconds:       20,
+								TimeoutSeconds:      5,
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/readyz",
+										Port:   intstr.FromString("metrics"),
+										Scheme: corev1.URISchemeHTTPS,
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       10,
+								TimeoutSeconds:      5,
+							},
 							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
This PR configures liveness and readiness probes in cluster-health-analyzer Deployment resource

To be merged after https://github.com/openshift/cluster-health-analyzer/pull/118
Assisted-By: Claude